### PR TITLE
fix: persist app icon metadata across layout flows

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -83,7 +83,6 @@ const extractIconSourcePath = (raw) => (
 );
 
 const imageMimeTypeByExt = {
-  '.ico': 'image/x-icon',
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -93,6 +92,8 @@ const imageMimeTypeByExt = {
 
 const toImageDataUrlFromFile = (filePath) => {
   const ext = path.extname(filePath).toLowerCase();
+  // Let Electron/nativeImage handle .ico so we don't accidentally use a tiny embedded frame.
+  if (ext === '.ico') return null;
   const mime = imageMimeTypeByExt[ext];
   if (!mime) return null;
   try {
@@ -117,7 +118,11 @@ const getSafeIconDataUrl = async (iconSourcePath) => {
       return directImageDataUrl;
     }
 
-    const nativeIcon = await app.getFileIcon(safePath, { size: 'normal' });
+    // Prefer large icons for sharper rendering in monitor layout previews.
+    let nativeIcon = await app.getFileIcon(safePath, { size: 'large' });
+    if (!nativeIcon || nativeIcon.isEmpty()) {
+      nativeIcon = await app.getFileIcon(safePath, { size: 'normal' });
+    }
     if (!nativeIcon || nativeIcon.isEmpty()) {
       // Fallback for files that can be loaded directly as image assets.
       const imageFallback = nativeImage.createFromPath(safePath);
@@ -410,9 +415,11 @@ ipcMain.handle('get-installed-apps', async () => {
       }
 
       if (!existing) {
+        const executablePath = context.targetExe || extractExecutablePath(sourcePath) || null;
         appMap.set(key, {
           name: normalizedName,
           iconPath: iconPath || null,
+          executablePath,
           priority: nextPriority,
         });
         return;
@@ -422,10 +429,12 @@ ipcMain.handle('get-installed-apps', async () => {
       const preferredName = currentPriority >= nextPriority ? existing.name : normalizedName;
       const preferredPriority = Math.max(currentPriority, nextPriority);
       const preferredIcon = existing.iconPath || iconPath || null;
+      const preferredExecutablePath = existing.executablePath || context.targetExe || extractExecutablePath(sourcePath) || null;
 
       appMap.set(key, {
         name: preferredName,
         iconPath: preferredIcon,
+        executablePath: preferredExecutablePath,
         priority: preferredPriority,
       });
     };
@@ -651,7 +660,7 @@ ipcMain.handle('get-installed-apps', async () => {
       );
     }
     return Array.from(appMap.values())
-      .map(({ name, iconPath }) => ({ name, iconPath }))
+      .map(({ name, iconPath, executablePath }) => ({ name, iconPath, executablePath: executablePath || null }))
       .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
   } catch (err) {
     console.error('Error in get-installed-apps handler:', err);
@@ -970,14 +979,17 @@ ipcMain.handle('capture-running-app-layout', async () => {
       const relX = relLeft + (relW / 2);
       const relY = relTop + (relH / 2);
 
-      // Keep capture fast: avoid per-window icon extraction here.
-      // Memory capture prioritizes layout correctness and responsiveness.
-      const iconPath = null;
+      // Preserve app icon metadata for layout-memory-created profiles and previews.
+      let iconPath = null;
+      if (windowInfo.executablePath) {
+        iconPath = await getSafeIconDataUrl(windowInfo.executablePath);
+      }
 
       const round1 = (n) => Math.round(n * 10) / 10;
       const mappedWindow = {
         name: windowInfo.name,
         iconPath,
+        executablePath: windowInfo.executablePath || null,
         position: {
           x: Math.max(0, Math.min(100, round1(relX))),
           y: Math.max(0, Math.min(100, round1(relY))),

--- a/src/renderer/hooks/useInstalledApps.ts
+++ b/src/renderer/hooks/useInstalledApps.ts
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 export type InstalledApp = {
   name: string;
   iconPath: string | null;
+  executablePath?: string | null;
 };
 
 type UseInstalledAppsOptions = {
@@ -18,13 +19,18 @@ let cachedInstalledApps: InstalledApp[] | null = null;
 let cachedAt = 0;
 let inFlightRequest: Promise<InstalledApp[]> | null = null;
 
-function normalizeApps(installedApps: { name: string; iconPath: string | null }[]): InstalledApp[] {
+function normalizeApps(installedApps: { name: string; iconPath: string | null; executablePath?: string | null }[]): InstalledApp[] {
   return installedApps
     .map((app) => ({
       name: app?.name,
       iconPath: app?.iconPath ?? null,
+      executablePath: app?.executablePath ?? null,
     }))
-    .filter((app): app is InstalledApp => typeof app.name === 'string' && app.name.trim().length > 0)
+    .filter((app) => typeof app.name === 'string' && app.name.trim().length > 0)
+    .map((app) => ({
+      ...app,
+      name: String(app.name).trim(),
+    }))
     .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 }
 

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -901,6 +901,8 @@ export default function App() {
           const newApp = {
             name: dragData.name,
             icon: dragData.icon,
+            iconPath: dragData.iconPath ?? null,
+            executablePath: dragData.executablePath ?? null,
             color: dragData.color,
             position,
             size: { width: 60, height: 60 },
@@ -1028,6 +1030,8 @@ export default function App() {
           const newApp = {
             name: dragData.name,
             icon: dragData.icon,
+            iconPath: dragData.iconPath ?? null,
+            executablePath: dragData.executablePath ?? null,
             color: dragData.color,
             volume: 50,
             launchBehavior: "minimize" as const,
@@ -1477,6 +1481,8 @@ export default function App() {
         const minimizedApp = {
           name: appToMove.name,
           icon: appToMove.icon,
+          iconPath: (appToMove as any).iconPath ?? null,
+          executablePath: (appToMove as any).executablePath ?? null,
           color: appToMove.color,
           volume: appToMove.volume || 0,
           launchBehavior: "minimize" as const,
@@ -1721,6 +1727,8 @@ export default function App() {
         const newApp = {
           name: minimizedApp.name,
           icon: minimizedApp.icon,
+          iconPath: (minimizedApp as any).iconPath ?? null,
+          executablePath: (minimizedApp as any).executablePath ?? null,
           color: minimizedApp.color,
           position: newPosition ||
             minimizedApp.sourcePosition || { x: 50, y: 50 },
@@ -2776,7 +2784,15 @@ export default function App() {
                   backgroundColor: `${dragState.dragData.color || dragState.dragData.fileColor || "#4A5568"}80`,
                 }}
               >
-                {dragState.dragData.icon && (
+                {dragState.dragData.iconPath && (
+                  <img
+                    src={dragState.dragData.iconPath}
+                    alt={dragState.dragData.name || "App"}
+                    className="w-4.5 h-4.5 object-contain rounded drop-shadow-sm"
+                    draggable={false}
+                  />
+                )}
+                {!dragState.dragData.iconPath && dragState.dragData.icon && (
                   <dragState.dragData.icon className="w-4.5 h-4.5 text-white drop-shadow-sm" />
                 )}
                 {dragState.dragData.fileIcon && (

--- a/src/renderer/layout/components/AddAppModal.tsx
+++ b/src/renderer/layout/components/AddAppModal.tsx
@@ -6,6 +6,7 @@ interface App {
   name: string;
   icon: any;
   iconPath?: string | null;
+  executablePath?: string | null;
   color: string;
   position: { x: number; y: number };
   size: { width: number; height: number };
@@ -78,6 +79,7 @@ export function AddAppModal({
         icon: meta?.icon || Settings,
         color: meta?.color || '#666666',
         iconPath: app.iconPath,
+        executablePath: app.executablePath ?? null,
       };
     })
   ), [installedApps]);
@@ -100,6 +102,7 @@ export function AddAppModal({
       name: selectedApp.name,
       icon: selectedApp.icon,
       iconPath: selectedApp.iconPath ?? null,
+      executablePath: selectedApp.executablePath ?? null,
       color: selectedApp.color,
       position: { x: 50, y: 50 },
       size: { 

--- a/src/renderer/layout/components/AppFileWindow.tsx
+++ b/src/renderer/layout/components/AppFileWindow.tsx
@@ -13,7 +13,9 @@ interface BaseItem {
 
 interface AppItem extends BaseItem {
   type: 'app';
-  icon: LucideIcon;
+  icon?: LucideIcon;
+  iconPath?: string | null;
+  executablePath?: string | null;
   color: string;
   volume?: number;
   launchBehavior?: 'new' | 'focus' | 'minimize';
@@ -223,13 +225,14 @@ export function AppFileWindow({
       const app = item as AppItem;
       return {
         icon: app.icon,
+        iconPath: app.iconPath ?? null,
         color: app.color,
         fileColor: null
       };
     }
   };
 
-  const { icon: mainIcon, color: mainColor, fileColor } = getIconAndColor();
+  const { icon: mainIcon, iconPath: mainIconPath, color: mainColor, fileColor } = getIconAndColor();
 
   // Get the file count for display
   const getFileCount = () => {
@@ -251,6 +254,20 @@ export function AppFileWindow({
 
   // FIXED: Bigger app icons with proper CSS classes
   const renderMainIcon = () => {
+    if (mainIconPath) {
+      return (
+        <img
+          src={mainIconPath}
+          alt={item.name}
+          className="app-icon object-contain rounded"
+          draggable={false}
+          onError={(e) => {
+            (e.target as HTMLImageElement).style.display = 'none';
+          }}
+        />
+      );
+    }
+
     if (!mainIcon) {
       return (
         <div className="app-icon-fallback bg-white/20 rounded-lg">
@@ -535,6 +552,8 @@ export function AppFileWindow({
       app: {
         name: item.name,
         icon: (item as AppItem).icon,
+        iconPath: (item as AppItem).iconPath ?? null,
+        executablePath: (item as AppItem).executablePath ?? null,
         color: (item as AppItem).color,
         volume: (item as AppItem).volume,
         runAsAdmin: (item as AppItem).runAsAdmin,

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -28,6 +28,7 @@ interface AppManagerProps {
 type DiscoveredApp = {
   name: string;
   iconPath: string | null;
+  executablePath?: string | null;
   icon?: undefined;
   color?: string;
   category?: string;
@@ -84,11 +85,12 @@ export function AppManager({
       const meta = appMeta[app.name.toLowerCase()];
       if (meta) {
         const { icon, ...rest } = meta;
-        return { ...rest, iconPath: app.iconPath };
+        return { ...rest, iconPath: app.iconPath, executablePath: app.executablePath ?? null };
       }
       return {
         name: app.name,
         iconPath: app.iconPath,
+        executablePath: app.executablePath ?? null,
         color: '#888',
         category: 'Other',
         firstLetter: app.name.charAt(0).toUpperCase(),
@@ -224,8 +226,11 @@ export function AppManager({
       type: 'app',
       name: app.name,
       icon: app.icon,
+      iconPath: app.iconPath ?? null,
+      executablePath: app.executablePath ?? null,
       color: app.color,
-      category: app.category
+      category: app.category,
+      firstLetter: app.firstLetter
     };
     
     const preview = (

--- a/src/renderer/layout/components/CreateProfileModal.tsx
+++ b/src/renderer/layout/components/CreateProfileModal.tsx
@@ -41,6 +41,7 @@ type MemoryCapture = {
     apps: Array<{
       name: string;
       iconPath: string | null;
+      executablePath?: string | null;
       position: { x: number; y: number };
       size: { width: number; height: number };
     }>;
@@ -48,6 +49,7 @@ type MemoryCapture = {
   minimizedApps?: Array<{
     name: string;
     iconPath: string | null;
+    executablePath?: string | null;
     position: { x: number; y: number };
     size: { width: number; height: number };
     targetMonitor?: string;
@@ -80,6 +82,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
         color: meta?.color || '#666666',
         category: meta?.category || 'Other',
         iconPath: app.iconPath,
+        executablePath: app.executablePath ?? null,
       };
     })
   ), [installedApps]);
@@ -156,6 +159,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
             name: app.name,
             icon: app.icon,
             iconPath: app.iconPath ?? null,
+            executablePath: app.executablePath ?? null,
             color: app.color,
             position: { x: 30 + (index % 2) * 40, y: 30 + Math.floor(index / 2) * 40 },
             size: { width: 35, height: 30 },
@@ -173,6 +177,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
             name: app.name,
             icon: app.icon,
             iconPath: app.iconPath ?? null,
+            executablePath: app.executablePath ?? null,
             color: app.color,
             position: { x: 30 + (index % 2) * 40, y: 30 + Math.floor(index / 2) * 40 },
             size: { width: 35, height: 30 },
@@ -222,6 +227,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
             name: app.name,
             icon: meta?.icon || Settings,
             iconPath: app.iconPath ?? null,
+            executablePath: app.executablePath ?? null,
             color: meta?.color || '#666666',
             position: app.position,
             size: app.size,
@@ -236,6 +242,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
           name: app.name,
           icon: meta?.icon || Settings,
           iconPath: app.iconPath ?? null,
+          executablePath: app.executablePath ?? null,
           color: meta?.color || '#666666',
           volume: 50,
           launchBehavior: 'minimize' as const,

--- a/src/renderer/layout/components/MinimizedApps.tsx
+++ b/src/renderer/layout/components/MinimizedApps.tsx
@@ -5,7 +5,9 @@ import { FileIcon, getFileTypeColor } from "./FileIcon";
 
 interface MinimizedApp {
   name: string;
-  icon: LucideIcon;
+  icon?: LucideIcon;
+  iconPath?: string | null;
+  executablePath?: string | null;
   color: string;
   volume?: number;
   launchBehavior?: 'new' | 'focus' | 'minimize';
@@ -90,6 +92,17 @@ export function MinimizedApps({
 
   // Safely handle the icon component
   const renderIcon = (app: MinimizedApp) => {
+    if (app.iconPath) {
+      return (
+        <img
+          src={app.iconPath}
+          alt={app.name}
+          className="w-5 h-5 object-contain rounded"
+          draggable={false}
+        />
+      );
+    }
+
     if (!app.icon) {
       return (
         <div className="w-5 h-5 bg-flow-text-muted/20 rounded flex items-center justify-center">
@@ -280,6 +293,8 @@ export function MinimizedApps({
         app: {
           name: app.name,
           icon: app.icon,
+          iconPath: app.iconPath ?? null,
+          executablePath: app.executablePath ?? null,
           color: app.color,
           volume: app.volume,
           targetMonitor: app.targetMonitor
@@ -288,7 +303,13 @@ export function MinimizedApps({
       
       const preview = (
         <div className="flex items-center gap-2">
-          <app.icon className="w-4 h-4" style={{ color: app.color }} />
+          {app.iconPath ? (
+            <img src={app.iconPath} alt={app.name} className="w-4 h-4 object-contain rounded" />
+          ) : app.icon ? (
+            <app.icon className="w-4 h-4" style={{ color: app.color }} />
+          ) : (
+            <Package className="w-4 h-4 text-flow-text-muted" />
+          )}
           <span>{app.name}</span>
         </div>
       );

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -10,7 +10,9 @@ import { DragState } from "../types/dragTypes";
 
 interface App {
   name: string;
-  icon: LucideIcon;
+  icon?: LucideIcon;
+  iconPath?: string | null;
+  executablePath?: string | null;
   color: string;
   position: { x: number; y: number };
   size: { width: number; height: number };
@@ -33,7 +35,9 @@ interface App {
 
 interface MinimizedApp {
   name: string;
-  icon: LucideIcon;
+  icon?: LucideIcon;
+  iconPath?: string | null;
+  executablePath?: string | null;
   color: string;
   volume?: number;
   launchBehavior?: 'new' | 'focus' | 'minimize';
@@ -974,6 +978,8 @@ export function MonitorLayout({
                               type: 'app',
                               name: app.name,
                               icon: app.icon,
+                              iconPath: app.iconPath ?? null,
+                              executablePath: app.executablePath ?? null,
                               color: app.color,
                               position: app.position,
                               size: app.size,
@@ -1001,6 +1007,8 @@ export function MonitorLayout({
                                 app: {
                                   name: app.name,
                                   icon: app.icon,
+                                  iconPath: app.iconPath ?? null,
+                                  executablePath: app.executablePath ?? null,
                                   color: app.color,
                                   volume: app.volume,
                                   position: app.position,

--- a/src/renderer/layout/components/SelectedAppDetails.tsx
+++ b/src/renderer/layout/components/SelectedAppDetails.tsx
@@ -79,6 +79,22 @@ export function SelectedAppDetails({
 
   // Render app icon with proper fallback
   const renderAppIcon = (app: any, size: string = "w-12 h-12") => {
+    if (app.iconPath) {
+      return (
+        <div
+          className={`${size} rounded-xl flex items-center justify-center border border-white/20 shadow-sm overflow-hidden`}
+          style={{ backgroundColor: `${app.color || '#666666'}40` }}
+        >
+          <img
+            src={app.iconPath}
+            alt={app.name || 'App'}
+            className="w-3/4 h-3/4 object-contain"
+            draggable={false}
+          />
+        </div>
+      );
+    }
+
     if (!app.icon) {
       return (
         <div className={`${size} bg-flow-surface rounded-xl flex items-center justify-center border border-flow-border`}>
@@ -745,7 +761,7 @@ export function SelectedAppDetails({
               </span>
             </div>
             <p className="text-sm text-flow-text-muted truncate font-mono">
-              {currentData.executablePath || 'C:\\Program Files\\App\\app.exe'}
+              {currentData.executablePath || 'Executable path not available'}
             </p>
             {monitorId && (
               <p className="text-xs text-flow-text-muted mt-1">

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -7,7 +7,7 @@ declare global {
     electron: {
       launchProfile: (profileId: string) => void;
       onProfileLoaded: (callback: (profile: Profile) => void) => void;
-      getInstalledApps: () => Promise<{ name: string; iconPath: string | null }[]>;
+      getInstalledApps: () => Promise<{ name: string; iconPath: string | null; executablePath?: string | null }[]>;
       captureRunningAppLayout: () => Promise<{
         capturedAt: number;
         appCount: number;
@@ -21,6 +21,7 @@ declare global {
           apps: Array<{
             name: string;
             iconPath: string | null;
+            executablePath?: string | null;
             position: { x: number; y: number };
             size: { width: number; height: number };
           }>;
@@ -28,6 +29,7 @@ declare global {
         minimizedApps?: Array<{
           name: string;
           iconPath: string | null;
+          executablePath?: string | null;
           position: { x: number; y: number };
           size: { width: number; height: number };
           targetMonitor?: string;


### PR DESCRIPTION
## Summary
- persist `iconPath` and `executablePath` from installed-app discovery through drag/drop, monitor layout, minimized apps, and selected-app details
- include icon/executable metadata in layout-memory capture so create-profile and right sidebar retain accurate app details
- improve monitor preview icon quality by preferring large native file icons and routing `.ico` handling through Electron's native image pipeline

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test
- [x] npm run build
- [ ] Manual: drag discovered apps into monitor preview and verify icon + executable path in right sidebar
- [ ] Manual: create a profile from layout memory and verify persisted icons/details in preview and details panel