### PR TITLE
fix: minimized apps strip, UI polish, and Apps search styling

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -141,6 +141,7 @@
   
   body {
     @apply bg-flow-bg-primary text-flow-text-primary;
+    color-scheme: dark;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     font-feature-settings: 'cv11', 'ss01';
     font-variation-settings: 'opsz' 32;

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -155,6 +155,62 @@
   h6 { @apply text-xs tracking-tight; font-weight: 600; }
 }
 
+/* Eagle-inspired: region shells, softer chrome, shared rhythm */
+@layer components {
+  .flow-shell-titlebar {
+    @apply border-b border-flow-border/50 bg-flow-bg-secondary/90 backdrop-blur-md;
+  }
+
+  .flow-shell-nav {
+    @apply bg-flow-bg-secondary border-r border-flow-border/50;
+  }
+
+  .flow-shell-canvas {
+    @apply bg-flow-bg-primary;
+  }
+
+  .flow-shell-inspector {
+    @apply bg-flow-bg-secondary border-l border-flow-border/50;
+    box-shadow: -12px 0 40px -16px oklch(0.05 0.02 240 / 0.55);
+  }
+
+  .flow-section-label {
+    @apply text-[11px] font-medium text-flow-text-secondary uppercase tracking-wider;
+  }
+
+  .flow-card-quiet {
+    @apply rounded-xl border border-flow-border/60 bg-flow-surface/90 transition-all duration-150 ease-out;
+  }
+
+  .flow-card-quiet:hover {
+    @apply border-flow-border-accent/40 bg-flow-surface-elevated;
+  }
+
+  .flow-segment-track {
+    @apply flex rounded-lg border border-flow-border/50 bg-flow-surface/70 p-0.5 gap-0.5;
+  }
+
+  .flow-segment-tab {
+    @apply flex-1 rounded-md text-xs font-medium transition-all duration-150 ease-out;
+  }
+
+  .flow-segment-tab-active {
+    @apply bg-flow-surface-elevated text-flow-text-primary shadow-sm ring-1 ring-flow-border-accent/20;
+  }
+
+  .flow-segment-tab-idle {
+    @apply text-flow-text-muted hover:bg-flow-surface hover:text-flow-text-primary;
+  }
+
+  .flow-header-well {
+    @apply rounded-xl border border-flow-border/50 bg-flow-surface/60 shadow-flow-shadow-sm transition-all duration-150 ease-out;
+  }
+
+  .flow-header-well-interactive:hover {
+    @apply border-flow-border-accent/35 bg-flow-surface-elevated;
+  }
+}
+
 @layer utilities {
   /* ENHANCED Monitor Layout System - FIXED for padding clipping */
   

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -155,14 +155,18 @@
   h6 { @apply text-xs tracking-tight; font-weight: 600; }
 }
 
-/* Eagle-inspired: region shells, softer chrome, shared rhythm */
+/* Eagle-inspired: region shells, softer chrome, shared rhythm.
+   Avoid opacity modifiers inside @apply with custom theme colors (PostCSS/Tailwind limitation). */
 @layer components {
   .flow-shell-titlebar {
-    @apply border-b border-flow-border/50 bg-flow-bg-secondary/90 backdrop-blur-md;
+    @apply border-b bg-flow-bg-secondary backdrop-blur-md;
+    border-color: color-mix(in oklch, var(--flow-border) 55%, transparent);
+    background-color: color-mix(in oklch, var(--flow-bg-secondary) 92%, transparent);
   }
 
   .flow-shell-nav {
-    @apply bg-flow-bg-secondary border-r border-flow-border/50;
+    @apply bg-flow-bg-secondary border-r;
+    border-right-color: color-mix(in oklch, var(--flow-border) 55%, transparent);
   }
 
   .flow-shell-canvas {
@@ -170,7 +174,8 @@
   }
 
   .flow-shell-inspector {
-    @apply bg-flow-bg-secondary border-l border-flow-border/50;
+    @apply bg-flow-bg-secondary border-l;
+    border-left-color: color-mix(in oklch, var(--flow-border) 55%, transparent);
     box-shadow: -12px 0 40px -16px oklch(0.05 0.02 240 / 0.55);
   }
 
@@ -179,15 +184,20 @@
   }
 
   .flow-card-quiet {
-    @apply rounded-xl border border-flow-border/60 bg-flow-surface/90 transition-all duration-150 ease-out;
+    @apply rounded-xl transition-all duration-150 ease-out;
+    border: 1px solid color-mix(in oklch, var(--flow-border) 62%, transparent);
+    background-color: color-mix(in oklch, var(--flow-surface) 92%, transparent);
   }
 
   .flow-card-quiet:hover {
-    @apply border-flow-border-accent/40 bg-flow-surface-elevated;
+    @apply bg-flow-surface-elevated;
+    border-color: color-mix(in oklch, var(--flow-border-accent) 42%, transparent);
   }
 
   .flow-segment-track {
-    @apply flex rounded-lg border border-flow-border/50 bg-flow-surface/70 p-0.5 gap-0.5;
+    @apply flex rounded-lg p-0.5 gap-0.5;
+    border: 1px solid color-mix(in oklch, var(--flow-border) 55%, transparent);
+    background-color: color-mix(in oklch, var(--flow-surface) 72%, transparent);
   }
 
   .flow-segment-tab {
@@ -195,7 +205,10 @@
   }
 
   .flow-segment-tab-active {
-    @apply bg-flow-surface-elevated text-flow-text-primary shadow-sm ring-1 ring-flow-border-accent/20;
+    @apply bg-flow-surface-elevated text-flow-text-primary shadow-sm;
+    box-shadow:
+      0 1px 2px 0 rgb(0 0 0 / 0.06),
+      0 0 0 1px color-mix(in oklch, var(--flow-border-accent) 22%, transparent);
   }
 
   .flow-segment-tab-idle {
@@ -203,11 +216,14 @@
   }
 
   .flow-header-well {
-    @apply rounded-xl border border-flow-border/50 bg-flow-surface/60 shadow-flow-shadow-sm transition-all duration-150 ease-out;
+    @apply rounded-xl shadow-flow-shadow-sm transition-all duration-150 ease-out;
+    border: 1px solid color-mix(in oklch, var(--flow-border) 55%, transparent);
+    background-color: color-mix(in oklch, var(--flow-surface) 62%, transparent);
   }
 
   .flow-header-well-interactive:hover {
-    @apply border-flow-border-accent/35 bg-flow-surface-elevated;
+    @apply bg-flow-surface-elevated;
+    border-color: color-mix(in oklch, var(--flow-border-accent) 38%, transparent);
   }
 }
 

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -271,6 +271,11 @@ export default function App() {
   }, [showProfileDropdown]);
 
   // SELECTED APP HANDLERS
+  const handleClearAppSelection = useCallback(() => {
+    setSelectedApp(null);
+    setRightSidebarOpen(false);
+  }, []);
+
   const handleAppSelect = useCallback(
     (
       appData: any,
@@ -3060,6 +3065,7 @@ export default function App() {
                   onMoveMinimizedFileToMonitor={() => {}} // REMOVED: No standalone minimized file to monitor moves
                   onCustomDragStart={handleCustomDragStart}
                   onAppSelect={handleAppSelect}
+                  onClearAppSelection={handleClearAppSelection}
                   onFileSelect={() => {}} // REMOVED: No standalone file selection
                   onAutoSnapApps={handleAutoSnapApps}
                   large={!rightSidebarOpen}

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -251,9 +251,6 @@ export default function App() {
         dropdownRef.current &&
         !dropdownRef.current.contains(event.target as Node)
       ) {
-        console.log(
-          "📱 DOCUMENT CLICK OUTSIDE DROPDOWN - Closing",
-        );
         setShowProfileDropdown(false);
       }
     };
@@ -2401,8 +2398,8 @@ export default function App() {
   };
 
   return (
-    <div className="h-screen overflow-hidden bg-flow-bg-primary">
-      <div className="app-drag-region h-9 px-3 border-b border-flow-border bg-flow-bg-secondary/95 flex items-center justify-between select-none">
+    <div className="h-screen overflow-hidden flow-shell-canvas">
+      <div className="app-drag-region h-9 px-3 flow-shell-titlebar flex items-center justify-between select-none">
         <div className="flex items-center gap-2">
           <img
             src="/flowswitch-logo.png"
@@ -2410,22 +2407,22 @@ export default function App() {
             className="h-8 w-8 rounded-md object-contain"
           />
         </div>
-        <span className="text-[11px] text-flow-text-muted">
-          Workspace Automation
+        <span className="text-[11px] text-flow-text-muted tracking-wide">
+          Workspace automation
         </span>
       </div>
       <div className="flex h-[calc(100vh-2.25rem)]">
         {/* Left Sidebar - FIXED: Better height management */}
-        <div className="w-[clamp(16rem,24vw,24rem)] min-w-[16rem] bg-flow-bg-secondary border-r border-flow-border flex flex-col">
+        <div className="w-[clamp(16rem,24vw,24rem)] min-w-[16rem] flow-shell-nav flex flex-col">
           {/* Header - Fixed height */}
-          <div className="flex-shrink-0 p-4 border-b border-flow-border">
+          <div className="flex-shrink-0 p-4 border-b border-flow-border/50">
             <div className="flex items-center justify-between mb-3">
               <div>
-                <h1 className="text-lg text-flow-text-primary font-semibold">
+                <h1 className="text-base text-flow-text-primary font-semibold tracking-tight">
                   FlowSwitch
                 </h1>
-                <p className="text-xs text-flow-text-muted">
-                  Workspace Automation
+                <p className="text-[11px] text-flow-text-muted mt-0.5">
+                  Profiles, apps, layouts
                 </p>
               </div>
               <div className="flex items-center gap-1.5">
@@ -2438,7 +2435,7 @@ export default function App() {
                 />
                 <label
                   htmlFor="import-profile"
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-colors cursor-pointer"
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out cursor-pointer"
                   title="Import Profile"
                   aria-label="Import profile"
                 >
@@ -2449,15 +2446,15 @@ export default function App() {
                     currentProfile &&
                     exportProfile(currentProfile.id)
                   }
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-colors"
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out"
                   title="Export Current Profile"
                   aria-label="Export current profile"
                 >
                   <Download className="w-3.5 h-3.5" />
                 </button>
-                <span className="h-4 w-px bg-flow-border/70 mx-0.5" aria-hidden="true" />
+                <span className="h-4 w-px bg-flow-border/40 mx-0.5" aria-hidden="true" />
                 <button
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-colors"
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out"
                   title="Open settings"
                   aria-label="Open settings"
                 >
@@ -2467,37 +2464,46 @@ export default function App() {
             </div>
 
             {/* View Toggle - Compact */}
-            <div className="flex bg-flow-surface border border-flow-border rounded-lg p-0.5">
+            <div className="flow-segment-track" role="tablist" aria-label="Sidebar view">
               <button
+                type="button"
+                role="tab"
+                aria-selected={currentView === "profiles"}
                 onClick={() => setCurrentView("profiles")}
-                className={`flex-1 px-2 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${
+                className={`flow-segment-tab px-2 py-1.5 ${
                   currentView === "profiles"
-                    ? "bg-flow-accent-blue/25 text-flow-accent-blue border border-flow-accent-blue/40 shadow-sm"
-                    : "text-flow-text-muted hover:bg-flow-surface hover:text-flow-text-primary"
+                    ? "flow-segment-tab-active"
+                    : "flow-segment-tab-idle"
                 }`}
               >
                 Profiles
               </button>
               <button
+                type="button"
+                role="tab"
+                aria-selected={currentView === "apps"}
                 onClick={() => setCurrentView("apps")}
-                className={`flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${
+                className={`flow-segment-tab flex items-center justify-center gap-1 px-2 py-1.5 ${
                   currentView === "apps"
-                    ? "bg-flow-accent-blue/25 text-flow-accent-blue border border-flow-accent-blue/40 shadow-sm"
-                    : "text-flow-text-muted hover:bg-flow-surface hover:text-flow-text-primary"
+                    ? "flow-segment-tab-active"
+                    : "flow-segment-tab-idle"
                 }`}
               >
-                <LayoutGrid className="w-3 h-3" />
+                <LayoutGrid className="w-3 h-3 shrink-0" />
                 Apps
               </button>
               <button
+                type="button"
+                role="tab"
+                aria-selected={currentView === "content"}
                 onClick={() => setCurrentView("content")}
-                className={`flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-md text-xs font-medium transition-all duration-200 ${
+                className={`flow-segment-tab flex items-center justify-center gap-1 px-2 py-1.5 ${
                   currentView === "content"
-                    ? "bg-flow-accent-blue/25 text-flow-accent-blue border border-flow-accent-blue/40 shadow-sm"
-                    : "text-flow-text-muted hover:bg-flow-surface hover:text-flow-text-primary"
+                    ? "flow-segment-tab-active"
+                    : "flow-segment-tab-idle"
                 }`}
               >
-                <Link className="w-3 h-3" />
+                <Link className="w-3 h-3 shrink-0" />
                 Content
               </button>
             </div>
@@ -2507,15 +2513,15 @@ export default function App() {
           <div className="flex-1 min-h-0 flex flex-col">
             {currentView === "profiles" && (
               <div className="flex-1 flex flex-col min-h-0">
-                <div className="flex-shrink-0 p-3 border-b border-flow-border">
+                <div className="flex-shrink-0 p-3 border-b border-flow-border/50">
                   <div className="flex items-center justify-between">
-                    <h2 className="text-xs font-medium text-flow-text-secondary uppercase tracking-wide">
+                    <h2 className="flow-section-label">
                       Profiles
                     </h2>
                     <button
                       onClick={() => setShowCreateProfile(true)}
                       disabled={isEditMode}
-                      className={`inline-flex items-center gap-1 px-2 py-1 text-xs rounded-lg transition-colors ${
+                      className={`inline-flex items-center gap-1 px-2 py-1 text-xs rounded-lg transition-all duration-150 ease-out ${
                         isEditMode
                           ? "text-flow-text-muted cursor-not-allowed opacity-50"
                           : "text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
@@ -2532,9 +2538,9 @@ export default function App() {
                   </div>
 
                   {isEditMode && (
-                    <div className="mt-3 p-2 bg-flow-accent-blue/10 border border-flow-accent-blue/30 rounded-lg">
-                      <div className="flex items-center gap-2 text-xs text-flow-accent-blue">
-                        <Edit className="w-3 h-3" />
+                    <div className="mt-3 p-2.5 rounded-lg border border-flow-border/60 bg-flow-surface/80">
+                      <div className="flex items-center gap-2 text-xs text-flow-text-secondary">
+                        <Edit className="w-3 h-3 text-flow-accent-blue shrink-0" />
                         <span>
                           Profile switching disabled while
                           editing
@@ -2545,7 +2551,7 @@ export default function App() {
                 </div>
 
                 <div className="flex-1 overflow-y-auto scrollbar-elegant p-3">
-                  <div className="space-y-2">
+                  <div className="space-y-2.5">
                     {profiles.map((profile) => (
                       <ProfileCard
                         key={profile.id}
@@ -2632,13 +2638,13 @@ export default function App() {
 
         {/* Main Content Area with Header and Right Sidebar */}
         <div
-          className={`flex-1 flex flex-col transition-all duration-300 ease-in-out ${
+          className={`flex-1 flex flex-col transition-[margin] duration-200 ease-out ${
             rightSidebarOpen ? "mr-[clamp(18rem,24vw,24rem)]" : "mr-0"
           }`}
         >
           {/* Header - Spans across Main Content and Right Sidebar area */}
           {currentProfile ? (
-            <header className="px-4 md:px-6 xl:px-8 py-2 md:py-3 border-b border-flow-border bg-flow-bg-secondary relative z-10">
+            <header className="px-4 md:px-6 xl:px-8 py-2.5 md:py-3 border-b border-flow-border/50 bg-flow-bg-secondary/80 backdrop-blur-sm relative z-10">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-4">
                   {/* Profile Switcher - Now without settings button */}
@@ -2646,15 +2652,15 @@ export default function App() {
                     <button
                       onClick={handleDropdownToggle}
                       disabled={isEditMode}
-                      className={`flex items-center gap-2 md:gap-3 p-2 md:p-2.5 rounded-lg border transition-all duration-200 max-w-[52vw] ${
+                      className={`flow-header-well flex items-center gap-2 md:gap-3 p-2 md:p-2.5 max-w-[52vw] ${
                         isEditMode
-                          ? "bg-flow-surface border-flow-border text-flow-text-muted cursor-not-allowed opacity-50"
-                          : "bg-flow-surface border-flow-border hover:bg-flow-surface-elevated hover:border-flow-border-accent text-flow-text-primary cursor-pointer"
+                          ? "opacity-50 cursor-not-allowed text-flow-text-muted"
+                          : "flow-header-well-interactive text-flow-text-primary cursor-pointer"
                       }`}
                     >
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-1">
-                          <h2 className="text-lg md:text-xl text-flow-text-primary font-semibold truncate max-w-[22rem]">
+                          <h2 className="text-base md:text-lg text-flow-text-primary font-semibold tracking-tight truncate max-w-[22rem]">
                             {currentProfile.name}
                           </h2>
                           {currentProfile.autoLaunchOnBoot && (
@@ -2705,7 +2711,7 @@ export default function App() {
                       </div>
                       {!isEditMode && (
                         <ChevronDown
-                          className={`w-4 h-4 text-flow-text-muted transition-transform duration-200 ${
+                          className={`w-4 h-4 text-flow-text-muted transition-transform duration-150 ease-out ${
                             showProfileDropdown
                               ? "rotate-180"
                               : ""
@@ -2717,7 +2723,7 @@ export default function App() {
                     {/* Profile Dropdown */}
                     {showProfileDropdown && !isEditMode && (
                       <div
-                        className="absolute top-full left-0 mt-2 w-full min-w-[20rem] bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-[60]"
+                        className="absolute top-full left-0 mt-2 w-full min-w-[20rem] bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg overflow-hidden z-[60]"
                         style={{ pointerEvents: "auto" }}
                       >
                         <div className="max-h-80 overflow-y-auto scrollbar-elegant">
@@ -2725,17 +2731,13 @@ export default function App() {
                             <button
                               key={profile.id}
                               onClick={() => {
-                                console.log(
-                                  "🔄 PROFILE CLICKED:",
-                                  profile.name,
-                                );
                                 handleProfileSwitch(profile.id);
                               }}
-                              className="w-full flex items-center gap-3 p-4 text-left hover:bg-flow-border/30 transition-colors"
+                              className="w-full flex items-center gap-3 p-3.5 text-left hover:bg-flow-surface/80 transition-colors duration-150 border-b border-flow-border/30 last:border-b-0"
                             >
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-2 mb-1">
-                                  <h3 className="font-semibold text-flow-text-primary">
+                                  <h3 className="text-sm font-semibold text-flow-text-primary tracking-tight">
                                     {profile.name}
                                   </h3>
                                   {profile.id ===
@@ -2799,10 +2801,10 @@ export default function App() {
                   <div className="flex items-center gap-2 md:gap-3 flex-wrap justify-end">
                     <button
                       onClick={() => setIsEditMode(!isEditMode)}
-                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-200 ${
+                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out ${
                         isEditMode
-                          ? "bg-flow-accent-blue text-flow-text-primary border border-flow-accent-blue hover:bg-flow-accent-blue-hover shadow-md ring-2 ring-flow-accent-blue/30"
-                          : "bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
+                          ? "bg-flow-accent-blue text-flow-text-primary border border-flow-accent-blue/80 hover:bg-flow-accent-blue-hover shadow-md ring-1 ring-flow-accent-blue/25"
+                          : "bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50"
                       }`}
                     >
                       {isEditMode ? (
@@ -2820,7 +2822,7 @@ export default function App() {
                           currentProfile.id,
                         )
                       }
-                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-200 bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent"
+                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50"
                       title="Profile Settings"
                     >
                       <Settings className="w-4 h-4" />
@@ -2829,7 +2831,7 @@ export default function App() {
                     <button
                       onClick={handleLaunch}
                       disabled={isLaunching || isEditMode}
-                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/80 disabled:opacity-50 shadow-sm"
+                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/90 disabled:opacity-50 shadow-sm"
                     >
                       {isLaunching ? (
                         <>
@@ -2868,13 +2870,16 @@ export default function App() {
               </div>
             </header>
           ) : (
-            <header className="px-4 md:px-6 xl:px-8 py-2 md:py-3 border-b border-flow-border bg-flow-bg-secondary relative z-10">
+            <header className="px-4 md:px-6 xl:px-8 py-2.5 md:py-3 border-b border-flow-border/50 bg-flow-bg-secondary/80 backdrop-blur-sm relative z-10">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-4">
-                  <div className="flex items-center gap-3 p-2.5 rounded-lg border bg-flow-surface border-flow-border text-flow-text-muted">
-                    <h2 className="text-xl font-semibold text-flow-text-secondary">
+                  <div className="flow-header-well flex flex-col gap-1 p-3 max-w-md">
+                    <h2 className="text-sm font-semibold text-flow-text-primary tracking-tight">
                       No profile selected
                     </h2>
+                    <p className="text-xs text-flow-text-muted leading-relaxed">
+                      Create a profile from the sidebar to capture layouts and launch your workspace.
+                    </p>
                   </div>
                 </div>
 
@@ -2908,8 +2913,8 @@ export default function App() {
 
           {/* Main Content Area */}
           {currentProfile && (
-            <main className="flex-1 overflow-hidden relative">
-              <div className="h-full px-4 md:px-6 xl:px-8 py-3 md:py-5">
+            <main className="flex-1 overflow-hidden relative flow-shell-canvas">
+              <div className="h-full px-4 md:px-6 xl:px-8 py-4 md:py-6">
                 <MonitorLayout
                   monitors={currentProfile.monitors}
                   minimizedApps={currentProfile.minimizedApps}
@@ -3067,17 +3072,18 @@ export default function App() {
         {/* Right Sidebar - Fixed position, animated visibility */}
         {rightSidebarOpen && (
           <div
-            className={`fixed right-0 top-0 w-[clamp(18rem,24vw,24rem)] h-full bg-flow-bg-secondary border-l border-flow-border flex flex-col z-30 transform transition-transform duration-300 ease-in-out ${
+            className={`fixed right-0 top-9 w-[clamp(18rem,24vw,24rem)] h-[calc(100vh-2.25rem)] flow-shell-inspector flex flex-col z-30 transform transition-transform duration-200 ease-out ${
               rightSidebarOpen
                 ? "translate-x-0"
                 : "translate-x-full"
             }`}
           >
             {/* Sidebar Header - Close button only */}
-            <div className="absolute top-4 right-4 z-10">
+            <div className="absolute top-3 right-3 z-10">
               <button
+                type="button"
                 onClick={handleCloseSidebar}
-                className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-colors"
+                className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -3116,10 +3122,11 @@ export default function App() {
         {/* Right Sidebar Toggle Button (when closed) */}
         {!rightSidebarOpen && selectedApp && (
           <button
+            type="button"
             onClick={() => setRightSidebarOpen(true)}
-            className="fixed right-0 bg-flow-surface border border-flow-border border-r-0 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary rounded-l-lg transition-all duration-200 p-2 z-20 shadow-lg"
+            className="fixed right-0 bg-flow-surface/95 border border-flow-border/60 border-r-0 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary rounded-l-lg transition-all duration-150 ease-out p-2 z-20 shadow-flow-shadow-md backdrop-blur-sm"
             style={{
-              top: "50%",
+              top: "calc(2.25rem + (100vh - 2.25rem) / 2)",
               transform: "translateY(-50%)",
             }}
             title="Open App Details"

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -225,8 +225,8 @@ export function AppManager({
         {/* Header - CLEAN: Consistent with UI */}
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-2">
-            <Settings className="w-4 h-4 text-flow-text-muted" />
-            <h2 className="text-xs font-medium text-flow-text-secondary uppercase tracking-wide">Apps</h2>
+            <Settings className="w-3.5 h-3.5 text-flow-text-muted" />
+            <h2 className="text-[11px] font-medium text-flow-text-secondary uppercase tracking-wider">Apps</h2>
           </div>
           <span className="text-flow-text-muted text-xs">{filteredApps.length} available</span>
         </div>
@@ -242,7 +242,7 @@ export function AppManager({
               placeholder="Search apps..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 pr-3 py-2 bg-flow-surface border border-flow-border rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
+              className="w-full pl-9 pr-3 py-2 bg-flow-surface/90 border border-flow-border/60 rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
             />
           </div>
 
@@ -251,7 +251,7 @@ export function AppManager({
             <select
               value={selectedCategory || ''}
               onChange={(e) => setSelectedCategory(e.target.value || null)}
-              className="flex-1 px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
+              className="flex-1 px-2 py-1.5 bg-flow-surface/90 border border-flow-border/60 rounded-md text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
               title="Filter by category"
             >
               <option value="">All</option>
@@ -262,7 +262,7 @@ export function AppManager({
             <select
               value={sortOption}
               onChange={e => setSortOption(e.target.value as 'name' | 'lastAccessed' | 'size')}
-              className="px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
+              className="px-2 py-1.5 bg-flow-surface/90 border border-flow-border/60 rounded-md text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
               title="Sort apps"
             >
               <option value="name">A-Z</option>
@@ -271,8 +271,8 @@ export function AppManager({
             </select>
             <button
               onClick={() => setExpandedApp(expandedApp ? null : 'toggle-all')}
-              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded transition-colors ${
-                expandedApp ? 'bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30' : 'bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent'
+              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded-md transition-all duration-150 ease-out ${
+                expandedApp ? 'bg-flow-surface-elevated text-flow-accent-blue ring-1 ring-flow-accent-blue/25 border border-flow-border/50' : 'bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/40'
               }`}
               title="Show app details"
             >
@@ -283,10 +283,10 @@ export function AppManager({
         </div>
 
         {/* Drag Instructions - Compact */}
-        <div className="bg-flow-accent-blue/10 border border-flow-accent-blue/30 rounded-lg p-3 mb-4">
-          <div className="flex items-center gap-2 text-xs text-flow-accent-blue">
-            <Move className="w-3 h-3" />
-            <span>Drag apps to monitors or minimized section</span>
+        <div className="rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3 mb-4">
+          <div className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
+            <Move className="w-3.5 h-3.5 text-flow-accent-blue shrink-0" />
+            <span>Drag apps onto a monitor or into the minimized row.</span>
           </div>
         </div>
 
@@ -299,11 +299,11 @@ export function AppManager({
             return (
               <div 
                 key={index} 
-                className="bg-flow-surface border border-flow-border rounded-lg transition-all duration-200 hover:border-flow-border-accent"
+                className="flow-card-quiet rounded-lg"
               >
                 <div className="flex items-center gap-3 p-3">
                   <div 
-                    className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 cursor-grab active:cursor-grabbing transition-transform hover:scale-105 select-none relative"
+                    className="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 cursor-grab active:cursor-grabbing transition-transform duration-150 ease-out hover:scale-[1.03] select-none relative"
                     style={{ backgroundColor: `${app.color ?? '#888'}20` }}
                     onMouseDown={(e) => handleMouseDown(e, app)}
                     title="Drag to add to monitor or minimized apps"

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -242,7 +242,7 @@ export function AppManager({
               placeholder="Search apps..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 pr-3 py-2 bg-flow-surface/90 border border-flow-border/60 rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
+              className="w-full pl-9 pr-3 py-2 bg-flow-surface border border-flow-border rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
             />
           </div>
 
@@ -251,7 +251,7 @@ export function AppManager({
             <select
               value={selectedCategory || ''}
               onChange={(e) => setSelectedCategory(e.target.value || null)}
-              className="flex-1 px-2 py-1.5 bg-flow-surface/90 border border-flow-border/60 rounded-md text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
+              className="flex-1 px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
               title="Filter by category"
             >
               <option value="">All</option>
@@ -262,7 +262,7 @@ export function AppManager({
             <select
               value={sortOption}
               onChange={e => setSortOption(e.target.value as 'name' | 'lastAccessed' | 'size')}
-              className="px-2 py-1.5 bg-flow-surface/90 border border-flow-border/60 rounded-md text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/40 focus:border-flow-border-accent/40 transition-all duration-150 ease-out"
+              className="px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
               title="Sort apps"
             >
               <option value="name">A-Z</option>
@@ -271,8 +271,10 @@ export function AppManager({
             </select>
             <button
               onClick={() => setExpandedApp(expandedApp ? null : 'toggle-all')}
-              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded-md transition-all duration-150 ease-out ${
-                expandedApp ? 'bg-flow-surface-elevated text-flow-accent-blue ring-1 ring-flow-accent-blue/25 border border-flow-border/50' : 'bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/40'
+              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded transition-colors ${
+                expandedApp
+                  ? 'bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30'
+                  : 'bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent'
               }`}
               title="Show app details"
             >

--- a/src/renderer/layout/components/MinimizedApps.tsx
+++ b/src/renderer/layout/components/MinimizedApps.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { safeIconSrc } from "../../utils/safeIconSrc";
 import { Minimize2, Settings, Trash2, Monitor, ArrowRight, Globe, ExternalLink, Maximize2, File, Package, FolderClosed, MoreHorizontal } from "lucide-react";
 import { LucideIcon } from "lucide-react";
@@ -71,6 +72,8 @@ export function MinimizedApps({
   compact = false,
 }: MinimizedAppsProps) {
   const [hoveredApp, setHoveredApp] = useState<number | string | null>(null);
+  /** Fixed-position popovers use viewport coords so they are not clipped by overflow ancestors. */
+  const [tooltipAnchor, setTooltipAnchor] = useState<{ x: number; y: number } | null>(null);
   
   // Timer and state for click vs drag detection
   const dragTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -404,7 +407,100 @@ export function MinimizedApps({
   const visibleApps = apps.slice(0, maxVisibleApps);
   const hiddenAppsCount = Math.max(0, apps.length - visibleApps.length);
 
+  const clearHover = () => {
+    setHoveredApp(null);
+    setTooltipAnchor(null);
+  };
+
+  const hoveredAppData =
+    typeof hoveredApp === "number" ? visibleApps[hoveredApp] : null;
+  const hoveredFileData =
+    typeof hoveredApp === "string" && hoveredApp.startsWith("file-")
+      ? files[parseInt(hoveredApp.replace("file-", ""), 10)]
+      : null;
+
+  const renderHoverPortal = () => {
+    if (!tooltipAnchor || hoveredApp === null) return null;
+
+    if (hoveredAppData) {
+      const app = hoveredAppData;
+      const monitorInfo = getMonitorInfo(app.targetMonitor || "monitor-1");
+      const isBrowser =
+        app.name.toLowerCase().includes("chrome") ||
+        app.name.toLowerCase().includes("browser");
+
+      return (
+        <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48 max-w-xs">
+          <div className="text-sm font-medium text-flow-text-primary mb-1">{app.name}</div>
+          <div className="text-xs text-flow-text-muted mb-2">
+            Target: {monitorInfo.name}
+            {monitorInfo.primary && (
+              <span className="ml-1 text-flow-accent-blue">(Primary)</span>
+            )}
+          </div>
+          {isBrowser && app.browserTabs && app.browserTabs.length > 0 && (
+            <div className="border-t border-flow-border pt-2">
+              <div className="text-xs text-flow-text-muted mb-1 font-medium">
+                Browser Tabs ({app.browserTabs.length})
+              </div>
+              <div className="space-y-1 max-h-24 overflow-y-auto scrollbar-elegant">
+                {app.browserTabs.slice(0, 3).map((tab, tabIndex) => (
+                  <div
+                    key={tabIndex}
+                    className={`flex items-center gap-2 px-2 py-1 rounded text-xs ${
+                      tab.isActive
+                        ? "bg-flow-accent-blue/20 text-flow-accent-blue"
+                        : "text-flow-text-muted"
+                    }`}
+                  >
+                    <Globe className="w-3 h-3 flex-shrink-0" />
+                    <span className="truncate flex-1">{tab.name}</span>
+                    {tab.isActive && (
+                      <div className="w-1.5 h-1.5 bg-flow-accent-blue rounded-full flex-shrink-0" />
+                    )}
+                  </div>
+                ))}
+                {app.browserTabs.length > 3 && (
+                  <div className="text-xs text-flow-text-muted text-center py-1">
+                    +{app.browserTabs.length - 3} more tabs
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    if (hoveredFileData) {
+      const file = hoveredFileData;
+      const monitorInfo = getMonitorInfo(file.targetMonitor || "monitor-1");
+      return (
+        <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48 max-w-xs">
+          <div className="text-sm font-medium text-flow-text-primary mb-1">{file.name}</div>
+          <div className="text-xs text-flow-text-muted mb-1">
+            Type: {file.type.toUpperCase()}
+          </div>
+          <div className="text-xs text-flow-text-muted mb-1">
+            Opens with: {file.associatedApp}
+          </div>
+          <div className="text-xs text-flow-text-muted">
+            Target: {monitorInfo.name}
+            {monitorInfo.primary && (
+              <span className="ml-1 text-flow-accent-blue">(Primary)</span>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  const hoverTipEl = tooltipAnchor ? renderHoverPortal() : null;
+
   return (
+    <>
     <div className={`w-full ${compact ? 'space-y-1' : 'space-y-1.5'}`}>
       {/* Header Section */}
       <div className="flex items-center justify-between">
@@ -442,7 +538,6 @@ export function MinimizedApps({
             {/* Render Apps — fixed-width tiles so a single app never stretches to full row width */}
             {visibleApps.map((app, index) => {
               const monitorInfo = getMonitorInfo(app.targetMonitor || 'monitor-1');
-              const isBrowser = app.name.toLowerCase().includes('chrome') || app.name.toLowerCase().includes('browser');
               const isSelected = selectedApp && 
                 selectedApp.source === 'minimized' &&
                 selectedApp.appIndex === index &&
@@ -452,8 +547,15 @@ export function MinimizedApps({
                 <div
                   key={`app-${index}`}
                   className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
-                  onMouseEnter={() => setHoveredApp(index)}
-                  onMouseLeave={() => setHoveredApp(null)}
+                  onMouseEnter={(e) => {
+                    setHoveredApp(index);
+                    const r = e.currentTarget.getBoundingClientRect();
+                    setTooltipAnchor({
+                      x: r.left + r.width / 2,
+                      y: r.top,
+                    });
+                  }}
+                  onMouseLeave={clearHover}
                 >
                   {/* App Card */}
                   <div 
@@ -466,7 +568,6 @@ export function MinimizedApps({
                       cursor: isEditMode ? 'grab' : 'pointer',
                     }}
                     onMouseDown={(e) => handleMouseDown(e, app, index)}
-                    title={isEditMode ? "Drag to move to monitor" : "Click to view details"}
                   >
                     {/* App Icon Container */}
                     <div 
@@ -560,53 +661,6 @@ export function MinimizedApps({
                       </div>
                     )}
                   </div>
-
-                  {/* Enhanced Tooltip */}
-                  {hoveredApp === index && (
-                    <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50">
-                      <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48">
-                        <div className="text-sm font-medium text-flow-text-primary mb-1">{app.name}</div>
-                        <div className="text-xs text-flow-text-muted mb-2">
-                          Target: {monitorInfo.name}
-                          {monitorInfo.primary && (
-                            <span className="ml-1 text-flow-accent-blue">(Primary)</span>
-                          )}
-                        </div>
-                        
-                        {/* Browser Tabs */}
-                        {isBrowser && app.browserTabs && app.browserTabs.length > 0 && (
-                          <div className="border-t border-flow-border pt-2">
-                            <div className="text-xs text-flow-text-muted mb-1 font-medium">
-                              Browser Tabs ({app.browserTabs.length})
-                            </div>
-                            <div className="space-y-1 max-h-24 overflow-y-auto scrollbar-elegant">
-                              {app.browserTabs.slice(0, 3).map((tab, tabIndex) => (
-                                <div
-                                  key={tabIndex}
-                                  className={`flex items-center gap-2 px-2 py-1 rounded text-xs ${
-                                    tab.isActive 
-                                      ? 'bg-flow-accent-blue/20 text-flow-accent-blue' 
-                                      : 'text-flow-text-muted'
-                                  }`}
-                                >
-                                  <Globe className="w-3 h-3 flex-shrink-0" />
-                                  <span className="truncate flex-1">{tab.name}</span>
-                                  {tab.isActive && (
-                                    <div className="w-1.5 h-1.5 bg-flow-accent-blue rounded-full flex-shrink-0" />
-                                  )}
-                                </div>
-                              ))}
-                              {app.browserTabs.length > 3 && (
-                                <div className="text-xs text-flow-text-muted text-center py-1">
-                                  +{app.browserTabs.length - 3} more tabs
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
                 </div>
               );
             })}
@@ -637,8 +691,15 @@ export function MinimizedApps({
                 <div
                   key={`file-${index}`}
                   className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
-                  onMouseEnter={() => setHoveredApp(`file-${index}`)}
-                  onMouseLeave={() => setHoveredApp(null)}
+                  onMouseEnter={(e) => {
+                    setHoveredApp(`file-${index}`);
+                    const r = e.currentTarget.getBoundingClientRect();
+                    setTooltipAnchor({
+                      x: r.left + r.width / 2,
+                      y: r.top,
+                    });
+                  }}
+                  onMouseLeave={clearHover}
                 >
                   {/* File Card */}
                   <div 
@@ -651,7 +712,6 @@ export function MinimizedApps({
                       cursor: isEditMode ? 'grab' : 'pointer',
                     }}
                     onMouseDown={(e) => handleFileMouseDown(e, file, index)}
-                    title={isEditMode ? "Drag to move to monitor" : "Click to view details"}
                   >
                     {/* File Icon Container */}
                     <div 
@@ -705,27 +765,6 @@ export function MinimizedApps({
                       </div>
                     )}
                   </div>
-
-                  {/* File Tooltip */}
-                  {hoveredApp === `file-${index}` && (
-                    <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50">
-                      <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48">
-                        <div className="text-sm font-medium text-flow-text-primary mb-1">{file.name}</div>
-                        <div className="text-xs text-flow-text-muted mb-1">
-                          Type: {file.type.toUpperCase()}
-                        </div>
-                        <div className="text-xs text-flow-text-muted mb-1">
-                          Opens with: {file.associatedApp}
-                        </div>
-                        <div className="text-xs text-flow-text-muted">
-                          Target: {monitorInfo.name}
-                          {monitorInfo.primary && (
-                            <span className="ml-1 text-flow-accent-blue">(Primary)</span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  )}
                 </div>
               );
             })}
@@ -747,5 +786,19 @@ export function MinimizedApps({
         )}
       </div>
     </div>
+    {tooltipAnchor && hoverTipEl && createPortal(
+      <div
+        className="pointer-events-none fixed z-[9999] w-max max-w-[min(20rem,calc(100vw-1.5rem))]"
+        style={{
+          left: tooltipAnchor.x,
+          top: tooltipAnchor.y,
+          transform: 'translate(-50%, calc(-100% - 8px))',
+        }}
+      >
+        <div className="pointer-events-auto">{hoverTipEl}</div>
+      </div>,
+      document.body,
+    )}
+  </>
   );
 }

--- a/src/renderer/layout/components/MinimizedApps.tsx
+++ b/src/renderer/layout/components/MinimizedApps.tsx
@@ -436,8 +436,10 @@ export function MinimizedApps({
         data-drop-target="minimized"
       >
         {totalItems > 0 ? (
-          <div className={`grid grid-cols-[repeat(auto-fill,minmax(${compact ? '68px' : '76px'},1fr))] ${compact ? 'gap-1.5' : 'gap-2'}`}>
-            {/* Render Apps */}
+          <div
+            className={`flex flex-wrap content-start items-start ${compact ? 'gap-1.5' : 'gap-2'}`}
+          >
+            {/* Render Apps — fixed-width tiles so a single app never stretches to full row width */}
             {visibleApps.map((app, index) => {
               const monitorInfo = getMonitorInfo(app.targetMonitor || 'monitor-1');
               const isBrowser = app.name.toLowerCase().includes('chrome') || app.name.toLowerCase().includes('browser');
@@ -449,7 +451,7 @@ export function MinimizedApps({
               return (
                 <div
                   key={`app-${index}`}
-                  className="relative group"
+                  className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
                   onMouseEnter={() => setHoveredApp(index)}
                   onMouseLeave={() => setHoveredApp(null)}
                 >
@@ -610,7 +612,11 @@ export function MinimizedApps({
             })}
 
             {hiddenAppsCount > 0 && (
-              <div className="relative flex flex-col items-center justify-center gap-1 p-1.5 rounded-lg border border-flow-border/60 bg-flow-surface/30">
+              <div
+                className={`relative flex shrink-0 flex-col items-center justify-center gap-1 p-1.5 rounded-lg border border-flow-border/60 bg-flow-surface/30 ${
+                  compact ? 'w-[4.25rem]' : 'w-[5rem]'
+                }`}
+              >
                 <div className="w-8 h-8 rounded-lg border border-flow-border/60 bg-flow-surface/50 flex items-center justify-center">
                   <MoreHorizontal className="w-4 h-4 text-flow-text-muted" />
                 </div>
@@ -630,7 +636,7 @@ export function MinimizedApps({
               return (
                 <div
                   key={`file-${index}`}
-                  className="relative group"
+                  className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
                   onMouseEnter={() => setHoveredApp(`file-${index}`)}
                   onMouseLeave={() => setHoveredApp(null)}
                 >

--- a/src/renderer/layout/components/MinimizedApps.tsx
+++ b/src/renderer/layout/components/MinimizedApps.tsx
@@ -50,6 +50,8 @@ interface MinimizedAppsProps {
   onRemoveApp?: (appIndex: number) => void;
   onRemoveFile?: (fileIndex: number) => void;
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
+  /** Clicking the minimized strip background (not a tile) clears selection. */
+  onClearAppSelection?: () => void;
   isEditMode?: boolean;
   compact?: boolean;
 }
@@ -68,6 +70,7 @@ export function MinimizedApps({
   onRemoveApp,
   onRemoveFile,
   onCustomDragStart,
+  onClearAppSelection,
   isEditMode = false,
   compact = false,
 }: MinimizedAppsProps) {
@@ -430,9 +433,11 @@ export function MinimizedApps({
         app.name.toLowerCase().includes("browser");
 
       return (
-        <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48 max-w-xs">
-          <div className="text-sm font-medium text-flow-text-primary mb-1">{app.name}</div>
-          <div className="text-xs text-flow-text-muted mb-2">
+        <div className="inline-block w-max max-w-[min(18rem,calc(100vw-1.5rem))] rounded-lg border border-flow-border bg-flow-surface-elevated px-2.5 py-2 shadow-lg">
+          <div className="text-sm font-medium text-flow-text-primary mb-1 max-w-[14rem] truncate" title={app.name}>
+            {app.name}
+          </div>
+          <div className="text-xs text-flow-text-muted mb-2 whitespace-normal">
             Target: {monitorInfo.name}
             {monitorInfo.primary && (
               <span className="ml-1 text-flow-accent-blue">(Primary)</span>
@@ -476,8 +481,10 @@ export function MinimizedApps({
       const file = hoveredFileData;
       const monitorInfo = getMonitorInfo(file.targetMonitor || "monitor-1");
       return (
-        <div className="bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg p-3 min-w-48 max-w-xs">
-          <div className="text-sm font-medium text-flow-text-primary mb-1">{file.name}</div>
+        <div className="inline-block w-max max-w-[min(18rem,calc(100vw-1.5rem))] rounded-lg border border-flow-border bg-flow-surface-elevated px-2.5 py-2 shadow-lg">
+          <div className="text-sm font-medium text-flow-text-primary mb-1 max-w-[14rem] truncate" title={file.name}>
+            {file.name}
+          </div>
           <div className="text-xs text-flow-text-muted mb-1">
             Type: {file.type.toUpperCase()}
           </div>
@@ -530,6 +537,11 @@ export function MinimizedApps({
             : `border-dashed border-flow-border/50 bg-flow-surface/10 ${compact ? 'p-2.5' : 'p-4'}`
         }`}
         data-drop-target="minimized"
+        onClick={(e) => {
+          if (!onClearAppSelection) return;
+          if ((e.target as HTMLElement).closest("[data-minimized-tile]")) return;
+          onClearAppSelection();
+        }}
       >
         {totalItems > 0 ? (
           <div
@@ -546,6 +558,7 @@ export function MinimizedApps({
               return (
                 <div
                   key={`app-${index}`}
+                  data-minimized-tile=""
                   className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
                   onMouseEnter={(e) => {
                     setHoveredApp(index);
@@ -571,9 +584,7 @@ export function MinimizedApps({
                   >
                     {/* App Icon Container */}
                     <div 
-                      className={`relative ${compact ? 'w-8 h-8' : 'w-10 h-10'} rounded-lg flex items-center justify-center transition-all duration-200 ${
-                        isSelected ? 'scale-105' : 'group-hover:scale-105'
-                      }`}
+                      className={`relative ${compact ? 'w-8 h-8' : 'w-10 h-10'} rounded-lg flex items-center justify-center transition-all duration-200 group-hover:scale-105`}
                       style={{ 
                         backgroundColor: `${app.color}20`,
                         border: `1px solid ${app.color}40`
@@ -620,11 +631,6 @@ export function MinimizedApps({
                           </div>
                         );
                       })()}
-                      
-                      {/* Selection Ring */}
-                      {isSelected && (
-                        <div className="absolute -inset-1 border-2 border-flow-accent-blue rounded-lg animate-pulse" />
-                      )}
                     </div>
 
                     {/* App Name */}
@@ -667,6 +673,7 @@ export function MinimizedApps({
 
             {hiddenAppsCount > 0 && (
               <div
+                data-minimized-tile=""
                 className={`relative flex shrink-0 flex-col items-center justify-center gap-1 p-1.5 rounded-lg border border-flow-border/60 bg-flow-surface/30 ${
                   compact ? 'w-[4.25rem]' : 'w-[5rem]'
                 }`}
@@ -690,6 +697,7 @@ export function MinimizedApps({
               return (
                 <div
                   key={`file-${index}`}
+                  data-minimized-tile=""
                   className={`relative group shrink-0 ${compact ? 'w-[4.25rem]' : 'w-[5rem]'}`}
                   onMouseEnter={(e) => {
                     setHoveredApp(`file-${index}`);
@@ -715,20 +723,13 @@ export function MinimizedApps({
                   >
                     {/* File Icon Container */}
                     <div 
-                      className={`relative w-10 h-10 rounded-lg flex items-center justify-center transition-all duration-200 ${
-                        isSelected ? 'scale-105' : 'group-hover:scale-105'
-                      }`}
+                      className="relative w-10 h-10 rounded-lg flex items-center justify-center transition-all duration-200 group-hover:scale-105"
                       style={{ 
                         backgroundColor: `${fileColor}20`,
                         border: `1px solid ${fileColor}40`
                       }}
                     >
                       <FileIcon type={file.type} className="w-5 h-5" />
-                      
-                      {/* Selection Ring */}
-                      {isSelected && (
-                        <div className="absolute -inset-1 border-2 border-flow-accent-blue rounded-lg animate-pulse" />
-                      )}
                     </div>
 
                     {/* File Name */}
@@ -788,7 +789,7 @@ export function MinimizedApps({
     </div>
     {tooltipAnchor && hoverTipEl && createPortal(
       <div
-        className="pointer-events-none fixed z-[9999] w-max max-w-[min(20rem,calc(100vw-1.5rem))]"
+        className="pointer-events-none fixed z-[9999] w-max"
         style={{
           left: tooltipAnchor.x,
           top: tooltipAnchor.y,

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -109,6 +109,7 @@ interface MonitorLayoutProps {
   onAssociateFileWithApp?: (monitorId: string, appIndex: number, fileData: any) => void;
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
   onAppSelect?: (appData: any, source: 'monitor' | 'minimized', monitorId?: string, appIndex?: number) => void;
+  onClearAppSelection?: () => void;
   onFileSelect?: (fileData: any, source: 'monitor' | 'minimized', monitorId?: string, fileIndex?: number) => void; // Legacy
   selectedApp?: any;
   onAutoSnapApps?: (monitorId: string, appUpdates: { appIndex: number; position: { x: number; y: number }; size: { width: number; height: number } }[]) => void;
@@ -359,6 +360,7 @@ export function MonitorLayout({
   onAssociateFileWithApp,
   onCustomDragStart,
   onAppSelect,
+  onClearAppSelection,
   onFileSelect, // Legacy
   selectedApp,
   onAutoSnapApps,
@@ -1467,6 +1469,7 @@ export function MonitorLayout({
             onRemoveFile={() => {}} // No more file removal
             monitors={monitors}
             compact={layoutColumnHeight > 0 && layoutColumnHeight < 760}
+            onClearAppSelection={onClearAppSelection}
           />
         </div>
       </div>

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -506,10 +506,6 @@ export function MonitorLayout({
 
   const compactPreviewMode = monitorPreviewScale < 0.82;
   const densePreviewMode = monitorPreviewScale < 0.62 || previewBounds.height < 620;
-  const minimizedSectionHeightPx = useMemo(() => {
-    if (layoutColumnHeight <= 0) return 110;
-    return Math.round(Math.min(132, Math.max(96, layoutColumnHeight * 0.12)));
-  }, [layoutColumnHeight]);
   const previewPositionsRef = useRef<Record<string, { x: number; y: number }>>({});
 
   const setPreviewPositions = (
@@ -549,13 +545,17 @@ export function MonitorLayout({
 
     const updateHeight = () => {
       const h = root.getBoundingClientRect().height;
-      if (h > 0) {
-        setLayoutColumnHeight(h);
-      }
+      if (h <= 0) return;
+      setLayoutColumnHeight((prev) => {
+        if (Math.abs(prev - h) < 0.75) return prev;
+        return h;
+      });
     };
 
     updateHeight();
-    const observer = new ResizeObserver(updateHeight);
+    const observer = new ResizeObserver(() => {
+      requestAnimationFrame(updateHeight);
+    });
     observer.observe(root);
 
     return () => {
@@ -1429,11 +1429,8 @@ export function MonitorLayout({
         </div>
       </div>
       
-      {/* Fixed Bottom Section: Minimized Apps - Always visible at bottom */}
-      <div
-        className="flex-shrink-0 overflow-hidden border-t border-flow-border/30"
-        style={{ minHeight: `${minimizedSectionHeightPx}px` }}
-      >
+      {/* Fixed Bottom Section: Minimized Apps — min-height is CSS-only so it does not feedback into ResizeObserver */}
+      <div className="flex-shrink-0 overflow-hidden border-t border-flow-border/30 min-h-[clamp(6rem,10vh,8.25rem)]">
         <div className={`h-full overflow-hidden ${densePreviewMode || layoutColumnHeight < 720 ? 'px-2 py-1' : 'px-3 py-1.5'}`}>
           <MinimizedApps 
             apps={minimizedApps}

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -523,18 +523,34 @@ export function MonitorLayout({
     const container = monitorPreviewRef.current;
     if (!container) return;
 
+    let raf = 0;
     const updateBounds = () => {
       const rect = container.getBoundingClientRect();
-      if (rect.width > 0 && rect.height > 0) {
-        setPreviewBounds({ width: rect.width, height: rect.height });
-      }
+      if (rect.width <= 0 || rect.height <= 0) return;
+      const w = Math.round(rect.width);
+      const h = Math.round(rect.height);
+      setPreviewBounds((prev) => {
+        if (Math.abs(prev.width - w) < 2 && Math.abs(prev.height - h) < 2) {
+          return prev;
+        }
+        return { width: w, height: h };
+      });
+    };
+
+    const schedule = () => {
+      if (raf) cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        updateBounds();
+      });
     };
 
     updateBounds();
-    const observer = new ResizeObserver(updateBounds);
+    const observer = new ResizeObserver(schedule);
     observer.observe(container);
 
     return () => {
+      if (raf) cancelAnimationFrame(raf);
       observer.disconnect();
     };
   }, []);
@@ -544,10 +560,10 @@ export function MonitorLayout({
     if (!root) return;
 
     const updateHeight = () => {
-      const h = root.getBoundingClientRect().height;
+      const h = Math.round(root.getBoundingClientRect().height);
       if (h <= 0) return;
       setLayoutColumnHeight((prev) => {
-        if (Math.abs(prev - h) < 0.75) return prev;
+        if (Math.abs(prev - h) < 2) return prev;
         return h;
       });
     };
@@ -1429,9 +1445,13 @@ export function MonitorLayout({
         </div>
       </div>
       
-      {/* Fixed Bottom Section: Minimized Apps — min-height is CSS-only so it does not feedback into ResizeObserver */}
-      <div className="flex-shrink-0 overflow-hidden border-t border-flow-border/30 min-h-[clamp(6rem,10vh,8.25rem)]">
-        <div className={`h-full overflow-hidden ${densePreviewMode || layoutColumnHeight < 720 ? 'px-2 py-1' : 'px-3 py-1.5'}`}>
+      {/* Minimized Apps: overflow visible so hover popovers are not clipped; min-height fits one full tile row */}
+      <div className="flex-shrink-0 border-t border-flow-border/30 min-h-[clamp(7.5rem,12vh,11rem)] overflow-x-hidden overflow-y-visible">
+        <div
+          className={`min-h-0 max-h-[min(40vh,18rem)] overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable] ${
+            densePreviewMode || layoutColumnHeight < 720 ? 'px-2 py-1' : 'px-3 py-1.5'
+          }`}
+        >
           <MinimizedApps 
             apps={minimizedApps}
             files={[]} // No more standalone files
@@ -1446,7 +1466,7 @@ export function MonitorLayout({
             onRemoveApp={onRemoveMinimizedApp}
             onRemoveFile={() => {}} // No more file removal
             monitors={monitors}
-            compact={previewBounds.height < 780 || monitorPreviewScale < 0.86 || layoutColumnHeight < 760}
+            compact={layoutColumnHeight > 0 && layoutColumnHeight < 760}
           />
         </div>
       </div>

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -100,18 +100,13 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
           clearHoverTimer();
           if (!disabled) setShowDetails(false);
         }}
-        className={`relative p-4 rounded-lg transition-all duration-200 group border ${
+        className={`relative p-3.5 rounded-xl transition-all duration-150 ease-out group border ${
           disabled
-            ? 'bg-flow-surface border-flow-border opacity-60 cursor-not-allowed'
-            : profile.isActive 
-              ? 'border-flow-accent-blue/50 bg-flow-accent-blue/10 shadow-lg cursor-pointer' 
-              : 'bg-flow-surface border-flow-border hover:bg-flow-surface-elevated hover:border-flow-border-accent shadow-sm cursor-pointer'
+            ? 'bg-flow-surface/80 border-flow-border/50 opacity-60 cursor-not-allowed'
+            : profile.isActive
+              ? 'border-flow-border-accent/35 bg-flow-surface-elevated ring-1 ring-flow-accent-blue/35 shadow-flow-shadow-md cursor-pointer'
+              : 'flow-card-quiet cursor-pointer'
         }`}
-        style={{ 
-          boxShadow: profile.isActive 
-            ? '0 0 0 1px var(--flow-accent-blue), var(--flow-shadow-md)' 
-            : 'var(--flow-shadow-sm)'
-        }}
       >
         {/* Status indicators - removed active dot */}
         {(profile.autoLaunchOnBoot || profile.autoSwitchTime) && (
@@ -130,15 +125,15 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
         )}
         
         <div className="flex items-start gap-3">
-          <div className={`p-2 rounded-lg transition-colors ${
-            profile.isActive ? 'bg-flow-accent-blue/20' : 'bg-flow-surface-elevated group-hover:bg-flow-surface'
+          <div className={`p-2 rounded-lg transition-colors duration-150 ${
+            profile.isActive ? 'bg-flow-accent-blue/15' : 'bg-flow-bg-tertiary/80 group-hover:bg-flow-surface'
           }`}>
             {getProfileIcon()}
           </div>
           
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <h3 className={`font-medium truncate ${
+              <h3 className={`text-sm font-semibold tracking-tight truncate ${
                 profile.isActive ? 'text-flow-accent-blue' : 'text-flow-text-primary'
               }`}>{profile.name}</h3>
               {profile.hotkey && (
@@ -148,7 +143,7 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
               )}
             </div>
             
-            <p className="text-flow-text-muted text-xs mb-3 line-clamp-2">{profile.description}</p>
+            <p className="text-flow-text-muted text-[11px] leading-snug mb-3 line-clamp-2">{profile.description}</p>
             
             <div className="grid grid-cols-2 gap-2 text-xs">
               <div className="flex items-center gap-1 text-flow-text-muted">
@@ -188,7 +183,7 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
               </button>
             
               {showActions && (
-                <div className="absolute top-6 right-0 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg z-10 py-1">
+                <div className="absolute top-6 right-0 w-48 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-10 py-1">
                   {onSettings && (
                     <button
                       onClick={(e) => handleActionClick(e, onSettings)}
@@ -244,8 +239,8 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
       
       {/* Hover details tooltip */}
       {showDetails && !showActions && !profile.isActive && (
-        <div className="absolute top-0 left-full ml-4 w-80 p-4 bg-flow-surface-elevated border border-flow-border rounded-xl shadow-lg z-50">
-          <h4 className="text-flow-text-primary font-medium mb-3">Apps &amp; Layout Preview</h4>
+        <div className="absolute top-0 left-full ml-4 w-80 p-4 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-50">
+          <h4 className="text-[11px] font-semibold uppercase tracking-wider text-flow-text-secondary mb-3">Apps &amp; layout</h4>
           <div className="space-y-3 max-h-64 overflow-y-auto">
             {(Array.isArray(profile.monitors) ? profile.monitors : []).map((monitor, index) => (
               <div key={monitor?.id || index} className="space-y-2">

--- a/src/renderer/layout/components/SelectedAppDetails.tsx
+++ b/src/renderer/layout/components/SelectedAppDetails.tsx
@@ -53,13 +53,13 @@ export function SelectedAppDetails({
   if (!selectedApp) {
     return (
       <div className="h-full flex items-center justify-center p-8">
-        <div className="text-center max-w-sm">
-          <div className="w-16 h-16 bg-flow-surface rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <Monitor className="w-8 h-8 text-flow-text-muted" />
+        <div className="text-center max-w-[17rem] rounded-2xl border border-flow-border/50 bg-flow-surface/40 px-6 py-8">
+          <div className="w-14 h-14 bg-flow-bg-tertiary/80 rounded-xl flex items-center justify-center mx-auto mb-4 ring-1 ring-flow-border/40">
+            <Monitor className="w-7 h-7 text-flow-text-muted" />
           </div>
-          <h3 className="font-semibold text-flow-text-primary mb-2">No App Selected</h3>
-          <p className="text-sm text-flow-text-muted leading-relaxed">
-            Click on any app in the monitor layout or minimized section to view and edit its settings.
+          <h3 className="text-sm font-semibold text-flow-text-primary tracking-tight mb-2">No app selected</h3>
+          <p className="text-xs text-flow-text-muted leading-relaxed">
+            Select an app on a monitor or in the minimized row to view launch options, files, and metadata.
           </p>
         </div>
       </div>
@@ -766,14 +766,14 @@ export function SelectedAppDetails({
   };
 
   return (
-    <div className="h-full flex flex-col bg-flow-bg-secondary">
+    <div className="h-full flex flex-col bg-flow-bg-secondary/95">
       {/* App Header - Always visible */}
-      <div className="px-6 py-4 border-b border-flow-border bg-flow-bg-tertiary">
+      <div className="px-5 py-4 border-b border-flow-border/50 bg-flow-surface/30 backdrop-blur-sm">
         <div className="flex items-start gap-4">
           {renderAppIcon(currentData)}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <span className="text-lg font-semibold text-flow-text-primary truncate">
+              <span className="text-base font-semibold text-flow-text-primary tracking-tight truncate">
                 {currentData.name}
               </span>
               <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
@@ -797,18 +797,19 @@ export function SelectedAppDetails({
       </div>
 
       {/* Tab Navigation */}
-      <div className="border-b border-flow-border bg-flow-bg-tertiary">
+      <div className="border-b border-flow-border/50 bg-flow-bg-secondary/80">
         <div className="flex">
           {tabs.map((tab) => {
             const IconComponent = tab.icon;
             return (
               <button
+                type="button"
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 text-xs font-medium transition-all duration-200 border-b-2 ${
+                className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 text-[11px] font-medium transition-all duration-150 ease-out border-b-2 ${
                   activeTab === tab.id
-                    ? 'border-flow-accent-blue text-flow-accent-blue bg-flow-bg-secondary'
-                    : 'border-transparent text-flow-text-muted hover:text-flow-text-primary hover:bg-flow-surface'
+                    ? 'border-flow-accent-blue text-flow-accent-blue bg-flow-bg-primary/40'
+                    : 'border-transparent text-flow-text-muted hover:text-flow-text-primary hover:bg-flow-surface/50'
                 }`}
               >
                 <IconComponent className="w-3 h-3" />
@@ -821,7 +822,7 @@ export function SelectedAppDetails({
 
       {/* Tab Content */}
       <div className="flex-1 overflow-y-auto scrollbar-elegant">
-        <div className="p-6">
+        <div className="p-5">
           {renderTabContent()}
         </div>
       </div>


### PR DESCRIPTION
Includes Eagle-inspired shell styling, Apps tab search/dark form fixes, minimized apps layout (no full-width tiles), stable strip height to stop fullscreen bounce, portal hover tooltips, tighter tooltips, selection ring only on card, click-away to clear selection, and related CSS PostCSS fixes.

Made with [Cursor](https://cursor.com)