### PR TITLE
fix: stabilize profile launch monitor placement and multi-window behavior

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, nativeImage } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const { spawn, execFile } = require('child_process');
 const ws = require('windows-shortcuts');
 const { scanForExeFiles } = require('./scanExeFiles');
 const { getRegistryInstalledApps } = require('./registryApps');
@@ -19,6 +20,21 @@ if (!gotSingleInstanceLock) {
   app.quit();
   process.exit(0);
 }
+
+// GPU process can crash on some Windows driver stacks (seen as 0xC0000409),
+// which leads to renderer blackscreens. Force software rendering path.
+app.disableHardwareAcceleration();
+app.commandLine.appendSwitch('disable-gpu');
+app.commandLine.appendSwitch('disable-gpu-compositing');
+app.commandLine.appendSwitch('in-process-gpu');
+app.commandLine.appendSwitch('use-angle', 'swiftshader');
+app.commandLine.appendSwitch('use-gl', 'swiftshader');
+app.commandLine.appendSwitch('disable-direct-composition');
+app.commandLine.appendSwitch('disable-d3d11');
+app.commandLine.appendSwitch(
+  'disable-features',
+  'UseSkiaRenderer,Vulkan,CanvasOopRasterization,VizDisplayCompositor,Accelerated2dCanvas',
+);
 
 const iconDataUrlCache = new Map();
 
@@ -327,16 +343,30 @@ const createWindow = () => {
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
+    backgroundColor: '#0b1020',
     webPreferences: {
       preload: path.join(__dirname, '../preload.js'), // Preload script for secure IPC
     },
   });
 
+  win.webContents.on('render-process-gone', (_event, details) => {
+    console.error('[electron] renderer process gone:', details);
+  });
+  win.webContents.on('did-fail-load', (_event, code, description, validatedURL, isMainFrame) => {
+    if (!isMainFrame) return;
+    console.error('[electron] main frame failed to load:', {
+      code,
+      description,
+      validatedURL,
+    });
+  });
+  win.webContents.on('unresponsive', () => {
+    console.error('[electron] window became unresponsive');
+  });
+
   win.loadURL('http://localhost:5173'); // Load the frontend (usually a dev server)
 };
 
-
-app.disableHardwareAcceleration();
 
 app.whenReady().then(() => {
   createWindow();
@@ -406,6 +436,1154 @@ const buildSystemMonitorSnapshot = () => {
   }];
 };
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const sortMonitorsByLayout = (monitors) => (
+  [...(Array.isArray(monitors) ? monitors : [])].sort((a, b) => (
+    (a?.layoutPosition?.y ?? a?.bounds?.y ?? 0) - (b?.layoutPosition?.y ?? b?.bounds?.y ?? 0)
+    || (a?.layoutPosition?.x ?? a?.bounds?.x ?? 0) - (b?.layoutPosition?.x ?? b?.bounds?.x ?? 0)
+    || Number(Boolean(b?.primary)) - Number(Boolean(a?.primary))
+  ))
+);
+
+const normalizeLabel = (value) => String(value || '').trim().toLowerCase();
+
+const parseMonitorOrdinal = (value) => {
+  const input = String(value || '').trim();
+  if (!input) return null;
+
+  const match = input.match(/(?:^|\s|-)monitor\s*([0-9]+)$/i) || input.match(/^monitor-([0-9]+)$/i);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+const createProfileMonitorMap = (profileMonitors, systemMonitors) => {
+  const profileList = sortMonitorsByLayout(profileMonitors);
+  const systemList = sortMonitorsByLayout(systemMonitors);
+  const usedSystemIds = new Set();
+  const bySystemId = new Map(systemList.map((monitor) => [monitor.id, monitor]));
+  const bySystemName = new Map();
+  for (const monitor of systemList) {
+    const key = normalizeLabel(monitor?.systemName);
+    if (key && !bySystemName.has(key)) bySystemName.set(key, monitor);
+  }
+  const byMonitorOrdinal = new Map();
+  for (const monitor of systemList) {
+    const ordinal = parseMonitorOrdinal(monitor?.name);
+    if (ordinal && !byMonitorOrdinal.has(ordinal)) {
+      byMonitorOrdinal.set(ordinal, monitor);
+    }
+  }
+
+  const closestByLayout = (profileMonitor) => {
+    const px = Number(profileMonitor?.layoutPosition?.x ?? NaN);
+    const py = Number(profileMonitor?.layoutPosition?.y ?? NaN);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return null;
+    let best = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const monitor of systemList) {
+      if (usedSystemIds.has(monitor.id)) continue;
+      const mx = Number(monitor?.layoutPosition?.x ?? monitor?.bounds?.x ?? NaN);
+      const my = Number(monitor?.layoutPosition?.y ?? monitor?.bounds?.y ?? NaN);
+      if (!Number.isFinite(mx) || !Number.isFinite(my)) continue;
+      const dx = px - mx;
+      const dy = py - my;
+      const distance = (dx * dx) + (dy * dy);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = monitor;
+      }
+    }
+    return best;
+  };
+
+  const pickFirstUnused = () => systemList.find((monitor) => !usedSystemIds.has(monitor.id)) || systemList[0] || null;
+
+  const mapping = new Map();
+  profileList.forEach((profileMonitor, index) => {
+    let target = null;
+    if (profileMonitor?.id && bySystemId.has(profileMonitor.id) && !usedSystemIds.has(profileMonitor.id)) {
+      target = bySystemId.get(profileMonitor.id);
+    }
+    if (!target) {
+      const nameMatch = bySystemName.get(normalizeLabel(profileMonitor?.systemName));
+      if (nameMatch && !usedSystemIds.has(nameMatch.id)) {
+        target = nameMatch;
+      }
+    }
+    if (!target) {
+      const ordinal = (
+        parseMonitorOrdinal(profileMonitor?.name)
+        || parseMonitorOrdinal(profileMonitor?.id)
+      );
+      const ordinalMatch = ordinal ? byMonitorOrdinal.get(ordinal) : null;
+      if (ordinalMatch && !usedSystemIds.has(ordinalMatch.id)) {
+        target = ordinalMatch;
+      }
+    }
+    if (!target) {
+      target = closestByLayout(profileMonitor);
+    }
+    if (!target) {
+      const indexCandidate = systemList[index];
+      if (indexCandidate && !usedSystemIds.has(indexCandidate.id)) {
+        target = indexCandidate;
+      }
+    }
+    if (!target) {
+      target = pickFirstUnused();
+    }
+
+    if (profileMonitor?.id && target) {
+      mapping.set(profileMonitor.id, target);
+      usedSystemIds.add(target.id);
+    }
+  });
+
+  return mapping;
+};
+
+const buildWindowBoundsForApp = (app, monitor, launchState) => {
+  const workArea = monitor?.workArea || monitor?.bounds;
+  if (!workArea) return null;
+
+  const hasExplicitSize = (
+    Number.isFinite(Number(app?.size?.width))
+    && Number.isFinite(Number(app?.size?.height))
+  );
+  const hasExplicitPosition = (
+    Number.isFinite(Number(app?.position?.x))
+    && Number.isFinite(Number(app?.position?.y))
+  );
+  const hasSourceGeometry = (
+    Number.isFinite(Number(app?.sourceSize?.width))
+    && Number.isFinite(Number(app?.sourceSize?.height))
+    && Number.isFinite(Number(app?.sourcePosition?.x))
+    && Number.isFinite(Number(app?.sourcePosition?.y))
+  );
+
+  const appSize = app?.size || {};
+  const appPosition = app?.position || app?.sourcePosition || {};
+  const widthPct = clamp(Number(appSize.width || 70), 5, 100);
+  const heightPct = clamp(Number(appSize.height || 70), 5, 100);
+  const centerXPct = clamp(Number(appPosition.x || 50), 0, 100);
+  const centerYPct = clamp(Number(appPosition.y || 50), 0, 100);
+  const width = Math.round(clamp((workArea.width * widthPct) / 100, 280, workArea.width));
+  const height = Math.round(clamp((workArea.height * heightPct) / 100, 220, workArea.height));
+  const left = Math.round(workArea.x + ((centerXPct / 100) * workArea.width) - (width / 2));
+  const top = Math.round(workArea.y + ((centerYPct / 100) * workArea.height) - (height / 2));
+
+  const boundedLeft = clamp(left, workArea.x, workArea.x + Math.max(0, workArea.width - width));
+  const boundedTop = clamp(top, workArea.y, workArea.y + Math.max(0, workArea.height - height));
+  const shouldForceFullscreen = launchState === 'maximized' || app?.launchBehavior === 'maximize';
+  const shouldMinimize = launchState === 'minimized' || app?.launchBehavior === 'minimize';
+  const looksFullscreenByGeometry = widthPct >= 95 && heightPct >= 95;
+  const minimizedWithoutSavedGeometry = (
+    shouldMinimize
+    && !hasSourceGeometry
+    && !(hasExplicitSize && hasExplicitPosition)
+  );
+
+  if (shouldForceFullscreen || looksFullscreenByGeometry || minimizedWithoutSavedGeometry) {
+    return {
+      left: workArea.x,
+      top: workArea.y,
+      width: workArea.width,
+      height: workArea.height,
+      state: shouldMinimize ? 'minimized' : 'maximized',
+    };
+  }
+
+  return {
+    left: boundedLeft,
+    top: boundedTop,
+    width,
+    height,
+    state: shouldMinimize ? 'minimized' : 'normal',
+  };
+};
+
+const moveWindowToBounds = ({
+  pid,
+  bounds,
+  processNameHint,
+  aggressiveMaximize = false,
+  positionOnlyBeforeMaximize = false,
+  preferNameEnumeration = false,
+  excludedWindowHandles = [],
+}) => (
+  new Promise((resolve) => {
+    const safePid = Number(pid || 0);
+    const safeProcessNameHint = String(processNameHint || '')
+      .trim()
+      .toLowerCase()
+      .replace(/\.exe$/i, '');
+    if (!bounds || (!Number.isFinite(safePid) && !safeProcessNameHint)) {
+      resolve({ applied: false, handle: null });
+      return;
+    }
+
+    const left = Number(bounds.left || 0);
+    const top = Number(bounds.top || 0);
+    const width = Math.max(120, Number(bounds.width || 800));
+    const height = Math.max(120, Number(bounds.height || 600));
+    const forceMaximize = bounds.state === 'maximized';
+    const setPosFlags = positionOnlyBeforeMaximize ? 0x0045 : 0x0044;
+    const windowState = bounds.state === 'maximized'
+      ? 3 // SW_MAXIMIZE
+      : bounds.state === 'minimized'
+        ? 2 // SW_MINIMIZE
+        : 9; // SW_RESTORE
+
+    const excludedCsv = (Array.isArray(excludedWindowHandles) ? excludedWindowHandles : [])
+      .map((h) => String(h || '').trim())
+      .filter(Boolean)
+      .join(',');
+
+    const psScript = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class Win32 {
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hWnd, IntPtr after, int X, int Y, int cx, int cy, uint flags);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int cmd);
+  [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc cb, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern int GetWindowTextLength(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint pid);
+
+  public static List<IntPtr> FindVisibleWindowsForPids(HashSet<uint> pids, HashSet<string> excluded) {
+    var found = new List<IntPtr>();
+    EnumWindows((hWnd, lp) => {
+      if (!IsWindowVisible(hWnd)) return true;
+      uint wPid;
+      GetWindowThreadProcessId(hWnd, out wPid);
+      if (!pids.Contains(wPid)) return true;
+      string hs = ((long)hWnd).ToString();
+      if (excluded != null && excluded.Contains(hs)) return true;
+      found.Add(hWnd);
+      return true;
+    }, IntPtr.Zero);
+    return found;
+  }
+}
+"@
+$excludedSet = New-Object 'System.Collections.Generic.HashSet[string]'
+foreach ($tok in ("${excludedCsv.replace(/"/g, '`"')}" -split ',')) {
+  $t = $tok.Trim()
+  if ($t.Length -gt 0) { [void]$excludedSet.Add($t) }
+}
+
+function Apply-Placement {
+  param([IntPtr]$Handle)
+  if ($Handle -eq [IntPtr]::Zero) { return $false }
+  [void][Win32]::SetWindowPos($Handle, [IntPtr]::Zero, ${Math.floor(left)}, ${Math.floor(top)}, ${Math.floor(width)}, ${Math.floor(height)}, ${setPosFlags})
+  [void][Win32]::ShowWindowAsync($Handle, ${windowState})
+  if (${(forceMaximize && aggressiveMaximize) ? '$true' : '$false'}) {
+    # Re-assert maximize a few times because Chromium can recreate/restore windows right after launch.
+    [void][Win32]::SetWindowPos($Handle, [IntPtr]::Zero, ${Math.floor(left)}, ${Math.floor(top)}, ${Math.floor(width)}, ${Math.floor(height)}, 0x0044)
+    for ($mx = 0; $mx -lt 3; $mx++) {
+      Start-Sleep -Milliseconds 80
+      [void][Win32]::ShowWindowAsync($Handle, 9)
+      Start-Sleep -Milliseconds 80
+      [void][Win32]::ShowWindowAsync($Handle, 3)
+    }
+  }
+  return $true
+}
+
+$applied = $false
+$appliedHandle = ""
+$maxAttempts = ${preferNameEnumeration ? 28 : 16}
+$sleepMs = ${preferNameEnumeration ? 100 : 90}
+for ($attempt = 0; $attempt -lt $maxAttempts; $attempt++) {
+  $candidates = New-Object 'System.Collections.Generic.List[IntPtr]'
+
+  # Strategy 1: PID tree (MainWindowHandle only — fast path for non-Chromium)
+  if (${preferNameEnumeration ? '$false' : '$true'} -and ${safePid} -gt 0) {
+    $treePids = New-Object 'System.Collections.Generic.HashSet[int]'
+    [void]$treePids.Add(${Math.floor(safePid)})
+    for ($d = 0; $d -lt 3; $d++) {
+      $snap = @($treePids)
+      foreach ($pp in $snap) {
+        try {
+          $children = Get-CimInstance Win32_Process -Filter ("ParentProcessId = " + $pp) -ErrorAction SilentlyContinue
+          foreach ($c in $children) { try { [void]$treePids.Add([int]$c.ProcessId) } catch {} }
+        } catch {}
+      }
+    }
+    foreach ($tp in $treePids) {
+      try {
+        $p = Get-Process -Id $tp -ErrorAction SilentlyContinue
+        if ($p -and $p.MainWindowHandle -ne 0) {
+          $hs = [string]([int64]$p.MainWindowHandle)
+          if (-not $excludedSet.Contains($hs)) {
+            [void]$candidates.Add([IntPtr]::new([int64]$p.MainWindowHandle))
+          }
+        }
+      } catch {}
+    }
+  }
+
+  # Strategy 2: EnumWindows — compiled C# callback finds ALL visible windows, not just MainWindowHandle
+  if ($candidates.Count -eq 0 -and -not [string]::IsNullOrWhiteSpace("${safeProcessNameHint.replace(/"/g, '`"')}")) {
+    $pids = New-Object 'System.Collections.Generic.HashSet[uint32]'
+    try {
+      $procs = Get-Process -Name "${safeProcessNameHint.replace(/"/g, '`"')}" -ErrorAction SilentlyContinue
+      foreach ($p in $procs) { [void]$pids.Add([uint32]$p.Id) }
+    } catch {}
+    if ($pids.Count -gt 0) {
+      $enumResults = [Win32]::FindVisibleWindowsForPids($pids, $excludedSet)
+      foreach ($eh in $enumResults) { [void]$candidates.Add($eh) }
+    }
+  }
+
+  # Strategy 3: foreground window fallback
+  if ($candidates.Count -eq 0) {
+    try {
+      $fg = [Win32]::GetForegroundWindow()
+      if ($fg -ne [IntPtr]::Zero) {
+        $fgStr = [string]([int64]$fg)
+        if (-not $excludedSet.Contains($fgStr)) {
+          [void]$candidates.Add($fg)
+        }
+      }
+    } catch {}
+  }
+
+  foreach ($candidate in $candidates) {
+    if ($candidate -eq [IntPtr]::Zero) { continue }
+    if (Apply-Placement -Handle $candidate) {
+      $applied = $true
+      $appliedHandle = [string]([int64]$candidate)
+      break
+    }
+  }
+
+  if ($applied) { break }
+  Start-Sleep -Milliseconds $sleepMs
+}
+if (-not $applied) {
+  Write-Output "no-window|"
+  exit 0
+}
+Write-Output "ok|$appliedHandle"`;
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+      { windowsHide: true, timeout: 12000, maxBuffer: 1024 * 256 },
+      (_error, stdout) => {
+        const output = String(stdout || '').trim();
+        const [status, handle] = output.split('|');
+        resolve({
+          applied: (status || '').toLowerCase() === 'ok',
+          handle: handle || null,
+        });
+      },
+    );
+  })
+);
+
+const moveSpecificWindowHandleToBounds = ({
+  handle,
+  bounds,
+  aggressiveMaximize = false,
+  positionOnlyBeforeMaximize = false,
+}) => (
+  new Promise((resolve) => {
+    const safeHandle = String(handle || '').trim();
+    if (!safeHandle || !bounds) {
+      resolve({ applied: false, handle: null });
+      return;
+    }
+
+    const left = Number(bounds.left || 0);
+    const top = Number(bounds.top || 0);
+    const width = Math.max(120, Number(bounds.width || 800));
+    const height = Math.max(120, Number(bounds.height || 600));
+    const setPosFlags = positionOnlyBeforeMaximize ? 0x0045 : 0x0044;
+    const windowState = bounds.state === 'maximized'
+      ? 3 // SW_MAXIMIZE
+      : bounds.state === 'minimized'
+        ? 2 // SW_MINIMIZE
+        : 9; // SW_RESTORE
+
+    const psScript = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class Win32 {
+  [DllImport("user32.dll")] public static extern bool SetWindowPos(IntPtr hWnd, IntPtr after, int X, int Y, int cx, int cy, uint flags);
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int cmd);
+}
+"@
+$h = [IntPtr]::new([int64]"${safeHandle.replace(/"/g, '`"')}")
+if ($h -eq [IntPtr]::Zero) { Write-Output "no-window|"; exit 0 }
+[void][Win32]::SetWindowPos($h, [IntPtr]::Zero, ${Math.floor(left)}, ${Math.floor(top)}, ${Math.floor(width)}, ${Math.floor(height)}, ${setPosFlags})
+[void][Win32]::ShowWindowAsync($h, ${windowState})
+if (${(bounds.state === 'maximized' && aggressiveMaximize) ? '$true' : '$false'}) {
+  [void][Win32]::SetWindowPos($h, [IntPtr]::Zero, ${Math.floor(left)}, ${Math.floor(top)}, ${Math.floor(width)}, ${Math.floor(height)}, 0x0044)
+  for ($mx = 0; $mx -lt 3; $mx++) {
+    Start-Sleep -Milliseconds 80
+    [void][Win32]::ShowWindowAsync($h, 9)
+    Start-Sleep -Milliseconds 80
+    [void][Win32]::ShowWindowAsync($h, 3)
+  }
+}
+Write-Output "ok|${safeHandle.replace(/"/g, '`"')}"`;
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+      { windowsHide: true, timeout: 6000, maxBuffer: 1024 * 128 },
+      (_error, stdout) => {
+        const output = String(stdout || '').trim();
+        const [status, outHandle] = output.split('|');
+        resolve({
+          applied: (status || '').toLowerCase() === 'ok',
+          handle: outHandle || null,
+        });
+      },
+    );
+  })
+);
+
+const maximizeWindowHandle = (handle) => (
+  new Promise((resolve) => {
+    const safeHandle = String(handle || '').trim();
+    if (!safeHandle) {
+      resolve(false);
+      return;
+    }
+
+    const psScript = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class Win32 {
+  [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int cmd);
+}
+"@
+$h = [IntPtr]::new([int64]"${safeHandle.replace(/"/g, '`"')}")
+if ($h -eq [IntPtr]::Zero) { Write-Output "no"; exit 0 }
+[void][Win32]::ShowWindowAsync($h, 9) # SW_RESTORE
+Start-Sleep -Milliseconds 90
+[void][Win32]::ShowWindowAsync($h, 3) # SW_MAXIMIZE
+Write-Output "ok"`;
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+      { windowsHide: true, timeout: 3000, maxBuffer: 1024 * 64 },
+      (_error, stdout) => {
+        resolve(String(stdout || '').toLowerCase().includes('ok'));
+      },
+    );
+  })
+);
+
+const getWindowRectByHandle = (handle) => (
+  new Promise((resolve) => {
+    const safeHandle = String(handle || '').trim();
+    if (!safeHandle) {
+      resolve(null);
+      return;
+    }
+
+    const psScript = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public static class Win32Rect {
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+}
+"@
+$h = [IntPtr]::new([int64]"${safeHandle.replace(/"/g, '`"')}")
+if ($h -eq [IntPtr]::Zero) { Write-Output "{}"; exit 0 }
+$r = New-Object Win32Rect+RECT
+$ok = [Win32Rect]::GetWindowRect($h, [ref]$r)
+if (-not $ok) { Write-Output "{}"; exit 0 }
+@{
+  left = [int]$r.Left
+  top = [int]$r.Top
+  width = [int]($r.Right - $r.Left)
+  height = [int]($r.Bottom - $r.Top)
+} | ConvertTo-Json -Depth 2`;
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+      { windowsHide: true, timeout: 4000, maxBuffer: 1024 * 128 },
+      (_error, stdout) => {
+        try {
+          const parsed = JSON.parse(String(stdout || '').trim() || '{}');
+          if (
+            Number.isFinite(Number(parsed?.left))
+            && Number.isFinite(Number(parsed?.top))
+            && Number.isFinite(Number(parsed?.width))
+            && Number.isFinite(Number(parsed?.height))
+          ) {
+            resolve({
+              left: Number(parsed.left),
+              top: Number(parsed.top),
+              width: Number(parsed.width),
+              height: Number(parsed.height),
+            });
+            return;
+          }
+          resolve(null);
+        } catch {
+          resolve(null);
+        }
+      },
+    );
+  })
+);
+
+const isWindowOnTargetMonitor = ({ rect, monitor }) => {
+  if (!rect || !monitor) return false;
+  const target = monitor.workArea || monitor.bounds || null;
+  if (!target) return false;
+
+  const centerX = rect.left + (rect.width / 2);
+  const centerY = rect.top + (rect.height / 2);
+  const centerOnTarget = (
+    centerX >= target.x
+    && centerX <= (target.x + target.width)
+    && centerY >= target.y
+    && centerY <= (target.y + target.height)
+  );
+  if (!centerOnTarget) return false;
+  return true;
+};
+
+const verifyAndCorrectWindowPlacement = async ({
+  handle,
+  monitor,
+  bounds,
+  aggressiveMaximize = false,
+  positionOnlyBeforeMaximize = false,
+  maxCorrections = 2,
+  initialCheckDelayMs = 0,
+}) => {
+  const safeHandle = String(handle || '').trim();
+  if (!safeHandle || !monitor || !bounds) {
+    return { verified: false, corrected: false };
+  }
+
+  if (initialCheckDelayMs > 0) {
+    await sleep(initialCheckDelayMs);
+  }
+
+  for (let attempt = 0; attempt <= maxCorrections; attempt += 1) {
+    const rect = await getWindowRectByHandle(safeHandle);
+    if (isWindowOnTargetMonitor({ rect, monitor, bounds })) {
+      return { verified: true, corrected: attempt > 0 };
+    }
+    if (attempt >= maxCorrections) break;
+
+    await moveSpecificWindowHandleToBounds({
+      handle: safeHandle,
+      bounds,
+      aggressiveMaximize,
+      positionOnlyBeforeMaximize,
+    });
+    await sleep(90);
+  }
+
+  return { verified: false, corrected: true };
+};
+
+const getVisibleWindowInfos = (processName) => (
+  new Promise((resolve) => {
+    const safeName = String(processName || '').trim().toLowerCase().replace(/\.exe$/i, '');
+    if (!safeName) { resolve([]); return; }
+
+    const psScript = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class WinEnum {
+  [StructLayout(LayoutKind.Sequential)]
+  public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+  public delegate bool EnumWinProc(IntPtr hWnd, IntPtr lp);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWinProc cb, IntPtr lp);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool IsWindowEnabled(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern bool IsHungAppWindow(IntPtr hWnd);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint pid);
+  [DllImport("user32.dll")] public static extern IntPtr GetWindowLongPtr(IntPtr hWnd, int nIndex);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+  [DllImport("user32.dll")] public static extern int GetWindowTextLength(IntPtr hWnd);
+  [DllImport("dwmapi.dll")] public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
+  public static List<Dictionary<string, object>> FindVisibleWindows(HashSet<uint> pids) {
+    var r = new List<Dictionary<string, object>>();
+    EnumWindows((h, l) => {
+      if (!IsWindowVisible(h)) return true;
+      uint p; GetWindowThreadProcessId(h, out p);
+      if (!pids.Contains(p)) return true;
+      RECT rect;
+      if (!GetWindowRect(h, out rect)) return true;
+      int width = rect.Right - rect.Left;
+      int height = rect.Bottom - rect.Top;
+      if (width <= 80 || height <= 80) return true;
+      long exStyle = GetWindowLongPtr(h, -20).ToInt64();
+      bool isToolWindow = (exStyle & 0x00000080L) != 0; // WS_EX_TOOLWINDOW
+      int cloaked = 0;
+      try { DwmGetWindowAttribute(h, 14, out cloaked, 4); } catch { cloaked = 0; } // DWMWA_CLOAKED
+      var cls = new StringBuilder(256);
+      GetClassName(h, cls, cls.Capacity);
+      int titleLen = GetWindowTextLength(h);
+      var row = new Dictionary<string, object>();
+      row["handle"] = ((long)h).ToString();
+      row["width"] = width;
+      row["height"] = height;
+      row["area"] = width * height;
+      row["enabled"] = IsWindowEnabled(h);
+      row["hung"] = IsHungAppWindow(h);
+      row["tool"] = isToolWindow;
+      row["cloaked"] = cloaked != 0;
+      row["className"] = cls.ToString();
+      row["titleLength"] = titleLen;
+      r.Add(row);
+      return true;
+    }, IntPtr.Zero);
+    return r;
+  }
+}
+"@
+$pids = New-Object 'System.Collections.Generic.HashSet[uint32]'
+try {
+  $procs = Get-Process -Name "${safeName.replace(/"/g, '`"')}" -ErrorAction SilentlyContinue
+  foreach ($p in $procs) { [void]$pids.Add([uint32]$p.Id) }
+} catch {}
+if ($pids.Count -eq 0) { Write-Output "[]"; exit 0 }
+$rows = [WinEnum]::FindVisibleWindows($pids)
+$rows | ConvertTo-Json -Depth 5`;
+
+    execFile(
+      'powershell.exe',
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', psScript],
+      { windowsHide: true, timeout: 8000, maxBuffer: 1024 * 256 },
+      (_error, stdout) => {
+        try {
+          const parsed = JSON.parse(String(stdout || '').trim() || '[]');
+          const rows = Array.isArray(parsed) ? parsed : [parsed];
+          resolve(rows.filter(Boolean).map((row) => ({
+            handle: String(row.handle || ''),
+            width: Number(row.width || 0),
+            height: Number(row.height || 0),
+            area: Number(row.area || 0),
+            enabled: Boolean(row.enabled),
+            hung: Boolean(row.hung),
+            tool: Boolean(row.tool),
+            cloaked: Boolean(row.cloaked),
+            className: String(row.className || ''),
+            titleLength: Number(row.titleLength || 0),
+          })).filter((row) => row.handle));
+        } catch {
+          resolve([]);
+        }
+      },
+    );
+  })
+);
+
+const scoreWindowCandidate = (row) => {
+  const className = String(row?.className || '').toLowerCase();
+  const titleLength = Number(row?.titleLength || 0);
+  const area = Number(row?.area || 0);
+  let score = 0;
+
+  if (row?.enabled) score += 1_000_000_000;
+  if (!row?.hung) score += 250_000_000;
+  if (!row?.tool) score += 100_000_000;
+  if (!row?.cloaked) score += 50_000_000;
+  if (titleLength > 0) score += 5_000_000;
+
+  // Penalize known non-primary Chromium surfaces that can appear blank/uninteractive.
+  if (className.includes('renderwidgethosthwnd')) score -= 150_000_000;
+  if (className.includes('intermediate d3d window')) score -= 120_000_000;
+
+  return score + area;
+};
+
+const waitForWindowResponsive = async (processName, handle, maxWaitMs = 1800) => {
+  const safeHandle = String(handle || '').trim();
+  if (!safeHandle) return false;
+
+  const deadline = Date.now() + Math.max(0, Number(maxWaitMs || 0));
+  while (Date.now() <= deadline) {
+    const rows = await getVisibleWindowInfos(processName);
+    const row = rows.find((candidate) => String(candidate.handle) === safeHandle);
+    if (row && row.enabled && !row.hung && !row.cloaked && row.area > 80_000) {
+      return true;
+    }
+    await sleep(120);
+  }
+
+  return false;
+};
+
+const launchExecutable = (executablePath, args = []) => (
+  new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(executablePath, args, {
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: false,
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    let completed = false;
+    const cleanup = () => {
+      child.removeListener('error', onError);
+      child.removeListener('spawn', onSpawn);
+    };
+    const onError = (error) => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      reject(error);
+    };
+    const onSpawn = () => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      child.unref();
+      resolve(child);
+    };
+
+    child.once('error', onError);
+    child.once('spawn', onSpawn);
+
+    setTimeout(() => {
+      if (completed) return;
+      completed = true;
+      cleanup();
+      child.unref();
+      resolve(child);
+    }, 200);
+  })
+);
+
+const gatherProfileAppLaunches = (profile, monitorMap) => {
+  const launches = [];
+  const skippedApps = [];
+  const primaryProfileMonitorId = (Array.isArray(profile?.monitors) ? profile.monitors : []).find((monitor) => monitor?.primary)?.id;
+  const defaultMonitor = sortMonitorsByLayout(buildSystemMonitorSnapshot())[0] || null;
+  const restrictedNames = new Set(
+    (Array.isArray(profile?.restrictedApps) ? profile.restrictedApps : [])
+      .map((name) => normalizeLabel(name))
+      .filter(Boolean),
+  );
+
+  const pushIfLaunchable = (app, profileMonitorId) => {
+    const appName = String(app?.name || '').trim();
+    if (!appName) {
+      skippedApps.push({
+        name: 'Unnamed App',
+        reason: 'missing-name',
+      });
+      return;
+    }
+    if (restrictedNames.has(normalizeLabel(appName))) {
+      skippedApps.push({
+        name: appName,
+        reason: 'restricted',
+      });
+      return;
+    }
+
+    const executablePath = extractExecutablePath(app?.executablePath || app?.path || '');
+    if (!executablePath) {
+      skippedApps.push({
+        name: appName,
+        reason: 'missing-executable-path',
+      });
+      return;
+    }
+
+    const monitor = (
+      (profileMonitorId && monitorMap.get(profileMonitorId))
+      || monitorMap.get(primaryProfileMonitorId)
+      || defaultMonitor
+    );
+    launches.push({
+      appName,
+      executablePath,
+      monitor,
+      app,
+    });
+  };
+
+  for (const monitor of (Array.isArray(profile?.monitors) ? profile.monitors : [])) {
+    for (const app of (Array.isArray(monitor?.apps) ? monitor.apps : [])) {
+      pushIfLaunchable(app, monitor?.id);
+    }
+  }
+
+  for (const app of (Array.isArray(profile?.minimizedApps) ? profile.minimizedApps : [])) {
+    pushIfLaunchable(app, app?.targetMonitor || primaryProfileMonitorId || null);
+  }
+
+  return { launches, skippedApps };
+};
+
+const gatherLegacyActionLaunches = (profile, monitorMap) => {
+  const actions = Array.isArray(profile?.actions) ? profile.actions : [];
+  const profileMonitors = sortMonitorsByLayout(profile?.monitors);
+  const defaultMonitor = sortMonitorsByLayout(buildSystemMonitorSnapshot())[0] || null;
+  const launches = [];
+  const browserUrls = [];
+  const skippedApps = [];
+  const restrictedNames = new Set(
+    (Array.isArray(profile?.restrictedApps) ? profile.restrictedApps : [])
+      .map((name) => normalizeLabel(name))
+      .filter(Boolean),
+  );
+
+  for (const action of actions) {
+    if (action?.type === 'browserTab') {
+      const url = String(action?.url || '').trim();
+      if (url) browserUrls.push(url);
+      continue;
+    }
+
+    if (action?.type !== 'app') continue;
+    const appName = String(action?.name || 'App').trim();
+    if (restrictedNames.has(normalizeLabel(appName))) {
+      skippedApps.push({
+        name: appName,
+        reason: 'restricted',
+      });
+      continue;
+    }
+
+    const executablePath = extractExecutablePath(action?.path || '');
+    if (!executablePath) {
+      skippedApps.push({
+        name: appName,
+        reason: 'invalid-legacy-action-path',
+      });
+      continue;
+    }
+
+    const monitorIndex = Math.max(0, Number(action?.monitor || 1) - 1);
+    const profileMonitorId = profileMonitors[monitorIndex]?.id;
+    const monitor = (profileMonitorId ? monitorMap.get(profileMonitorId) : null) || defaultMonitor;
+    launches.push({
+      appName,
+      executablePath,
+      monitor,
+      app: {
+        name: appName,
+        launchBehavior: 'new',
+      },
+    });
+  }
+
+  return {
+    launches,
+    browserUrls,
+    skippedApps,
+  };
+};
+
+const launchProfileById = async (profileId) => {
+  const profiles = readProfilesFromDisk();
+  const normalizedProfileId = String(profileId || '').trim();
+  const profile = profiles.find(
+    (candidate) => String(candidate?.id || '').trim() === normalizedProfileId,
+  );
+  if (!profile) {
+    return {
+      ok: false,
+      error: 'Profile not found. Save the profile and try again.',
+      requestedProfileId: normalizedProfileId,
+      availableProfileIds: profiles
+        .map((candidate) => String(candidate?.id || '').trim())
+        .filter(Boolean),
+    };
+  }
+
+  const launchState = profile?.launchMaximized
+    ? 'maximized'
+    : profile?.launchMinimized
+      ? 'minimized'
+      : 'normal';
+
+  const systemMonitors = buildSystemMonitorSnapshot();
+  const monitorMap = createProfileMonitorMap(profile?.monitors, systemMonitors);
+  const modernLaunchData = gatherProfileAppLaunches(profile, monitorMap);
+  const legacyLaunchData = gatherLegacyActionLaunches(profile, monitorMap);
+  const launchKey = (launch) => `${String(launch.executablePath || '').toLowerCase()}::${launch.monitor?.id || 'monitor'}`;
+  const seenLaunchKeys = new Set();
+  const appLaunches = [...modernLaunchData.launches, ...legacyLaunchData.launches]
+    .filter((launch) => {
+      const key = launchKey(launch);
+      if (seenLaunchKeys.has(key)) return false;
+      seenLaunchKeys.add(key);
+      return true;
+    });
+  const skippedApps = [...modernLaunchData.skippedApps, ...legacyLaunchData.skippedApps];
+  const failedApps = [];
+  let launchedAppCount = 0;
+  const launchOrder = profile?.launchOrder === 'sequential' ? 'sequential' : 'all-at-once';
+  const appLaunchDelays = (profile?.appLaunchDelays && typeof profile.appLaunchDelays === 'object')
+    ? profile.appLaunchDelays
+    : {};
+  const processHintCounts = new Map();
+  for (const launchItem of appLaunches) {
+    const processNameHint = path.basename(launchItem.executablePath, path.extname(launchItem.executablePath)).toLowerCase();
+    processHintCounts.set(processNameHint, (processHintCounts.get(processNameHint) || 0) + 1);
+  }
+
+  const runLaunch = async (launchItem) => {
+    try {
+      const processNameHint = path.basename(launchItem.executablePath, path.extname(launchItem.executablePath));
+      const processHintLc = processNameHint.toLowerCase();
+      const hintCount = processHintCounts.get(processHintLc) || 0;
+      const isDuplicateProcessLaunch = hintCount > 1;
+      const isChromiumFamily = processHintLc === 'msedge' || processHintLc === 'brave' || processHintLc === 'chrome';
+      const launchArgs = (isChromiumFamily && isDuplicateProcessLaunch) ? ['--new-window'] : [];
+      const preLaunchWindowInfos = isDuplicateProcessLaunch
+        ? await getVisibleWindowInfos(processHintLc)
+        : [];
+      const preLaunchHandles = preLaunchWindowInfos.map((row) => row.handle);
+
+      const launchedChild = await launchExecutable(launchItem.executablePath, launchArgs);
+      launchedAppCount += 1;
+      const bounds = buildWindowBoundsForApp(launchItem.app, launchItem.monitor, launchState);
+      if (bounds) {
+        const aggressiveMaximize = bounds.state === 'maximized' && processHintLc === 'msedge';
+        const positionOnlyBeforeMaximize = processHintLc === 'msedge' && bounds.state === 'maximized';
+        const shouldDelayChromiumMaximize = (
+          isChromiumFamily
+          && isDuplicateProcessLaunch
+          && bounds.state === 'maximized'
+        );
+        const placementBounds = shouldDelayChromiumMaximize
+          ? { ...bounds, state: 'normal' }
+          : bounds;
+        const excludedHandles = preLaunchHandles;
+
+        if (isDuplicateProcessLaunch) {
+          await sleep(240);
+        }
+
+        let result = { applied: false, handle: null };
+        let newHandles = [];
+
+        if (isDuplicateProcessLaunch) {
+          const postLaunchWindowInfos = await getVisibleWindowInfos(processHintLc);
+          const postLaunchHandles = postLaunchWindowInfos.map((row) => row.handle);
+          const preHandleSet = new Set(preLaunchHandles);
+          newHandles = postLaunchHandles.filter((h) => !preHandleSet.has(h));
+          const newHandleSet = new Set(newHandles);
+          const rankedNewWindows = postLaunchWindowInfos
+            .filter((row) => newHandleSet.has(row.handle))
+            .sort((a, b) => scoreWindowCandidate(b) - scoreWindowCandidate(a));
+
+          for (const candidateRow of rankedNewWindows) {
+            const newHandle = candidateRow.handle;
+            if (isChromiumFamily) {
+              await waitForWindowResponsive(processHintLc, newHandle, 2200);
+            }
+            result = await moveSpecificWindowHandleToBounds({
+              handle: newHandle,
+              bounds: placementBounds,
+              aggressiveMaximize,
+              positionOnlyBeforeMaximize,
+            });
+            if (result.applied) break;
+          }
+
+          // Trace duplicate-window routing for any multi-window app.
+          console.log('[launch-profile] duplicate-window-placement', {
+            appName: launchItem.appName,
+            process: processHintLc,
+            targetMonitor: launchItem.monitor?.name || launchItem.monitor?.id || 'unknown',
+            targetState: bounds.state,
+            preHandles: preLaunchHandles,
+            postHandles: postLaunchHandles,
+            newHandles,
+            rankedNewWindowCandidates: rankedNewWindows.map((row) => ({
+              handle: row.handle,
+              enabled: row.enabled,
+              hung: row.hung,
+              tool: row.tool,
+              cloaked: row.cloaked,
+              className: row.className,
+              titleLength: row.titleLength,
+              area: row.area,
+              score: scoreWindowCandidate(row),
+            })),
+            placedHandle: result.handle,
+            applied: result.applied,
+          });
+        }
+
+        if (!result.applied) {
+          result = await moveWindowToBounds({
+            pid: launchedChild?.pid || 0,
+            bounds: placementBounds,
+            processNameHint,
+            aggressiveMaximize,
+            positionOnlyBeforeMaximize,
+            preferNameEnumeration: isDuplicateProcessLaunch,
+            excludedWindowHandles: excludedHandles,
+          });
+        }
+
+        if (!result.applied && isDuplicateProcessLaunch) {
+          await sleep(260);
+          result = await moveWindowToBounds({
+            pid: launchedChild?.pid || 0,
+            bounds: placementBounds,
+            processNameHint,
+            aggressiveMaximize,
+            positionOnlyBeforeMaximize,
+            preferNameEnumeration: true,
+            excludedWindowHandles: excludedHandles,
+          });
+        }
+
+        if (!result.applied && isDuplicateProcessLaunch && newHandles.length > 0) {
+          for (const newHandle of newHandles) {
+            result = await moveSpecificWindowHandleToBounds({
+              handle: newHandle,
+              bounds: placementBounds,
+              aggressiveMaximize,
+              positionOnlyBeforeMaximize,
+            });
+            if (result.applied) break;
+          }
+        }
+
+        if (result.applied && result.handle && isDuplicateProcessLaunch && launchItem.monitor) {
+          const verification = await verifyAndCorrectWindowPlacement({
+            handle: result.handle,
+            monitor: launchItem.monitor,
+            bounds: placementBounds,
+            aggressiveMaximize,
+            positionOnlyBeforeMaximize,
+            maxCorrections: isDuplicateProcessLaunch ? 1 : 0,
+            initialCheckDelayMs: isDuplicateProcessLaunch ? 220 : 0,
+          });
+
+          console.log('[launch-profile] placement-verification', {
+            appName: launchItem.appName,
+            process: processHintLc,
+            targetMonitor: launchItem.monitor?.name || launchItem.monitor?.id || 'unknown',
+            targetState: bounds.state,
+            handle: result.handle,
+            verified: verification.verified,
+            corrected: verification.corrected,
+          });
+        }
+
+        if (result.applied && result.handle && shouldDelayChromiumMaximize) {
+          await waitForWindowResponsive(processHintLc, result.handle, 2200);
+          await maximizeWindowHandle(result.handle);
+        }
+      }
+    } catch (error) {
+      failedApps.push({
+        name: launchItem.appName,
+        path: launchItem.executablePath,
+        error: String(error?.message || error || 'Failed to launch app'),
+      });
+    }
+  };
+
+  const hasDuplicateProcessLaunches = Array.from(processHintCounts.values())
+    .some((count) => count > 1);
+
+  if (launchOrder === 'sequential' || hasDuplicateProcessLaunches) {
+    for (const launchItem of appLaunches) {
+      const delaySeconds = Number(appLaunchDelays[launchItem.appName] || 0);
+      const safeDelayMs = Math.max(0, Math.floor(delaySeconds * 1000));
+      if (safeDelayMs > 0) {
+        await sleep(safeDelayMs);
+      }
+      await runLaunch(launchItem);
+    }
+  } else {
+    await Promise.all(appLaunches.map((launchItem) => runLaunch(launchItem)));
+  }
+
+  const { shell } = require('electron');
+  const browserTabs = Array.isArray(profile?.browserTabs) ? profile.browserTabs : [];
+  const launchedUrls = new Set();
+  let launchedTabCount = 0;
+  for (const tab of browserTabs) {
+    const url = String(tab?.url || '').trim();
+    if (!url || launchedUrls.has(url)) continue;
+    launchedUrls.add(url);
+    try {
+      await shell.openExternal(url);
+      launchedTabCount += 1;
+    } catch {
+      // Keep profile launch resilient if one tab URL fails.
+    }
+  }
+
+  for (const url of legacyLaunchData.browserUrls) {
+    if (!url || launchedUrls.has(url)) continue;
+    launchedUrls.add(url);
+    try {
+      await shell.openExternal(url);
+      launchedTabCount += 1;
+    } catch {
+      // Keep profile launch resilient if one tab URL fails.
+    }
+  }
+
+  if (launchedAppCount === 0 && launchedTabCount === 0) {
+    return {
+      ok: false,
+      error: 'No launchable apps or tabs found in this profile. Add an executable path in app details or recreate from installed apps.',
+      profile,
+      launchedAppCount,
+      launchedTabCount,
+      failedApps,
+      skippedApps,
+      requestedAppCount: appLaunches.length,
+    };
+  }
+
+  return {
+    ok: failedApps.length === 0,
+    profile,
+    launchedAppCount,
+    launchedTabCount,
+    failedApps,
+    skippedApps,
+    requestedAppCount: appLaunches.length,
+  };
+};
+
 ipcMain.handle('get-system-monitors', async () => {
   try {
     const monitors = buildSystemMonitorSnapshot();
@@ -452,41 +1630,12 @@ ipcMain.handle('profiles:save-all', async (_event, profiles) => {
   }
 });
 
-// Listen for 'launch-profile' IPC events from the renderer process
-ipcMain.on('launch-profile', (event, profileId) => {
+ipcMain.handle('launch-profile', async (_event, profileId) => {
   try {
-    const profiles = readProfilesFromDisk();
-    const profile = profiles.find((candidate) => candidate?.id === profileId);
-
-    if (!profile) {
-      event.reply('profile-loaded', { error: 'Profile not found' });
-      return;
-    }
-
-    // Send profile back to React
-    event.reply('profile-loaded', profile);
-
-    const actions = Array.isArray(profile.actions) ? profile.actions : [];
-    if (actions.length === 0) return;
-
-    // Require node modules for launching things
-    const { spawn } = require('child_process');
-    const { shell } = require('electron');
-
-    // Loop through each action in the profile
-    for (const action of actions) {
-      if (action?.type === 'app' && action.path) {
-        spawn(action.path, {
-          detached: true,
-          stdio: 'ignore',
-        }).unref();
-      } else if (action?.type === 'browserTab' && action.url) {
-        shell.openExternal(action.url);
-      }
-    }
+    return await launchProfileById(profileId);
   } catch (err) {
     console.error('Failed to load or launch profile:', err);
-    event.reply('profile-loaded', { error: 'Failed to load profile' });
+    return { ok: false, error: 'Failed to load profile' };
   }
 });
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -354,6 +354,85 @@ app.on('second-instance', () => {
   existingWindow.focus();
 });
 
+const buildSystemMonitorSnapshot = () => {
+  const { screen } = require('electron');
+  const displays = screen.getAllDisplays();
+  const primaryDisplayId = screen.getPrimaryDisplay().id;
+
+  const monitors = displays.map((display, idx) => ({
+    id: `monitor-${display.id}`,
+    name: `Monitor ${idx + 1}`,
+    systemName: (display.label && String(display.label).trim()) ? String(display.label).trim() : null,
+    primary: display.id === primaryDisplayId,
+    scaleFactor: display.scaleFactor,
+    resolution: `${Math.round(display.bounds.width * display.scaleFactor)}x${Math.round(display.bounds.height * display.scaleFactor)}`,
+    orientation: (
+      display.rotation === 90
+      || display.rotation === 270
+      || display.bounds.height > display.bounds.width
+    ) ? 'portrait' : 'landscape',
+    layoutPosition: { x: display.bounds.x, y: display.bounds.y },
+    bounds: display.bounds,
+    workArea: display.workArea,
+    pixelBounds: {
+      x: Math.round(display.bounds.x * display.scaleFactor),
+      y: Math.round(display.bounds.y * display.scaleFactor),
+      width: Math.round(display.bounds.width * display.scaleFactor),
+      height: Math.round(display.bounds.height * display.scaleFactor),
+    },
+    pixelWorkArea: {
+      x: Math.round(display.workArea.x * display.scaleFactor),
+      y: Math.round(display.workArea.y * display.scaleFactor),
+      width: Math.round(display.workArea.width * display.scaleFactor),
+      height: Math.round(display.workArea.height * display.scaleFactor),
+    },
+    apps: [],
+  }));
+
+  return monitors.length > 0 ? monitors : [{
+    id: 'monitor-1',
+    name: 'Monitor 1',
+    systemName: null,
+    primary: true,
+    scaleFactor: 1,
+    resolution: '1920x1080',
+    orientation: 'landscape',
+    layoutPosition: { x: 0, y: 0 },
+    bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    pixelBounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    pixelWorkArea: { x: 0, y: 0, width: 1920, height: 1080 },
+    apps: [],
+  }];
+};
+
+ipcMain.handle('get-system-monitors', async () => {
+  try {
+    const monitors = buildSystemMonitorSnapshot();
+    return monitors.map((monitor) => {
+      const cleanedMonitor = { ...monitor };
+      delete cleanedMonitor.bounds;
+      delete cleanedMonitor.workArea;
+      delete cleanedMonitor.pixelBounds;
+      delete cleanedMonitor.pixelWorkArea;
+      return cleanedMonitor;
+    });
+  } catch (error) {
+    console.error('Error in get-system-monitors handler:', error);
+    return [{
+      id: 'monitor-1',
+      name: 'Monitor 1',
+      systemName: null,
+      primary: true,
+      scaleFactor: 1,
+      resolution: '1920x1080',
+      orientation: 'landscape',
+      layoutPosition: { x: 0, y: 0 },
+      apps: [],
+    }];
+  }
+});
+
 ipcMain.handle('profiles:list', async () => {
   try {
     return readProfilesFromDisk();
@@ -691,65 +770,20 @@ ipcMain.handle('get-installed-apps', async () => {
 
 ipcMain.handle('capture-running-app-layout', async () => {
   try {
-    const { screen } = require('electron');
-    const displays = screen.getAllDisplays();
     const processes = await getRunningWindowProcesses();
-
-    const monitors = displays.map((display, idx) => ({
-      id: `monitor-${display.id}`,
-      name: `Monitor ${idx + 1}`,
-      primary: display.id === screen.getPrimaryDisplay().id,
-      scaleFactor: display.scaleFactor,
-      // Use physical pixel resolution so it matches our pixel-space normalization.
-      resolution: `${Math.round(display.bounds.width * display.scaleFactor)}x${Math.round(display.bounds.height * display.scaleFactor)}`,
-      orientation: (
-        display.rotation === 90
-        || display.rotation === 270
-        || display.bounds.height > display.bounds.width
-      ) ? 'portrait' : 'landscape',
-      layoutPosition: { x: display.bounds.x, y: display.bounds.y },
-      // Full display bounds (DIP) for monitor assignment.
-      bounds: display.bounds,
-      // Work area bounds (DIP) for optional dock-aware normalization.
-      workArea: display.workArea,
-      // Keep these fields for potential future heuristics/debug,
-      // but current geometry uses DIP to avoid scaling mismatches.
-      pixelBounds: {
-        x: Math.round(display.bounds.x * display.scaleFactor),
-        y: Math.round(display.bounds.y * display.scaleFactor),
-        width: Math.round(display.bounds.width * display.scaleFactor),
-        height: Math.round(display.bounds.height * display.scaleFactor),
-      },
-      pixelWorkArea: {
-        x: Math.round(display.workArea.x * display.scaleFactor),
-        y: Math.round(display.workArea.y * display.scaleFactor),
-        width: Math.round(display.workArea.width * display.scaleFactor),
-        height: Math.round(display.workArea.height * display.scaleFactor),
-      },
-      apps: [],
-    }));
-
-    const targetMonitors = monitors.length > 0 ? monitors : [{
-      id: 'monitor-1',
-      name: 'Monitor 1',
-      primary: true,
-      scaleFactor: 1,
-      resolution: '1920x1080',
-      orientation: 'landscape',
-      layoutPosition: { x: 0, y: 0 },
-      bounds: { x: 0, y: 0, width: 1920, height: 1080 },
-      workArea: { x: 0, y: 0, width: 1920, height: 1080 },
-      pixelBounds: { x: 0, y: 0, width: 1920, height: 1080 },
-      pixelWorkArea: { x: 0, y: 0, width: 1920, height: 1080 },
-      apps: [],
-    }];
+    const targetMonitors = buildSystemMonitorSnapshot();
     const minimizedApps = [];
+    const captureAllowList = new Set(['steamwebhelper', 'explorer']);
 
     const uniqueWindows = [];
     const seen = new Set();
     for (const p of processes) {
       if (!p?.name || !p?.bounds) continue;
-      if (hiddenProcessNamePatterns.some((pattern) => pattern.test(p.name))) continue;
+      const processNameLc = String(p.name).toLowerCase();
+      if (
+        hiddenProcessNamePatterns.some((pattern) => pattern.test(p.name))
+        && !captureAllowList.has(processNameLc)
+      ) continue;
       if (p?.title && hiddenWindowTitlePatterns.some((pattern) => pattern.test(p.title))) continue;
       const dedupeKey = `${p.id}::${p.title.toLowerCase()}::${p.bounds.x},${p.bounds.y},${p.bounds.width},${p.bounds.height}`;
       if (seen.has(dedupeKey)) continue;
@@ -1007,8 +1041,13 @@ ipcMain.handle('capture-running-app-layout', async () => {
       }
 
       const round1 = (n) => Math.round(n * 10) / 10;
+      const processName = String(windowInfo.name || '');
+      const normalizedAppName = (
+        processName.toLowerCase() === 'steamwebhelper'
+        || processName.toLowerCase() === 'steam'
+      ) ? 'Steam' : processName;
       const mappedWindow = {
-        name: windowInfo.name,
+        name: normalizedAppName,
         iconPath,
         executablePath: windowInfo.executablePath || null,
         position: {

--- a/src/main/services/windows-process-service.js
+++ b/src/main/services/windows-process-service.js
@@ -4,7 +4,6 @@ const hiddenProcessNamePatterns = [
   /^electron$/i,
   /helper$/i,
   /updater$/i,
-  /webhelper$/i,
   /crashpad/i,
   /^runtimebroker$/i,
   /^shellexperiencehost$/i,
@@ -42,21 +41,36 @@ public struct WINDOWPLACEMENT {
   public RECT rcNormalPosition;
 }
 public static class Win32 {
+  public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+  [DllImport("user32.dll")]
+  public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")]
+  public static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+  public static extern int GetWindowText(IntPtr hWnd, System.Text.StringBuilder lpString, int nMaxCount);
+  [DllImport("user32.dll")]
+  public static extern int GetWindowTextLength(IntPtr hWnd);
+  [DllImport("user32.dll")]
+  public static extern IntPtr GetShellWindow();
   [DllImport("user32.dll")]
   public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
   [DllImport("user32.dll")]
   public static extern bool IsIconic(IntPtr hWnd);
   [DllImport("user32.dll")]
   public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+  [DllImport("user32.dll")]
+  public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 }
 "@
 $items = @()
+$seen = New-Object 'System.Collections.Generic.HashSet[string]'
 Get-Process | Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -and $_.MainWindowTitle.Trim().Length -gt 0 } | ForEach-Object {
   $rect = New-Object RECT
-  if ([Win32]::GetWindowRect($_.MainWindowHandle, [ref]$rect)) {
+  $hWnd = [System.IntPtr]::new([int64]$_.MainWindowHandle)
+  if ([Win32]::GetWindowRect($hWnd, [ref]$rect)) {
     $width = $rect.Right - $rect.Left
     $height = $rect.Bottom - $rect.Top
-    $isMinimized = [Win32]::IsIconic($_.MainWindowHandle)
+    $isMinimized = [Win32]::IsIconic($hWnd)
     $normalLeft = $null
     $normalTop = $null
     $normalRight = $null
@@ -71,7 +85,7 @@ Get-Process | Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -
           # If SizeOf fails, leave length as-is; GetWindowPlacement will just return false.
           $placement.length = 0
         }
-        if ([Win32]::GetWindowPlacement($_.MainWindowHandle, [ref]$placement)) {
+        if ([Win32]::GetWindowPlacement($hWnd, [ref]$placement)) {
           $normalLeft = $placement.rcNormalPosition.Left
           $normalTop = $placement.rcNormalPosition.Top
           $normalRight = $placement.rcNormalPosition.Right
@@ -82,26 +96,101 @@ Get-Process | Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -
       }
     }
     if ($width -gt 0 -and $height -gt 0) {
-      $items += [pscustomobject]@{
-        ProcessName = $_.ProcessName
-        Id = $_.Id
-        MainWindowTitle = $_.MainWindowTitle
-        Path = $_.Path
-        IsMinimized = $isMinimized
-        Left = $rect.Left
-        Top = $rect.Top
-        Right = $rect.Right
-        Bottom = $rect.Bottom
-        NormalLeft = $normalLeft
-        NormalTop = $normalTop
-        NormalRight = $normalRight
-        NormalBottom = $normalBottom
-        Width = $width
-        Height = $height
+      $dedupeKey = "$($_.Id)|$($_.MainWindowTitle)|$($rect.Left),$($rect.Top),$($rect.Right),$($rect.Bottom)"
+      if ($seen.Add($dedupeKey)) {
+        $items += [pscustomobject]@{
+          ProcessName = $_.ProcessName
+          Id = $_.Id
+          MainWindowTitle = $_.MainWindowTitle
+          Path = $_.Path
+          IsMinimized = $isMinimized
+          Left = $rect.Left
+          Top = $rect.Top
+          Right = $rect.Right
+          Bottom = $rect.Bottom
+          NormalLeft = $normalLeft
+          NormalTop = $normalTop
+          NormalRight = $normalRight
+          NormalBottom = $normalBottom
+          Width = $width
+          Height = $height
+        }
       }
     }
   }
 }
+# Fallback capture for Explorer windows that can be missed by MainWindowHandle scanning.
+try {
+  $shellWindow = [Win32]::GetShellWindow()
+  $enumProc = [Win32+EnumWindowsProc]{
+    param([System.IntPtr]$hWnd, [System.IntPtr]$lParam)
+    try {
+      if ($hWnd -eq [System.IntPtr]::Zero -or $hWnd -eq $shellWindow) { return $true }
+      if (-not [Win32]::IsWindowVisible($hWnd)) { return $true }
+      $titleLen = [Win32]::GetWindowTextLength($hWnd)
+      if ($titleLen -le 0) { return $true }
+      $titleBuilder = New-Object System.Text.StringBuilder ($titleLen + 1)
+      [void][Win32]::GetWindowText($hWnd, $titleBuilder, $titleBuilder.Capacity)
+      $title = $titleBuilder.ToString()
+      if ([string]::IsNullOrWhiteSpace($title)) { return $true }
+
+      $rect = New-Object RECT
+      if (-not [Win32]::GetWindowRect($hWnd, [ref]$rect)) { return $true }
+      $width = $rect.Right - $rect.Left
+      $height = $rect.Bottom - $rect.Top
+      if ($width -le 0 -or $height -le 0) { return $true }
+
+      [uint32]$pid = 0
+      [void][Win32]::GetWindowThreadProcessId($hWnd, [ref]$pid)
+      if ($pid -le 0) { return $true }
+
+      $proc = [System.Diagnostics.Process]::GetProcessById([int]$pid)
+      if ($proc.ProcessName -ine 'explorer') { return $true }
+      $processPath = $null
+      try { $processPath = $proc.Path } catch { $processPath = $null }
+
+      $isMinimized = [Win32]::IsIconic($hWnd)
+      $normalLeft = $null
+      $normalTop = $null
+      $normalRight = $null
+      $normalBottom = $null
+
+      if ($isMinimized) {
+        $placement = New-Object WINDOWPLACEMENT
+        $placement.length = [System.Runtime.InteropServices.Marshal]::SizeOf([WINDOWPLACEMENT])
+        if ([Win32]::GetWindowPlacement($hWnd, [ref]$placement)) {
+          $normalLeft = $placement.rcNormalPosition.Left
+          $normalTop = $placement.rcNormalPosition.Top
+          $normalRight = $placement.rcNormalPosition.Right
+          $normalBottom = $placement.rcNormalPosition.Bottom
+        }
+      }
+
+      $dedupeKey = "$($proc.Id)|$title|$($rect.Left),$($rect.Top),$($rect.Right),$($rect.Bottom)"
+      if ($seen.Add($dedupeKey)) {
+        $items += [pscustomobject]@{
+          ProcessName = $proc.ProcessName
+          Id = $proc.Id
+          MainWindowTitle = $title
+          Path = $processPath
+          IsMinimized = $isMinimized
+          Left = $rect.Left
+          Top = $rect.Top
+          Right = $rect.Right
+          Bottom = $rect.Bottom
+          NormalLeft = $normalLeft
+          NormalTop = $normalTop
+          NormalRight = $normalRight
+          NormalBottom = $normalBottom
+          Width = $width
+          Height = $height
+        }
+      }
+    } catch {}
+    return $true
+  }
+  [void][Win32]::EnumWindows($enumProc, [System.IntPtr]::Zero)
+} catch {}
 $items | ConvertTo-Json -Depth 3`;
 
     execFile(

--- a/src/preload.js
+++ b/src/preload.js
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('electron', {
 
   // Capture running app layout from main process
   captureRunningAppLayout: () => ipcRenderer.invoke('capture-running-app-layout'),
+  getSystemMonitors: () => ipcRenderer.invoke('get-system-monitors'),
 
   // Profile persistence API
   listProfiles: () => ipcRenderer.invoke('profiles:list'),

--- a/src/preload.js
+++ b/src/preload.js
@@ -3,18 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 // Expose safe APIs to the frontend through `window.electron`
 contextBridge.exposeInMainWorld('electron', {
-  // Call this to request a profile load
-  launchProfile: (profileId) => {
-    ipcRenderer.send('launch-profile', profileId);
-  },
-
-  // Subscribe to the loaded profile sent back from the main process
-  onProfileLoaded: (callback) => {
-    ipcRenderer.on('profile-loaded', (_event, profileData) => {
-      // Call the React-side handler with the profile data
-      callback(profileData);
-    });
-  },
+  // Launch profile actions in main process (apps + tabs)
+  launchProfile: (profileId) => ipcRenderer.invoke('launch-profile', profileId),
 
   // Fetch installed apps from main process (returns Promise<{ name, iconPath }[]>)
   getInstalledApps: () => ipcRenderer.invoke('get-installed-apps'),

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -1951,6 +1951,33 @@ export default function App() {
     );
   };
 
+  const updateMonitorPositions = (
+    profileId: string,
+    positions: Array<{ id: string; layoutPosition: { x: number; y: number } }>,
+  ) => {
+    const positionMap = new Map(
+      positions.map((position) => [position.id, position.layoutPosition]),
+    );
+
+    setProfiles((prev) =>
+      prev.map((profile) => {
+        if (profile.id !== profileId) return profile;
+
+        return {
+          ...profile,
+          monitors: profile.monitors.map((monitor) => {
+            const nextPosition = positionMap.get(monitor.id);
+            if (!nextPosition) return monitor;
+            return {
+              ...monitor,
+              layoutPosition: nextPosition,
+            };
+          }),
+        };
+      }),
+    );
+  };
+
   const updateBrowserTabs = (
     profileId: string,
     tabs: any[],
@@ -2772,6 +2799,9 @@ export default function App() {
                       monitorId,
                       layout,
                     )
+                  }
+                  onUpdateMonitorPositions={(positions) =>
+                    updateMonitorPositions(currentProfile.id, positions)
                   }
                   onAddAppToMinimized={(newApp) =>
                     addAppToMinimized(currentProfile.id, newApp)

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -69,12 +69,35 @@ interface SelectedApp {
   data: any;
 }
 
+interface LaunchFeedbackState {
+  status: "idle" | "in-progress" | "success" | "error";
+  message: string;
+}
+
+const toSerializableProfiles = (inputProfiles: FlowProfile[]) => {
+  try {
+    return JSON.parse(JSON.stringify(inputProfiles));
+  } catch {
+    // Last-resort fallback to keep profile saves resilient.
+    return (Array.isArray(inputProfiles) ? inputProfiles : []).map(
+      (profile) => ({ ...profile }),
+    );
+  }
+};
+
 export default function App() {
   const [profiles, setProfiles] = useState<FlowProfile[]>([]);
   const [profilesLoaded, setProfilesLoaded] = useState(false);
   const [selectedProfile, setSelectedProfile] =
     useState<string>("");
   const [isLaunching, setIsLaunching] = useState(false);
+  const [launchFeedback, setLaunchFeedback] =
+    useState<LaunchFeedbackState>({
+      status: "idle",
+      message: "",
+    });
+  const launchFeedbackTimeoutRef = useRef<number | null>(null);
+  const skipNextAutosaveRef = useRef(true);
   const [isEditMode, setIsEditMode] = useState(false);
   const [
     selectedProfileForSettings,
@@ -159,9 +182,21 @@ export default function App() {
     };
   }, []);
 
+  useEffect(() => (
+    () => {
+      if (launchFeedbackTimeoutRef.current) {
+        window.clearTimeout(launchFeedbackTimeoutRef.current);
+      }
+    }
+  ), []);
+
   useEffect(() => {
     if (!profilesLoaded) return;
     if (!window.electron?.saveProfiles) return;
+    if (skipNextAutosaveRef.current) {
+      skipNextAutosaveRef.current = false;
+      return;
+    }
 
     const timer = window.setTimeout(() => {
       void window.electron.saveProfiles(profiles).catch((error) => {
@@ -1211,10 +1246,99 @@ export default function App() {
   };
 
   const handleLaunch = async () => {
+    if (!currentProfile?.id || !window.electron?.launchProfile) return;
+
+    if (launchFeedbackTimeoutRef.current) {
+      window.clearTimeout(launchFeedbackTimeoutRef.current);
+      launchFeedbackTimeoutRef.current = null;
+    }
+
     setIsLaunching(true);
-    setTimeout(() => {
+    setLaunchFeedback({
+      status: "in-progress",
+      message: "Launching profile...",
+    });
+
+    try {
+      if (window.electron?.saveProfiles) {
+        const serializableProfiles = toSerializableProfiles(
+          profiles,
+        );
+        const saveResult = await window.electron.saveProfiles(
+          serializableProfiles,
+        );
+        if (!saveResult?.ok) {
+          setLaunchFeedback({
+            status: "error",
+            message: "Could not save profile changes before launch.",
+          });
+          setIsLaunching(false);
+          launchFeedbackTimeoutRef.current = window.setTimeout(() => {
+            setLaunchFeedback({
+              status: "idle",
+              message: "",
+            });
+            launchFeedbackTimeoutRef.current = null;
+          }, 7000);
+          return;
+        }
+      }
+
+      const launchResult = await window.electron.launchProfile(
+        currentProfile.id,
+      );
+      const launchedApps = Number(launchResult?.launchedAppCount || 0);
+      const launchedTabs = Number(launchResult?.launchedTabCount || 0);
+      const failedCount = Array.isArray(launchResult?.failedApps)
+        ? launchResult.failedApps.length
+        : 0;
+      const skippedCount = Array.isArray(launchResult?.skippedApps)
+        ? launchResult.skippedApps.length
+        : 0;
+
+      if (launchResult?.ok) {
+        const summaryParts = [
+          `${launchedApps} app${launchedApps === 1 ? "" : "s"}`,
+          `${launchedTabs} tab${launchedTabs === 1 ? "" : "s"}`,
+        ];
+        if (failedCount > 0) summaryParts.push(`${failedCount} failed`);
+        if (skippedCount > 0) summaryParts.push(`${skippedCount} skipped`);
+        setLaunchFeedback({
+          status: "success",
+          message: `Launch complete: ${summaryParts.join(", ")}.`,
+        });
+      } else {
+        const errorMessage = launchResult?.error
+          || "Could not launch this profile. Check app executable paths in app details.";
+        setLaunchFeedback({
+          status: "error",
+          message: errorMessage,
+        });
+        console.error(
+          "Profile launch completed with errors:",
+          launchResult?.error || launchResult?.failedApps || [],
+        );
+      }
+    } catch (error) {
+      console.error("Failed to launch profile:", error);
+      const errorMessage =
+        error instanceof Error && error.message
+          ? error.message
+          : "Launch failed unexpectedly. Please try again.";
+      setLaunchFeedback({
+        status: "error",
+        message: errorMessage,
+      });
+    } finally {
       setIsLaunching(false);
-    }, 2000);
+      launchFeedbackTimeoutRef.current = window.setTimeout(() => {
+        setLaunchFeedback({
+          status: "idle",
+          message: "",
+        });
+        launchFeedbackTimeoutRef.current = null;
+      }, 7000);
+    }
   };
 
   const handleDragStart = () => {
@@ -2643,53 +2767,75 @@ export default function App() {
                 </div>
 
                 {/* MOVED: Action buttons with edit/save button first */}
-                <div className="flex items-center gap-3">
-                  <button
-                    onClick={() => setIsEditMode(!isEditMode)}
-                    className={`inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
-                      isEditMode
-                        ? "bg-flow-accent-blue text-flow-text-primary border border-flow-accent-blue hover:bg-flow-accent-blue-hover shadow-md ring-2 ring-flow-accent-blue/30"
-                        : "bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
-                    }`}
-                  >
-                    {isEditMode ? (
-                      <Save className="w-4 h-4" />
-                    ) : (
-                      <Edit className="w-4 h-4" />
-                    )}
-                    {isEditMode
-                      ? "Save Profile"
-                      : "Edit Profile"}
-                  </button>
-                  <button
-                    onClick={() =>
-                      setSelectedProfileForSettings(
-                        currentProfile.id,
-                      )
-                    }
-                    className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
-                    title="Profile Settings"
-                  >
-                    <Settings className="w-4 h-4" />
-                    Settings
-                  </button>
-                  <button
-                    onClick={handleLaunch}
-                    disabled={isLaunching || isEditMode}
-                    className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/80 disabled:opacity-50 shadow-sm"
-                  >
-                    {isLaunching ? (
-                      <>
-                        <div className="w-4 h-4 border-2 border-flow-text-primary/30 border-t-flow-text-primary rounded-full animate-spin" />
-                        Launching...
-                      </>
-                    ) : (
-                      <>
-                        <Play className="w-4 h-4" />
-                        Launch Profile
-                      </>
-                    )}
-                  </button>
+                <div className="flex flex-col items-end gap-2">
+                  <div className="flex items-center gap-3">
+                    <button
+                      onClick={() => setIsEditMode(!isEditMode)}
+                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 ${
+                        isEditMode
+                          ? "bg-flow-accent-blue text-flow-text-primary border border-flow-accent-blue hover:bg-flow-accent-blue-hover shadow-md ring-2 ring-flow-accent-blue/30"
+                          : "bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
+                      }`}
+                    >
+                      {isEditMode ? (
+                        <Save className="w-4 h-4" />
+                      ) : (
+                        <Edit className="w-4 h-4" />
+                      )}
+                      {isEditMode
+                        ? "Save Profile"
+                        : "Edit Profile"}
+                    </button>
+                    <button
+                      onClick={() =>
+                        setSelectedProfileForSettings(
+                          currentProfile.id,
+                        )
+                      }
+                      className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
+                      title="Profile Settings"
+                    >
+                      <Settings className="w-4 h-4" />
+                      Settings
+                    </button>
+                    <button
+                      onClick={handleLaunch}
+                      disabled={isLaunching || isEditMode}
+                      className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/80 disabled:opacity-50 shadow-sm"
+                    >
+                      {isLaunching ? (
+                        <>
+                          <div className="w-4 h-4 border-2 border-flow-text-primary/30 border-t-flow-text-primary rounded-full animate-spin" />
+                          Launching...
+                        </>
+                      ) : (
+                        <>
+                          <Play className="w-4 h-4" />
+                          Launch Profile
+                        </>
+                      )}
+                    </button>
+                  </div>
+                  {launchFeedback.status !== "idle" && (
+                    <div
+                      className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs ${
+                        launchFeedback.status === "success"
+                          ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-300"
+                          : launchFeedback.status === "error"
+                            ? "border-rose-400/40 bg-rose-500/10 text-rose-300"
+                            : "border-flow-border-accent bg-flow-surface-elevated text-flow-text-secondary"
+                      }`}
+                    >
+                      {launchFeedback.status === "success" ? (
+                        <Check className="w-3.5 h-3.5" />
+                      ) : launchFeedback.status === "error" ? (
+                        <X className="w-3.5 h-3.5" />
+                      ) : (
+                        <div className="w-3.5 h-3.5 border border-current border-t-transparent rounded-full animate-spin" />
+                      )}
+                      <span>{launchFeedback.message}</span>
+                    </div>
+                  )}
                 </div>
               </div>
             </header>

--- a/src/renderer/layout/components/CreateProfileModal.tsx
+++ b/src/renderer/layout/components/CreateProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { X, Search, Plus, Scan, Folder, Monitor, Globe, Settings } from "lucide-react";
 import { useInstalledApps } from "../../hooks/useInstalledApps";
 
@@ -34,6 +34,7 @@ type MemoryCapture = {
   monitors: Array<{
     id: string;
     name: string;
+    systemName?: string | null;
     primary: boolean;
     resolution: string;
     orientation: 'landscape' | 'portrait';
@@ -59,6 +60,136 @@ type MemoryCapture = {
   error?: string;
 };
 
+type DetectedMonitor = {
+  id: string;
+  name: string;
+  systemName?: string | null;
+  primary: boolean;
+  resolution: string;
+  orientation: 'landscape' | 'portrait';
+  layoutPosition?: { x: number; y: number };
+};
+
+const LAYOUT_ALIGN_THRESHOLD = 14;
+
+const getMonitorFootprint = (orientation: 'landscape' | 'portrait') => (
+  orientation === 'portrait'
+    ? { width: 22, height: 34 }
+    : { width: 40, height: 24 }
+);
+
+const groupAlignedAxis = (values: number[]) => {
+  if (values.length <= 1) return values;
+  const indexed = values.map((value, index) => ({ index, value })).sort((a, b) => a.value - b.value);
+  const grouped: Array<{ members: Array<{ index: number; value: number }> }> = [];
+
+  indexed.forEach((entry) => {
+    const lastGroup = grouped[grouped.length - 1];
+    if (!lastGroup) {
+      grouped.push({ members: [entry] });
+      return;
+    }
+
+    const lastValue = lastGroup.members[lastGroup.members.length - 1].value;
+    if (Math.abs(entry.value - lastValue) <= LAYOUT_ALIGN_THRESHOLD) {
+      lastGroup.members.push(entry);
+      return;
+    }
+
+    grouped.push({ members: [entry] });
+  });
+
+  const aligned = [...values];
+  grouped.forEach((group) => {
+    const avg = group.members.reduce((sum, item) => sum + item.value, 0) / group.members.length;
+    group.members.forEach((item) => {
+      aligned[item.index] = Math.round(avg * 10) / 10;
+    });
+  });
+  return aligned;
+};
+
+const normalizeMonitorLayout = <
+  T extends { id: string; orientation: 'landscape' | 'portrait'; layoutPosition?: { x: number; y: number } }
+>(inputMonitors: T[]) => {
+  if (inputMonitors.length === 0) return inputMonitors;
+  if (inputMonitors.length === 1) {
+    return inputMonitors.map((monitor) => ({ ...monitor, layoutPosition: { x: 50, y: 50 } }));
+  }
+
+  const raw = inputMonitors.map((monitor, index) => ({
+    id: monitor.id,
+    orientation: monitor.orientation,
+    x: monitor.layoutPosition?.x ?? ((index % 3) * 300),
+    y: monitor.layoutPosition?.y ?? (Math.floor(index / 3) * 220),
+  }));
+  const allPercent = raw.every((item) => item.x >= 0 && item.x <= 100 && item.y >= 0 && item.y <= 100);
+
+  let positions = raw.map((item) => ({ ...item }));
+  if (!allPercent) {
+    const minX = Math.min(...raw.map((item) => item.x));
+    const maxX = Math.max(...raw.map((item) => item.x));
+    const minY = Math.min(...raw.map((item) => item.y));
+    const maxY = Math.max(...raw.map((item) => item.y));
+    const spanX = Math.max(1, maxX - minX);
+    const spanY = Math.max(1, maxY - minY);
+
+    positions = raw.map((item) => ({
+      ...item,
+      x: 50 + ((((item.x - minX) / spanX) * 100 - 50) * 0.65),
+      y: 50 + ((((item.y - minY) / spanY) * 100 - 50) * 0.65),
+    }));
+  }
+
+  const alignedX = groupAlignedAxis(positions.map((item) => item.x));
+  const alignedY = groupAlignedAxis(positions.map((item) => item.y));
+  positions = positions.map((item, index) => ({
+    ...item,
+    x: alignedX[index],
+    y: alignedY[index],
+  }));
+
+  // Keep monitors from overlapping by nudging conflicting cards.
+  const placed: Array<{ id: string; x: number; y: number; width: number; height: number }> = [];
+  positions
+    .sort((a, b) => a.y - b.y || a.x - b.x)
+    .forEach((pos) => {
+      const footprint = getMonitorFootprint(pos.orientation);
+      let x = pos.x;
+      let y = pos.y;
+
+      for (let attempt = 0; attempt < 40; attempt += 1) {
+        const conflicting = placed.find((existing) => (
+          Math.abs(existing.x - x) < ((existing.width + footprint.width) / 2) + 2
+          && Math.abs(existing.y - y) < ((existing.height + footprint.height) / 2) + 2
+        ));
+        if (!conflicting) break;
+
+        x += 8;
+        if (x > 90) {
+          x = 18 + (attempt % 3) * 10;
+          y += 10;
+        }
+      }
+
+      const clampedX = Math.max(10, Math.min(90, x));
+      const clampedY = Math.max(10, Math.min(90, y));
+      placed.push({
+        id: pos.id,
+        x: clampedX,
+        y: clampedY,
+        width: footprint.width,
+        height: footprint.height,
+      });
+    });
+
+  const positionsById = new Map(placed.map((item) => [item.id, { x: item.x, y: item.y }]));
+  return inputMonitors.map((monitor) => ({
+    ...monitor,
+    layoutPosition: positionsById.get(monitor.id) || monitor.layoutPosition || { x: 50, y: 50 },
+  }));
+};
+
 export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateProfileModalProps) {
   const [creationMode, setCreationMode] = useState<'manual' | 'memory'>('manual');
   const [profileName, setProfileName] = useState('');
@@ -70,6 +201,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
   const [memoryCapture, setMemoryCapture] = useState<MemoryCapture | null>(null);
   const [isCapturingMemory, setIsCapturingMemory] = useState(false);
   const [memoryCaptureError, setMemoryCaptureError] = useState<string | null>(null);
+  const [detectedMonitors, setDetectedMonitors] = useState<DetectedMonitor[]>([]);
   const installedApps = useInstalledApps();
   const availableApps = useMemo(() => (
     installedApps.map((app) => {
@@ -100,6 +232,37 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
     const minimizedCount = memoryCapture.minimizedApps?.length || 0;
     return visibleCount + minimizedCount;
   }, [memoryCapture]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (!window.electron?.getSystemMonitors) return;
+
+    let cancelled = false;
+    const loadMonitors = async () => {
+      try {
+        const monitors = await window.electron.getSystemMonitors();
+        if (cancelled) return;
+        if (Array.isArray(monitors) && monitors.length > 0) {
+          setDetectedMonitors(monitors.map((monitor) => ({
+            id: monitor.id,
+            name: monitor.name,
+            systemName: monitor.systemName ?? null,
+            primary: monitor.primary,
+            resolution: monitor.resolution,
+            orientation: monitor.orientation,
+            layoutPosition: monitor.layoutPosition,
+          })));
+        }
+      } catch {
+        // Keep manual profile creation resilient with fallback monitor defaults.
+      }
+    };
+
+    void loadMonitors();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
 
   const captureMemoryLayout = async () => {
     if (!window.electron || typeof window.electron.captureRunningAppLayout !== 'function') {
@@ -132,7 +295,31 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
 
   const createManualProfile = () => {
     if (!profileName.trim()) return;
-    
+
+    const fallbackMonitors: DetectedMonitor[] = [{
+      id: 'monitor-1',
+      name: 'Monitor 1',
+      primary: true,
+      resolution: '1920x1080',
+      orientation: 'landscape',
+      layoutPosition: { x: 0, y: 0 },
+    }];
+    const sourceMonitors = normalizeMonitorLayout((detectedMonitors.length > 0 ? detectedMonitors : fallbackMonitors)
+      .slice()
+      .sort((a, b) => {
+        const ay = a.layoutPosition?.y ?? 0;
+        const by = b.layoutPosition?.y ?? 0;
+        const ax = a.layoutPosition?.x ?? 0;
+        const bx = b.layoutPosition?.x ?? 0;
+        return ay - by || ax - bx || Number(b.primary) - Number(a.primary);
+      }));
+
+    const appsPerMonitor: Array<typeof selectedApps> = sourceMonitors.map(() => []);
+    selectedApps.forEach((app, index) => {
+      const targetMonitorIndex = index % sourceMonitors.length;
+      appsPerMonitor[targetMonitorIndex].push(app);
+    });
+
     const newProfile = {
       id: `profile-${Date.now()}`,
       name: profileName,
@@ -145,14 +332,15 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
       restrictedApps: [],
       estimatedStartupTime: Math.max(3, selectedApps.length * 0.8),
       autoLaunch: false,
-      monitors: [
-        {
-          id: 'monitor-1',
-          name: 'Monitor 1',
-          primary: true,
-          resolution: '2560x1440',
-          orientation: 'landscape' as const,
-          apps: selectedApps.slice(0, Math.ceil(selectedApps.length / 2)).map((app, index) => ({
+      monitors: sourceMonitors.map((monitor, monitorIndex) => ({
+          id: monitor.id,
+          name: monitor.name,
+          systemName: monitor.systemName ?? null,
+          primary: monitor.primary,
+          resolution: monitor.resolution,
+          orientation: monitor.orientation,
+          layoutPosition: monitor.layoutPosition ?? { x: monitorIndex * 100, y: 0 },
+          apps: appsPerMonitor[monitorIndex].map((app, index) => ({
             name: app.name,
             icon: app.icon,
             iconPath: app.iconPath ?? null,
@@ -163,26 +351,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
             volume: app.volume,
             launchBehavior: app.launchBehavior
           }))
-        },
-        {
-          id: 'monitor-2',
-          name: 'Monitor 2',
-          primary: false,
-          resolution: '1920x1080',
-          orientation: 'landscape' as const,
-          apps: selectedApps.slice(Math.ceil(selectedApps.length / 2)).map((app, index) => ({
-            name: app.name,
-            icon: app.icon,
-            iconPath: app.iconPath ?? null,
-            executablePath: app.executablePath ?? null,
-            color: app.color,
-            position: { x: 30 + (index % 2) * 40, y: 30 + Math.floor(index / 2) * 40 },
-            size: { width: 35, height: 30 },
-            volume: app.volume,
-            launchBehavior: app.launchBehavior
-          }))
-        }
-      ],
+        })),
       minimizedApps: [],
       browserTabs: []
     };
@@ -192,13 +361,13 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
 
   const createMemoryProfile = () => {
     if (!profileName.trim() || !memoryCapture) return;
-    const orderedMonitors = [...memoryCapture.monitors].sort((a, b) => {
+    const orderedMonitors = normalizeMonitorLayout([...memoryCapture.monitors].sort((a, b) => {
       const ay = a.layoutPosition?.y ?? 0;
       const by = b.layoutPosition?.y ?? 0;
       const ax = a.layoutPosition?.x ?? 0;
       const bx = b.layoutPosition?.x ?? 0;
       return ay - by || ax - bx;
-    });
+    }));
 
     const newProfile = {
       id: `memory-${Date.now()}`,
@@ -215,9 +384,11 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
       monitors: orderedMonitors.map((monitor) => ({
         id: monitor.id,
         name: monitor.name,
+        systemName: monitor.systemName ?? null,
         primary: monitor.primary,
         resolution: monitor.resolution,
         orientation: monitor.orientation,
+        layoutPosition: monitor.layoutPosition,
         apps: monitor.apps.map((app) => ({
           name: app.name,
           icon: Settings,

--- a/src/renderer/layout/components/MinimizedApps.tsx
+++ b/src/renderer/layout/components/MinimizedApps.tsx
@@ -393,7 +393,7 @@ export function MinimizedApps({
   const totalItems = apps.length + files.length;
 
   return (
-    <div className="w-full space-y-3">
+    <div className="w-full space-y-2">
       {/* Header Section */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -418,13 +418,13 @@ export function MinimizedApps({
       <div 
         className={`relative rounded-lg border transition-all duration-200 ${
           totalItems > 0 
-            ? 'border-flow-border bg-flow-surface/30 p-4' 
-            : 'border-dashed border-flow-border/50 bg-flow-surface/10 p-6'
+            ? 'border-flow-border bg-flow-surface/30 p-3' 
+            : 'border-dashed border-flow-border/50 bg-flow-surface/10 p-4'
         }`}
         data-drop-target="minimized"
       >
         {totalItems > 0 ? (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-4">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-3">
             {/* Render Apps */}
             {apps.map((app, index) => {
               const monitorInfo = getMonitorInfo(app.targetMonitor || 'monitor-1');
@@ -443,7 +443,7 @@ export function MinimizedApps({
                 >
                   {/* App Card */}
                   <div 
-                    className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border transition-all duration-200 ${
+                    className={`relative flex flex-col items-center gap-1.5 p-2 rounded-lg border transition-all duration-200 ${
                       isSelected
                         ? 'border-flow-accent-blue bg-flow-accent-blue/10 ring-1 ring-flow-accent-blue/30'
                         : 'border-flow-border/50 bg-flow-surface/50 hover:bg-flow-surface hover:border-flow-border-accent'
@@ -615,7 +615,7 @@ export function MinimizedApps({
                 >
                   {/* File Card */}
                   <div 
-                    className={`relative flex flex-col items-center gap-2 p-3 rounded-lg border transition-all duration-200 ${
+                    className={`relative flex flex-col items-center gap-1.5 p-2 rounded-lg border transition-all duration-200 ${
                       isSelected
                         ? 'border-flow-accent-blue bg-flow-accent-blue/10 ring-1 ring-flow-accent-blue/30'
                         : 'border-flow-border/50 bg-flow-surface/50 hover:bg-flow-surface hover:border-flow-border-accent'
@@ -705,7 +705,7 @@ export function MinimizedApps({
           </div>
         ) : (
           /* Empty State */
-          <div className="flex flex-col items-center justify-center text-center py-8">
+          <div className="flex flex-col items-center justify-center text-center py-5">
             <div className="w-12 h-12 rounded-lg bg-flow-surface/50 border border-flow-border/50 flex items-center justify-center mb-3">
               <Package className="w-6 h-6 text-flow-text-muted" />
             </div>

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { Monitor, Grid3X3, Zap, ChevronDown } from "lucide-react";
+import { Monitor, Grid3X3, Zap, ChevronDown, GripVertical } from "lucide-react";
 import { AppFileWindow } from "./AppFileWindow";
 import { MinimizedApps } from "./MinimizedApps";
 import { AppSettings } from "./AppSettings";
@@ -67,9 +67,11 @@ interface MonitorLayoutProps {
   monitors: {
     id: string;
     name: string;
+    systemName?: string | null;
     primary: boolean;
     resolution: string;
     orientation?: 'landscape' | 'portrait';
+    layoutPosition?: { x: number; y: number };
     predefinedLayout?: string | null;
     apps: App[];
     files?: any[]; // Legacy support but won't be used
@@ -106,6 +108,7 @@ interface MonitorLayoutProps {
   onFileSelect?: (fileData: any, source: 'monitor' | 'minimized', monitorId?: string, fileIndex?: number) => void; // Legacy
   selectedApp?: any;
   onAutoSnapApps?: (monitorId: string, appUpdates: { appIndex: number; position: { x: number; y: number }; size: { width: number; height: number } }[]) => void;
+  onUpdateMonitorPositions?: (positions: Array<{ id: string; layoutPosition: { x: number; y: number } }>) => void;
 }
 
 // Layout definitions - Horizontal Monitor Layouts
@@ -354,7 +357,8 @@ export function MonitorLayout({
   onAppSelect,
   onFileSelect, // Legacy
   selectedApp,
-  onAutoSnapApps
+  onAutoSnapApps,
+  onUpdateMonitorPositions
 }: MonitorLayoutProps) {
   // Enhanced drag state with persistence
   const [localDragState, setLocalDragState] = useState<{
@@ -389,6 +393,173 @@ export function MonitorLayout({
   const [selectedItemIndex, setSelectedItemIndex] = useState<number>(-1);
   const [selectedMonitorId, setSelectedMonitorId] = useState<string>('');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const monitorPreviewRef = useRef<HTMLDivElement | null>(null);
+  const [previewBounds, setPreviewBounds] = useState({ width: 1, height: 1 });
+  const [monitorPreviewPositions, setMonitorPreviewPositions] = useState<Record<string, { x: number; y: number }>>({});
+  const [draggingMonitor, setDraggingMonitor] = useState<{
+    monitorId: string;
+    startX: number;
+    startY: number;
+    startPos: { x: number; y: number };
+  } | null>(null);
+
+  const getMonitorFootprint = (monitor: { orientation?: 'landscape' | 'portrait' }) => {
+    const isPortrait = monitor.orientation === 'portrait';
+    const widthPx = isPortrait ? (large ? 208 : 160) : (large ? 448 : 320);
+    const cardHeightPx = isPortrait ? (large ? 384 : 288) : (large ? 288 : 208);
+    const headerHeightPx = 64;
+    return { widthPx, heightPx: cardHeightPx + headerHeightPx };
+  };
+
+  const clampPreviewPosition = (
+    monitor: { orientation?: 'landscape' | 'portrait' },
+    position: { x: number; y: number },
+  ) => {
+    if (previewBounds.width <= 10 || previewBounds.height <= 10) {
+      return {
+        x: Math.max(0, Math.min(100, position.x)),
+        y: Math.max(0, Math.min(100, position.y)),
+      };
+    }
+
+    const footprint = getMonitorFootprint(monitor);
+    const halfWidthPct = ((footprint.widthPx / previewBounds.width) * 100) / 2;
+    const halfHeightPct = ((footprint.heightPx / previewBounds.height) * 100) / 2;
+    const sidePadPct = (10 / previewBounds.width) * 100;
+    const topPadPct = (22 / previewBounds.height) * 100;
+    const bottomPadPct = (10 / previewBounds.height) * 100;
+
+    const minX = Math.min(50, Math.max(0, halfWidthPct + sidePadPct));
+    const maxX = Math.max(minX, 100 - halfWidthPct - sidePadPct);
+    const minY = Math.min(50, Math.max(0, halfHeightPct + topPadPct));
+    const maxY = Math.max(minY, 100 - halfHeightPct - bottomPadPct);
+
+    return {
+      x: Math.max(minX, Math.min(maxX, position.x)),
+      y: Math.max(minY, Math.min(maxY, position.y)),
+    };
+  };
+
+  useEffect(() => {
+    const container = monitorPreviewRef.current;
+    if (!container) return;
+
+    const updateBounds = () => {
+      const rect = container.getBoundingClientRect();
+      if (rect.width > 0 && rect.height > 0) {
+        setPreviewBounds({ width: rect.width, height: rect.height });
+      }
+    };
+
+    updateBounds();
+    const observer = new ResizeObserver(updateBounds);
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (monitors.length === 0) {
+      setMonitorPreviewPositions({});
+      return;
+    }
+
+    if (monitors.length === 1) {
+      setMonitorPreviewPositions({ [monitors[0].id]: { x: 50, y: 50 } });
+      return;
+    }
+
+    const rawPositions = monitors.map((monitor, index) => ({
+      id: monitor.id,
+      x: monitor.layoutPosition?.x ?? ((index % 3) * 300),
+      y: monitor.layoutPosition?.y ?? (Math.floor(index / 3) * 220),
+    }));
+
+    const minX = Math.min(...rawPositions.map((p) => p.x));
+    const maxX = Math.max(...rawPositions.map((p) => p.x));
+    const minY = Math.min(...rawPositions.map((p) => p.y));
+    const maxY = Math.max(...rawPositions.map((p) => p.y));
+    const spanX = Math.max(1, maxX - minX);
+    const spanY = Math.max(1, maxY - minY);
+
+    const allPercentCoordinates = rawPositions.every(
+      (pos) => pos.x >= 0 && pos.x <= 100 && pos.y >= 0 && pos.y <= 100,
+    );
+
+    const normalized: Record<string, { x: number; y: number }> = {};
+    rawPositions.forEach((pos) => {
+      if (allPercentCoordinates) {
+        normalized[pos.id] = { x: pos.x, y: pos.y };
+        return;
+      }
+
+      const normalizedX = ((pos.x - minX) / spanX) * 100;
+      const normalizedY = ((pos.y - minY) / spanY) * 100;
+      normalized[pos.id] = {
+        // Keep relative pattern from Windows, compress spacing to fit preview.
+        x: 50 + ((normalizedX - 50) * 0.55),
+        y: 50 + ((normalizedY - 50) * 0.55),
+      };
+    });
+
+    setMonitorPreviewPositions(normalized);
+  }, [monitors]);
+
+  useEffect(() => {
+    if (!draggingMonitor) return;
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const container = monitorPreviewRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+
+      const deltaXPct = ((event.clientX - draggingMonitor.startX) / rect.width) * 100;
+      const deltaYPct = ((event.clientY - draggingMonitor.startY) / rect.height) * 100;
+
+      const monitor = monitors.find((item) => item.id === draggingMonitor.monitorId);
+      if (!monitor) return;
+
+      const nextPosition = {
+        x: draggingMonitor.startPos.x + deltaXPct,
+        y: draggingMonitor.startPos.y + deltaYPct,
+      };
+      const clamped = clampPreviewPosition(monitor, nextPosition);
+
+      setMonitorPreviewPositions((prev) => ({
+        ...prev,
+        [draggingMonitor.monitorId]: clamped,
+      }));
+    };
+
+    const handleMouseUp = () => {
+      setDraggingMonitor(null);
+      if (!onUpdateMonitorPositions) return;
+
+      const positions = monitors.map((monitor) => {
+        const preview = monitorPreviewPositions[monitor.id] || { x: 50, y: 50 };
+        const clamped = clampPreviewPosition(monitor, preview);
+        return {
+          id: monitor.id,
+          layoutPosition: {
+            x: Math.round(clamped.x),
+            y: Math.round(clamped.y),
+          },
+        };
+      });
+      onUpdateMonitorPositions(positions);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [draggingMonitor, monitorPreviewPositions, monitors, onUpdateMonitorPositions, previewBounds]);
 
   // Handle updating associated files for an app
   const handleUpdateAssociatedFiles = (monitorId: string, appIndex: number, files: any[]) => {
@@ -890,50 +1061,99 @@ export function MonitorLayout({
           )}
         </div>
       </div>
-      
+
       {/* Monitor Layout Section - Flex-1 with overflow for scrolling if needed */}
-      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
-        <div className="pb-6">
-          <div className={`flex gap-8 justify-center flex-wrap ${large ? 'gap-12' : ''} min-w-0`}>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <div className="h-full pb-2">
+          <div
+            ref={monitorPreviewRef}
+            className={`relative h-full min-h-[24rem] ${large ? 'min-h-[32rem]' : ''}`}
+          >
             {monitors.map((monitor) => {
               const isPortrait = monitor.orientation === 'portrait';
               // Enhanced sizing with proper flex handling to prevent wrapping
               const baseWidth = isPortrait ? (large ? 'w-52 min-w-52 flex-shrink-0' : 'w-40 min-w-40 flex-shrink-0') : (large ? 'w-[28rem] min-w-[28rem] flex-shrink' : 'w-80 min-w-72 flex-shrink');
               const baseHeight = isPortrait ? (large ? 'h-96' : 'h-72') : (large ? 'h-72' : 'h-52');
               const totalItems = monitor.apps.length; // Only count apps now
+              const preview = monitorPreviewPositions[monitor.id] || { x: 50, y: 50 };
+              const clampedPreview = clampPreviewPosition(monitor, preview);
               
               return (
-                <div key={monitor.id} className="space-y-4">
+                <div
+                  key={monitor.id}
+                  className="space-y-4 absolute"
+                  style={{
+                    left: `${clampedPreview.x}%`,
+                    top: `${clampedPreview.y}%`,
+                    transform: 'translate(-50%, -50%)',
+                    transformOrigin: 'center center',
+                  }}
+                >
                   {/* Monitor header - Improved */}
-                  <div className="text-center">
-                    <div className="flex items-center justify-center gap-2 mb-1">
-                      <span className="text-white text-sm font-medium">{monitor.name}</span>
-                      {isEditMode && onUpdateMonitorLayout && (
-                        <div className="relative">
-                          <MonitorLayoutConfig
-                            monitor={{
-                              id: monitor.id,
-                              name: monitor.name,
-                              orientation: monitor.orientation || 'landscape',
-                              predefinedLayout: monitor.predefinedLayout,
-                              apps: monitor.apps
-                            }}
-                            onLayoutChange={onUpdateMonitorLayout}
-                            isDropdown={true}
-                          />
+                  <div
+                    className={`text-center ${draggingMonitor?.monitorId === monitor.id ? 'opacity-90' : ''}`}
+                    onMouseDown={(event) => {
+                      if (!isEditMode) return;
+                      event.preventDefault();
+                      setDraggingMonitor({
+                        monitorId: monitor.id,
+                        startX: event.clientX,
+                        startY: event.clientY,
+                        startPos: clampedPreview,
+                      });
+                    }}
+                  >
+                    {isEditMode ? (
+                      <div className={`flex flex-wrap items-center justify-center gap-2 mb-1 mx-auto ${baseWidth}`}>
+                        <div className="inline-flex items-center gap-1 text-white text-sm font-medium rounded px-2 py-1 transition-colors cursor-grab active:cursor-grabbing bg-white/5 hover:bg-white/10 whitespace-nowrap">
+                          <GripVertical className="w-3.5 h-3.5 text-white/70" />
+                          <span className="whitespace-nowrap">{monitor.name}</span>
                         </div>
-                      )}
-                      {isEditMode && totalItems > 0 && onAutoSnapApps && (
-                        <button
-                          onClick={() => handleAutoSnap(monitor.id)}
-                          className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-flow-accent-purple text-white hover:bg-flow-accent-purple/80 rounded border border-flow-accent-purple/50 transition-colors shadow-sm"
-                          title="Auto-snap all windows to closest zones"
-                        >
-                          <Zap className="w-3 h-3" />
-                          Auto-Snap
-                        </button>
-                      )}
-                    </div>
+                        {monitor.systemName && (
+                          <span className="text-[11px] text-white/55 whitespace-nowrap">({monitor.systemName})</span>
+                        )}
+                        {onUpdateMonitorLayout && (
+                          <div className="relative shrink-0">
+                            <MonitorLayoutConfig
+                              monitor={{
+                                id: monitor.id,
+                                name: monitor.name,
+                                orientation: monitor.orientation || 'landscape',
+                                predefinedLayout: monitor.predefinedLayout,
+                                apps: monitor.apps
+                              }}
+                              onLayoutChange={onUpdateMonitorLayout}
+                              isDropdown={true}
+                            />
+                          </div>
+                        )}
+                        {totalItems > 0 && onAutoSnapApps && (
+                          <button
+                            onClick={() => handleAutoSnap(monitor.id)}
+                            className="inline-flex items-center gap-1 px-2 py-1 text-xs bg-flow-accent-purple text-white hover:bg-flow-accent-purple/80 rounded border border-flow-accent-purple/50 transition-colors shadow-sm whitespace-nowrap shrink-0"
+                            title="Auto-snap all windows to closest zones"
+                          >
+                            <Zap className="w-3 h-3" />
+                            Auto-Snap
+                          </button>
+                        )}
+                      </div>
+                    ) : (
+                      <div className={`mb-1 mx-auto ${baseWidth}`}>
+                        <div className="flex flex-col items-center justify-center gap-1 text-center">
+                          <div className="inline-flex items-center justify-center whitespace-nowrap rounded-full border border-white/15 bg-white/10 backdrop-blur-md px-3 py-1.5 shadow-[0_6px_20px_rgba(0,0,0,0.35)]">
+                            <span className="text-white text-sm font-semibold leading-none tracking-[0.01em] whitespace-nowrap">
+                              {monitor.name}
+                            </span>
+                          </div>
+                          {monitor.systemName && (
+                            <div className="text-[11px] leading-tight text-white/60 whitespace-nowrap truncate max-w-full">
+                              {monitor.systemName}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
                     <div className="flex items-center justify-center gap-2 text-xs text-white/50">
                       <span>{monitor.resolution}</span>
                       <span>•</span>
@@ -1079,7 +1299,7 @@ export function MonitorLayout({
       
       {/* Fixed Bottom Section: Minimized Apps - Always visible at bottom */}
       <div className="flex-shrink-0">
-        <div className="px-4 py-4">
+        <div className="px-3 py-2">
           <MinimizedApps 
             apps={minimizedApps}
             files={[]} // No more standalone files

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -47,6 +47,14 @@ interface ProfileCardProps {
 export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelete, onExport, onSetOnStartup, disabled = false }: ProfileCardProps) {
   const [showDetails, setShowDetails] = useState(false);
   const [showActions, setShowActions] = useState(false);
+
+  const renderPreviewAppIcon = (app: any) => {
+    const IconComponent = app?.icon;
+    if (typeof IconComponent === "function") {
+      return <IconComponent className="w-2 h-2 text-white" />;
+    }
+    return <Folder className="w-2 h-2 text-white" />;
+  };
   
   const getProfileIcon = () => {
     switch (profile.icon) {
@@ -220,30 +228,30 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
         <div className="absolute top-0 left-full ml-4 w-80 p-4 bg-flow-surface-elevated border border-flow-border rounded-xl shadow-lg z-50">
           <h4 className="text-flow-text-primary font-medium mb-3">Apps &amp; Layout Preview</h4>
           <div className="space-y-3 max-h-64 overflow-y-auto">
-            {profile.monitors.map((monitor, index) => (
-              <div key={index} className="space-y-2">
+            {(Array.isArray(profile.monitors) ? profile.monitors : []).map((monitor, index) => (
+              <div key={monitor?.id || index} className="space-y-2">
                 <div className="flex items-center gap-2 text-flow-text-secondary text-sm">
                   <Monitor className="w-3 h-3" />
-                  <span>{monitor.name}</span>
+                  <span>{monitor?.name || `Monitor ${index + 1}`}</span>
                   {monitor.primary && (
                     <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30">Primary</span>
                   )}
                 </div>
                 <div className="flex flex-wrap gap-1.5 ml-4">
-                  {monitor.apps.slice(0, 6).map((app, appIndex) => (
+                  {(Array.isArray(monitor?.apps) ? monitor.apps : []).slice(0, 6).map((app, appIndex) => (
                     <div key={appIndex} className="flex items-center gap-1.5 px-2 py-1 bg-flow-surface rounded text-xs text-flow-text-muted">
                       <div 
                         className="w-3 h-3 rounded flex items-center justify-center"
-                        style={{ backgroundColor: `${app.color}40` }}
+                        style={{ backgroundColor: `${app?.color || "#64748b"}40` }}
                       >
-                        <app.icon className="w-2 h-2 text-white" />
+                        {renderPreviewAppIcon(app)}
                       </div>
-                      <span>{app.name}</span>
+                      <span>{app?.name || "Unknown app"}</span>
                     </div>
                   ))}
-                  {monitor.apps.length > 6 && (
+                  {(Array.isArray(monitor?.apps) ? monitor.apps.length : 0) > 6 && (
                     <span className="text-xs text-flow-text-muted px-2 py-1">
-                      +{monitor.apps.length - 6} more
+                      +{(Array.isArray(monitor?.apps) ? monitor.apps.length : 0) - 6} more
                     </span>
                   )}
                 </div>
@@ -258,11 +266,11 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
                     <div key={appIndex} className="flex items-center gap-1.5 px-2 py-1 bg-flow-surface rounded text-xs text-flow-text-muted">
                       <div 
                         className="w-3 h-3 rounded flex items-center justify-center"
-                        style={{ backgroundColor: `${app.color}40` }}
+                        style={{ backgroundColor: `${app?.color || "#64748b"}40` }}
                       >
-                        <app.icon className="w-2 h-2 text-white" />
+                        {renderPreviewAppIcon(app)}
                       </div>
-                      <span>{app.name}</span>
+                      <span>{app?.name || "Unknown app"}</span>
                     </div>
                   ))}
                 </div>

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -5,8 +5,23 @@ export {};
 declare global {
   interface Window {
     electron: {
-      launchProfile: (profileId: string) => void;
-      onProfileLoaded: (callback: (profile: Profile) => void) => void;
+      launchProfile: (profileId: string) => Promise<{
+        ok: boolean;
+        error?: string;
+        profile?: Profile;
+        launchedAppCount?: number;
+        launchedTabCount?: number;
+        requestedAppCount?: number;
+        failedApps?: Array<{
+          name: string;
+          path: string;
+          error: string;
+        }>;
+        skippedApps?: Array<{
+          name: string;
+          reason: string;
+        }>;
+      }>;
       getInstalledApps: () => Promise<{ name: string; iconPath: string | null; executablePath?: string | null }[]>;
       captureRunningAppLayout: () => Promise<{
         capturedAt: number;

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -14,6 +14,7 @@ declare global {
         monitors: Array<{
           id: string;
           name: string;
+          systemName?: string | null;
           primary: boolean;
           resolution: string;
           orientation: 'landscape' | 'portrait';
@@ -38,6 +39,17 @@ declare global {
         }>;
         error?: string;
       }>;
+      getSystemMonitors: () => Promise<Array<{
+        id: string;
+        name: string;
+        systemName?: string | null;
+        primary: boolean;
+        scaleFactor: number;
+        resolution: string;
+        orientation: 'landscape' | 'portrait';
+        layoutPosition?: { x: number; y: number };
+        apps: Array<unknown>;
+      }>>;
       listProfiles: () => Promise<any[]>;
       saveProfiles: (profiles: any[]) => Promise<{ ok: boolean; count?: number; error?: string }>;
     };


### PR DESCRIPTION
## Summary
- harden profile launch execution so duplicate windows from the same process are discovered deterministically and moved to their assigned monitors
- improve launch UX and IPC flow by returning structured launch results to the renderer and surfacing in-progress/success/error feedback
- add bounded placement verification/correction and readiness-aware maximize handling to keep duplicate Chromium windows usable while still landing fullscreen on target displays

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [ ] Launch FlowSwitch and run a profile with duplicate Brave windows assigned to different monitors
- [ ] Confirm each duplicate window opens on its assigned monitor and remains interactive
- [ ] Confirm both windows maximize/fullscreen according to profile launch state
- [ ] Smoke test non-browser multi-window app placement (for example File Explorer)

Made with [Cursor](https://cursor.com)