### PR TITLE
fix: stabilize confirmation ownership and post-confirmation placement

### DIFF
--- a/docs/superpowers/specs/workflow-orchestration-execution-checklist.md
+++ b/docs/superpowers/specs/workflow-orchestration-execution-checklist.md
@@ -33,7 +33,6 @@ Priority legend:
 - Current focus phase: **Phase 2 - Reliability Hardening**
 - Current blockers:
   - Steam/launcher-child post-confirmation placement consistency
-  - Full runId + stale-status isolation completion
   - Tracker migration parity and cutover validation
 
 ## Milestones
@@ -50,18 +49,23 @@ Priority legend:
 ## Workstreams
 
 ### A) Run Lifecycle and Status Truth
-- [ ] (P0, owner: agent) Implement strict runId isolation in all status paths (`not_started`)  
+- [x] (P0, owner: agent) Implement strict runId isolation in all status paths (`done`)  
   depends_on: none  
   done_when: status API + renderer ignore mismatched runId in all launch states
-- [ ] (P0, owner: agent) Enforce stale-status rejection in renderer and IPC consumers (`not_started`)  
+- [x] (P0, owner: agent) Enforce stale-status rejection in renderer and IPC consumers (`done`)  
   depends_on: runId isolation  
   done_when: stale updates never mutate active UI state in tests
-- [ ] (P0, owner: agent) Implement cancel/relaunch policy (`replace`) end-to-end (`not_started`)  
+- [x] (P0, owner: agent) Implement cancel/relaunch policy (`replace`) end-to-end (`done`)  
   depends_on: runId isolation  
   done_when: new run supersedes old run without pending-state leakage
 - [ ] (P1, owner: agent) Add degraded-mode handling for status-store write failures (`not_started`)  
   depends_on: lifecycle status model  
   done_when: `statusDegraded=true` path validated with non-fatal renderer warning
+
+Progress note (2026-04-16):
+- Added run-scoped status store (`runId`) and active-run guards in main process.
+- Added stale snapshot rejection in renderer polling by `runId` + poll token.
+- Added replace semantics where new launch supersedes prior run and stale async writes are ignored.
 
 ### B) Classifier and Candidate Selection
 - [ ] (P0, owner: agent) Extract classifier from `main.js` to dedicated module (`not_started`)  
@@ -107,6 +111,11 @@ Priority legend:
 - [ ] (P0, owner: agent) Enforce run-budget terminal semantics and authoritative timeout event (`not_started`)  
   depends_on: lifecycle status truth  
   done_when: `run-budget-exhausted` emitted once and terminal state is deterministic
+
+Progress note (2026-04-16, confirmation-routing hotfix):
+- Tightened process hint expansion to avoid unrelated token matches (for example `OBS Studio` pulling in `code`).
+- Updated ready-gate blocker logic so windows that qualify as strong main-placement candidates are not treated as hard blockers.
+- Added regression tests for overlap disambiguation vs true modal blockers in `src/main/utils/window-ready-gate.test.js`.
 
 ### E) Global Tracker Migration
 - [ ] (P1, owner: agent) Implement global tracker abstraction with scoped subscriptions (`not_started`)  

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -21,6 +21,7 @@ const {
   describeMonitor,
   summarizeWindowRows,
 } = require('./utils/launch-diagnostics');
+const { createLaunchStatusStore } = require('./utils/launch-status-store');
 const {
   hiddenProcessNamePatterns,
   hiddenWindowTitlePatterns,
@@ -60,22 +61,7 @@ const MAX_URL_LENGTH = 2048;
 const MAX_SHORTCUT_PATH_LENGTH = 4096;
 const DEFAULT_AUTOMATION_SETTLE_MS = 1800;
 const DEFAULT_AUTOMATION_START_DELAY_MS = 900;
-const launchStatusByProfileId = new Map();
-
-const clonePendingConfirmations = (pendingConfirmations) => (
-  (Array.isArray(pendingConfirmations) ? pendingConfirmations : []).map((item) => ({
-    name: String(item?.name || ''),
-    path: String(item?.path || ''),
-    reason: String(item?.reason || ''),
-    processHintLc: item?.processHintLc ? String(item.processHintLc) : undefined,
-    blockerHandle: item?.blockerHandle ? String(item.blockerHandle) : null,
-    status: ['waiting', 'resolved', 'failed'].includes(String(item?.status || '').toLowerCase())
-      ? String(item.status).toLowerCase()
-      : 'waiting',
-    handle: item?.handle ? String(item.handle) : undefined,
-    resolvedAt: Number.isFinite(Number(item?.resolvedAt)) ? Number(item.resolvedAt) : undefined,
-  }))
-);
+const launchStatusStore = createLaunchStatusStore();
 
 const parseBooleanEnv = (value) => {
   const normalized = String(value || '').trim().toLowerCase();
@@ -2969,10 +2955,6 @@ const buildCompanionProcessHints = async ({
   const base = String(baseProcessHintLc || '').trim().toLowerCase().replace(/\.exe$/i, '');
   if (!base) return [];
   const hints = new Set([base]);
-  const appTokens = String(appNameHint || '')
-    .toLowerCase()
-    .split(/[^a-z0-9]+/g)
-    .filter((token) => token.length >= 4);
   let processRows = [];
   try {
     processRows = await getRunningWindowProcesses();
@@ -2988,10 +2970,7 @@ const buildCompanionProcessHints = async ({
       || base.startsWith(name)
       || (base.length >= minimumMatchLength && name.includes(base))
     );
-    const rowTitle = String(row?.title || '').trim().toLowerCase();
-    const rowPath = String(row?.executablePath || '').trim().toLowerCase();
-    const appNameRelated = appTokens.some((token) => rowTitle.includes(token) || rowPath.includes(token));
-    if (related || appNameRelated) hints.add(name);
+    if (related) hints.add(name);
   }
   const result = Array.from(hints);
   if (diagnostics && result.length > 1) {
@@ -3389,27 +3368,9 @@ const gatherLegacyActionLaunches = (profile, monitorMap) => {
   };
 };
 
-const publishLaunchProfileStatus = (profileId, status) => {
-  const safeProfileId = String(profileId || '').trim();
-  if (!safeProfileId || !status || typeof status !== 'object') return;
-  const pendingConfirmations = clonePendingConfirmations(status.pendingConfirmations);
-  const unresolvedPendingConfirmationCount = pendingConfirmations
-    .filter((item) => item.status !== 'resolved')
-    .length;
-  launchStatusByProfileId.set(safeProfileId, {
-    profileId: safeProfileId,
-    state: String(status.state || 'idle'),
-    launchedAppCount: Number(status.launchedAppCount || 0),
-    launchedTabCount: Number(status.launchedTabCount || 0),
-    failedAppCount: Number(status.failedAppCount || 0),
-    skippedAppCount: Number(status.skippedAppCount || 0),
-    pendingConfirmationCount: pendingConfirmations.length,
-    unresolvedPendingConfirmationCount,
-    requestedAppCount: Number(status.requestedAppCount || 0),
-    pendingConfirmations,
-    updatedAt: Date.now(),
-  });
-};
+const publishLaunchProfileStatus = (profileId, runId, status) => (
+  launchStatusStore.publishStatus(profileId, runId, status)
+);
 
 const launchProfileById = async (profileId) => {
   const { profiles, storeError } = unpackProfilesReadResult(readProfilesFromDisk());
@@ -3436,6 +3397,18 @@ const launchProfileById = async (profileId) => {
         .filter(Boolean),
     };
   }
+  const runSession = launchStatusStore.startRun(normalizedProfileId);
+  const activeRunId = String(runSession?.runId || '').trim();
+  if (!activeRunId) {
+    return {
+      ok: false,
+      error: 'Could not initialize launch run state.',
+      profile,
+      requestedProfileId: normalizedProfileId,
+    };
+  }
+  const replacedRunId = runSession?.replacedRunId || null;
+  const isCurrentRunActive = () => launchStatusStore.isActiveRun(normalizedProfileId, activeRunId);
 
   const launchState = profile?.launchMaximized
     ? 'maximized'
@@ -3491,12 +3464,13 @@ const launchProfileById = async (profileId) => {
   const profileDiagnostics = createLaunchDiagnostics({
     profileId: normalizedProfileId,
     launchState,
+    runId: activeRunId,
   });
   const publishCurrentLaunchStatus = (state = 'in-progress') => {
-    publishLaunchProfileStatus(normalizedProfileId, {
+    publishLaunchProfileStatus(normalizedProfileId, activeRunId, {
       state,
       launchedAppCount,
-      launchedTabCount: 0,
+      launchedTabCount,
       failedAppCount: failedApps.length,
       skippedAppCount: skippedApps.length,
       requestedAppCount: appLaunches.length,
@@ -3528,10 +3502,12 @@ const launchProfileById = async (profileId) => {
   });
 
   const runLaunch = async (launchItem) => {
+    if (!isCurrentRunActive()) return;
     const launchDiagnostics = createLaunchDiagnostics({
       profileId: normalizedProfileId,
       launchSequence: Number(launchItem?.launchSequence ?? -1),
       appName: launchItem?.appName || 'unknown',
+      runId: activeRunId,
     });
     try {
       const processHintLc = getPlacementProcessKey(launchItem);
@@ -3747,6 +3723,7 @@ const launchProfileById = async (profileId) => {
               placementState: placementBounds.state,
             },
           }).then((resumeResult) => {
+            if (!isCurrentRunActive()) return;
             const status = String(resumeResult?.status || '').trim().toLowerCase();
             const mappedStatus = (
               status === 'resolved'
@@ -3762,6 +3739,7 @@ const launchProfileById = async (profileId) => {
             }
             publishCurrentLaunchStatus('awaiting-confirmations');
           }).catch(() => {
+            if (!isCurrentRunActive()) return;
             pendingEntry.status = 'failed';
             publishCurrentLaunchStatus('awaiting-confirmations');
           });
@@ -4192,6 +4170,7 @@ const launchProfileById = async (profileId) => {
   });
 
   for (const launchItem of appLaunches) {
+    if (!isCurrentRunActive()) break;
     const delaySeconds = Number(appLaunchDelays[launchItem.appName] || 0);
     const safeDelayMs = Math.max(0, Math.floor(delaySeconds * 1000));
     if (safeDelayMs > 0) {
@@ -4203,6 +4182,7 @@ const launchProfileById = async (profileId) => {
   const browserTabs = Array.isArray(profile?.browserTabs) ? profile.browserTabs : [];
   const launchedUrls = new Set();
   for (const tab of browserTabs) {
+    if (!isCurrentRunActive()) break;
     const url = normalizeSafeUrl(tab?.url);
     if (!url || launchedUrls.has(url)) continue;
     launchedUrls.add(url);
@@ -4216,6 +4196,7 @@ const launchProfileById = async (profileId) => {
   }
 
   for (const url of legacyLaunchData.browserUrls) {
+    if (!isCurrentRunActive()) break;
     const safeUrl = normalizeSafeUrl(url);
     if (!safeUrl || launchedUrls.has(safeUrl)) continue;
     launchedUrls.add(safeUrl);
@@ -4238,9 +4219,12 @@ const launchProfileById = async (profileId) => {
       skippedAppCount: skippedApps.length,
     });
     publishCurrentLaunchStatus('failed');
+    launchStatusStore.sealRun(normalizedProfileId, activeRunId, 'failed');
     return {
       ok: false,
       error: 'No launchable apps or tabs found in this profile. Add an executable path in app details or recreate from installed apps.',
+      runId: activeRunId,
+      replacedRunId,
       profile,
       launchedAppCount,
       launchedTabCount,
@@ -4272,8 +4256,17 @@ const launchProfileById = async (profileId) => {
       ? 'awaiting-confirmations'
       : (failedApps.length === 0 ? 'complete' : 'failed'),
   );
+  if (unresolvedPendingConfirmations.length === 0) {
+    launchStatusStore.sealRun(
+      normalizedProfileId,
+      activeRunId,
+      failedApps.length === 0 ? 'complete' : 'failed',
+    );
+  }
   return {
     ok: failedApps.length === 0,
+    runId: activeRunId,
+    replacedRunId,
     profile,
     launchedAppCount,
     launchedTabCount,
@@ -4470,14 +4463,11 @@ handleTrustedIpc('launch-profile', async (_event, profileId) => {
 handleTrustedIpc('launch-profile-status', async (_event, profileId) => {
   const safeProfileId = String(profileId || '').trim();
   if (!safeProfileId) return { ok: false, error: 'Invalid profile id' };
-  const status = launchStatusByProfileId.get(safeProfileId);
+  const status = launchStatusStore.getStatus(safeProfileId);
   if (!status) return { ok: true, status: null };
   return {
     ok: true,
-    status: {
-      ...status,
-      pendingConfirmations: clonePendingConfirmations(status.pendingConfirmations),
-    },
+    status,
   };
 });
 

--- a/src/main/services/window-ready-gate.js
+++ b/src/main/services/window-ready-gate.js
@@ -49,8 +49,8 @@ const isLikelyModalBlockerWindow = (row, expectedBounds = null) => {
   const clearlySmallerThanTarget = (
     expectedWidth > 0
     && expectedHeight > 0
-    && width <= Math.floor(expectedWidth * 0.9)
-    && height <= Math.floor(expectedHeight * 0.9)
+    && width <= Math.floor(expectedWidth * 0.78)
+    && height <= Math.floor(expectedHeight * 0.78)
   );
   if (MODAL_DIALOG_CLASSES.has(className)) return true;
   if (hasOwner && titleLength > 0 && clearlySmallerThanTarget) return true;
@@ -62,10 +62,17 @@ const isLikelyModalBlockerWindow = (row, expectedBounds = null) => {
 const isLikelyMainPlacementWindow = (row, expectedBounds = null) => {
   if (!row || row.cloaked || row.hung || row.tool || !row.enabled) return false;
   if (isLikelyModalBlockerWindow(row, expectedBounds)) return false;
+  return isLikelyMainPlacementWindowIgnoringBlocker(row, expectedBounds);
+};
+
+const isLikelyMainPlacementWindowIgnoringBlocker = (row, expectedBounds = null) => {
+  if (!row || row.cloaked || row.hung || row.tool || !row.enabled) return false;
   const width = Number(row.width || 0);
   const height = Number(row.height || 0);
-  const minExpectedWidth = Math.max(320, Math.floor(Number(expectedBounds?.width || 0) * 0.52));
-  const minExpectedHeight = Math.max(220, Math.floor(Number(expectedBounds?.height || 0) * 0.52));
+  const expectsMaximized = String(expectedBounds?.state || '').toLowerCase() === 'maximized';
+  const sizeRatio = expectsMaximized ? 0.36 : 0.52;
+  const minExpectedWidth = Math.max(320, Math.floor(Number(expectedBounds?.width || 0) * sizeRatio));
+  const minExpectedHeight = Math.max(220, Math.floor(Number(expectedBounds?.height || 0) * sizeRatio));
   return width >= minExpectedWidth && height >= minExpectedHeight;
 };
 
@@ -99,6 +106,7 @@ const waitForMainWindowReadyOrBlocker = async ({
   let blockerStableCount = 0;
   let stableHandle = null;
   let stableCount = 0;
+  let lastRows = [];
 
   while (Date.now() <= deadline) {
     const windowsByHint = await Promise.all(
@@ -124,9 +132,24 @@ const waitForMainWindowReadyOrBlocker = async ({
       }
     }
 
+    const strictCandidates = rows
+      .filter((row) => isLikelyMainPlacementWindow(row, expectedBounds))
+      .sort((a, b) => scoreWindowCandidate(b, safeProcess || normalizedHints[0])
+        - scoreWindowCandidate(a, safeProcess || normalizedHints[0]));
+    const relaxedCandidates = rows
+      .filter((row) => isLikelyMainPlacementWindowIgnoringBlocker(row, expectedBounds))
+      .sort((a, b) => scoreWindowCandidate(b, safeProcess || normalizedHints[0])
+        - scoreWindowCandidate(a, safeProcess || normalizedHints[0]));
+    const candidateHandleSet = new Set(
+      relaxedCandidates.map((row) => String(row?.handle || '').trim()).filter(Boolean),
+    );
+    lastRows = rows;
     const blockers = rows.filter((row) => isLikelyModalBlockerWindow(row, expectedBounds));
-    if (blockers.length > 0) {
-      const rankedBlockers = [...blockers].sort((a, b) => Number(b.area || 0) - Number(a.area || 0));
+    const blockingOnlyRows = blockers.filter(
+      (row) => !candidateHandleSet.has(String(row?.handle || '').trim()),
+    );
+    if (blockingOnlyRows.length > 0) {
+      const rankedBlockers = [...blockingOnlyRows].sort((a, b) => Number(b.area || 0) - Number(a.area || 0));
       const blocker = rankedBlockers[0];
       const blockerHandle = String(blocker?.handle || '').trim() || null;
       const blockerTitle = String(blocker?.title || '').trim();
@@ -153,8 +176,8 @@ const waitForMainWindowReadyOrBlocker = async ({
           reason: 'modal-window-blocking-placement',
           processHintLc: safeProcess || normalizedHints[0],
           processHints: normalizedHints,
-          blockerCount: blockers.length,
-          blockerSample: summarizeWindowRows(blockers, 3),
+          blockerCount: blockingOnlyRows.length,
+          blockerSample: summarizeWindowRows(blockingOnlyRows, 3),
           blockerKind: isLikelyLoadingModal ? 'loading' : 'confirmation',
         });
         blockerReported = true;
@@ -167,7 +190,7 @@ const waitForMainWindowReadyOrBlocker = async ({
           blocked: true,
           blockerKind: 'confirmation',
           blockerHandle,
-          blockerSample: summarizeWindowRows(blockers, 3),
+          blockerSample: summarizeWindowRows(blockingOnlyRows, 3),
           handle: null,
         };
       }
@@ -180,11 +203,9 @@ const waitForMainWindowReadyOrBlocker = async ({
     blockerFirstSeenAt = 0;
     lastBlockerHandle = null;
     blockerStableCount = 0;
-
-    const candidates = rows
-      .filter((row) => isLikelyMainPlacementWindow(row, expectedBounds))
-      .sort((a, b) => scoreWindowCandidate(b, safeProcess || normalizedHints[0])
-        - scoreWindowCandidate(a, safeProcess || normalizedHints[0]));
+    const candidates = (blockers.length > 0 && blockingOnlyRows.length === 0)
+      ? relaxedCandidates
+      : strictCandidates;
     if (candidates.length === 0) {
       stableHandle = null;
       stableCount = 0;
@@ -212,7 +233,32 @@ const waitForMainWindowReadyOrBlocker = async ({
     await sleep(pollMs);
   }
 
+  const timeoutInteractiveRows = lastRows.filter((row) => (
+    !row?.cloaked
+    && !row?.hung
+    && !row?.tool
+    && row?.enabled
+    && Number(row?.titleLength || 0) > 0
+    && Number(row?.width || 0) >= 280
+    && Number(row?.height || 0) >= 140
+    && Number(row?.area || 0) >= 80_000
+  ));
+  const blockedByTimeoutInteractive = timeoutInteractiveRows.length > 0;
   if (diagnostics) {
+    if (!blockerReported && timeoutInteractiveRows.length > 0) {
+      diagnostics.decision({
+        ...diagnosticsContext,
+        strategy: 'launch-blocker-detected',
+        reason: 'timeout-interactive-window-blocking-placement',
+        processHintLc: safeProcess || normalizedHints[0],
+        processHints: normalizedHints,
+        blockerCount: timeoutInteractiveRows.length,
+        blockerSample: summarizeWindowRows(timeoutInteractiveRows, 3),
+        blockerKind: 'confirmation',
+      });
+      blockerReported = true;
+      lastBlockerKind = 'confirmation';
+    }
     diagnostics.failure({
       ...diagnosticsContext,
       strategy: 'window-ready-gate',
@@ -225,8 +271,8 @@ const waitForMainWindowReadyOrBlocker = async ({
   return {
     ready: false,
     timedOut: true,
-    blocked: blockerReported,
-    blockerKind: blockerReported ? (lastBlockerKind || 'loading') : null,
+    blocked: blockerReported || blockedByTimeoutInteractive,
+    blockerKind: (blockerReported || blockedByTimeoutInteractive) ? (lastBlockerKind || 'confirmation') : null,
     handle: null,
   };
 };

--- a/src/main/utils/launch-status-store.js
+++ b/src/main/utils/launch-status-store.js
@@ -1,0 +1,137 @@
+const normalizePendingStatus = (value) => {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === 'resolved') return 'resolved';
+  if (normalized === 'failed') return 'failed';
+  return 'waiting';
+};
+
+const clonePendingConfirmations = (pendingConfirmations) => (
+  (Array.isArray(pendingConfirmations) ? pendingConfirmations : []).map((item) => ({
+    name: String(item?.name || ''),
+    path: String(item?.path || ''),
+    reason: String(item?.reason || ''),
+    processHintLc: item?.processHintLc ? String(item.processHintLc) : undefined,
+    blockerHandle: item?.blockerHandle ? String(item.blockerHandle) : null,
+    status: normalizePendingStatus(item?.status),
+    handle: item?.handle ? String(item.handle) : undefined,
+    resolvedAt: Number.isFinite(Number(item?.resolvedAt)) ? Number(item.resolvedAt) : undefined,
+  }))
+);
+
+const createRunIdFactory = ({ now }) => {
+  let sequence = 0;
+  return () => {
+    sequence += 1;
+    return `run-${now()}-${sequence}`;
+  };
+};
+
+const createLaunchStatusStore = (options = {}) => {
+  const now = typeof options.now === 'function' ? options.now : () => Date.now();
+  const nextRunId = typeof options.createRunId === 'function'
+    ? options.createRunId
+    : createRunIdFactory({ now });
+  const clonePending = typeof options.clonePendingConfirmations === 'function'
+    ? options.clonePendingConfirmations
+    : clonePendingConfirmations;
+  const statusByProfileId = new Map();
+  const activeRunByProfileId = new Map();
+
+  const startRun = (profileId) => {
+    const safeProfileId = String(profileId || '').trim();
+    if (!safeProfileId) return null;
+    const previousActiveRunId = activeRunByProfileId.get(safeProfileId)?.runId || null;
+    const runId = String(nextRunId(safeProfileId) || '').trim();
+    if (!runId) return null;
+    activeRunByProfileId.set(safeProfileId, {
+      runId,
+      startedAt: now(),
+    });
+    return {
+      profileId: safeProfileId,
+      runId,
+      replacedRunId: previousActiveRunId,
+    };
+  };
+
+  const isActiveRun = (profileId, runId) => {
+    const safeProfileId = String(profileId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeProfileId || !safeRunId) return false;
+    return activeRunByProfileId.get(safeProfileId)?.runId === safeRunId;
+  };
+
+  const publishStatus = (profileId, runId, status) => {
+    const safeProfileId = String(profileId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeProfileId || !safeRunId || !status || typeof status !== 'object') {
+      return { published: false, reason: 'invalid-arguments' };
+    }
+    if (!isActiveRun(safeProfileId, safeRunId)) {
+      return { published: false, reason: 'inactive-run' };
+    }
+    const pendingConfirmations = clonePending(status.pendingConfirmations);
+    const unresolvedPendingConfirmationCount = pendingConfirmations
+      .filter((item) => item.status !== 'resolved')
+      .length;
+    const nextStatus = {
+      profileId: safeProfileId,
+      runId: safeRunId,
+      state: String(status.state || 'idle'),
+      launchedAppCount: Number(status.launchedAppCount || 0),
+      launchedTabCount: Number(status.launchedTabCount || 0),
+      failedAppCount: Number(status.failedAppCount || 0),
+      skippedAppCount: Number(status.skippedAppCount || 0),
+      pendingConfirmationCount: pendingConfirmations.length,
+      unresolvedPendingConfirmationCount,
+      requestedAppCount: Number(status.requestedAppCount || 0),
+      pendingConfirmations,
+      updatedAt: now(),
+    };
+    statusByProfileId.set(safeProfileId, nextStatus);
+    return { published: true, status: { ...nextStatus, pendingConfirmations: clonePending(nextStatus.pendingConfirmations) } };
+  };
+
+  const getStatus = (profileId) => {
+    const safeProfileId = String(profileId || '').trim();
+    if (!safeProfileId) return null;
+    const status = statusByProfileId.get(safeProfileId);
+    if (!status) return null;
+    return {
+      ...status,
+      pendingConfirmations: clonePending(status.pendingConfirmations),
+    };
+  };
+
+  const sealRun = (profileId, runId, state = null) => {
+    const safeProfileId = String(profileId || '').trim();
+    const safeRunId = String(runId || '').trim();
+    if (!safeProfileId || !safeRunId) return false;
+    if (!isActiveRun(safeProfileId, safeRunId)) return false;
+    activeRunByProfileId.delete(safeProfileId);
+    if (state) {
+      const currentStatus = statusByProfileId.get(safeProfileId);
+      if (currentStatus && currentStatus.runId === safeRunId) {
+        statusByProfileId.set(safeProfileId, {
+          ...currentStatus,
+          state: String(state),
+          updatedAt: now(),
+        });
+      }
+    }
+    return true;
+  };
+
+  return {
+    startRun,
+    isActiveRun,
+    publishStatus,
+    getStatus,
+    sealRun,
+  };
+};
+
+module.exports = {
+  clonePendingConfirmations,
+  createLaunchStatusStore,
+};

--- a/src/main/utils/launch-status-store.test.js
+++ b/src/main/utils/launch-status-store.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createLaunchStatusStore } = require('./launch-status-store');
+
+test('startRun sets active run and supersedes previous run for same profile', () => {
+  const store = createLaunchStatusStore({ now: () => 1700000000000 });
+  const firstRun = store.startRun('profile-1');
+  const secondRun = store.startRun('profile-1');
+
+  assert.ok(firstRun?.runId);
+  assert.ok(secondRun?.runId);
+  assert.notEqual(secondRun.runId, firstRun.runId);
+  assert.equal(secondRun.replacedRunId, firstRun.runId);
+  assert.equal(store.isActiveRun('profile-1', firstRun.runId), false);
+  assert.equal(store.isActiveRun('profile-1', secondRun.runId), true);
+});
+
+test('publishStatus rejects inactive run and accepts active run', () => {
+  let tick = 0;
+  const store = createLaunchStatusStore({ now: () => 1700000000000 + (tick += 1) });
+  const firstRun = store.startRun('profile-1');
+  const secondRun = store.startRun('profile-1');
+
+  const staleWrite = store.publishStatus('profile-1', firstRun.runId, {
+    state: 'in-progress',
+    launchedAppCount: 1,
+  });
+  assert.equal(staleWrite.published, false);
+  assert.equal(staleWrite.reason, 'inactive-run');
+
+  const activeWrite = store.publishStatus('profile-1', secondRun.runId, {
+    state: 'awaiting-confirmations',
+    launchedAppCount: 2,
+    launchedTabCount: 1,
+    failedAppCount: 0,
+    skippedAppCount: 0,
+    requestedAppCount: 3,
+    pendingConfirmations: [
+      { name: 'Steam', path: 'C:\\Steam\\steam.exe', reason: 'Confirm', status: 'waiting' },
+    ],
+  });
+
+  assert.equal(activeWrite.published, true);
+  assert.equal(activeWrite.status.runId, secondRun.runId);
+  assert.equal(activeWrite.status.pendingConfirmationCount, 1);
+  assert.equal(activeWrite.status.unresolvedPendingConfirmationCount, 1);
+});
+
+test('sealRun prevents late async status writes from same run', () => {
+  const store = createLaunchStatusStore({ now: () => 1700000000000 });
+  const run = store.startRun('profile-1');
+
+  const initial = store.publishStatus('profile-1', run.runId, {
+    state: 'in-progress',
+    launchedAppCount: 1,
+    pendingConfirmations: [],
+  });
+  assert.equal(initial.published, true);
+
+  store.sealRun('profile-1', run.runId, 'complete');
+  assert.equal(store.isActiveRun('profile-1', run.runId), false);
+
+  const lateWrite = store.publishStatus('profile-1', run.runId, {
+    state: 'awaiting-confirmations',
+    pendingConfirmations: [{ name: 'Late', path: '', reason: 'Late', status: 'waiting' }],
+  });
+  assert.equal(lateWrite.published, false);
+  assert.equal(lateWrite.reason, 'inactive-run');
+
+  const status = store.getStatus('profile-1');
+  assert.equal(status?.state, 'complete');
+  assert.equal(status?.runId, run.runId);
+});

--- a/src/main/utils/window-ready-gate.test.js
+++ b/src/main/utils/window-ready-gate.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { waitForMainWindowReadyOrBlocker } = require('../services/window-ready-gate');
+
+const buildRow = (overrides = {}) => ({
+  handle: '100',
+  className: 'Chrome_WidgetWin_1',
+  title: 'Sample Window',
+  titleLength: 12,
+  hasOwner: true,
+  topMost: false,
+  tool: false,
+  enabled: true,
+  hung: false,
+  cloaked: false,
+  width: 1300,
+  height: 700,
+  area: 910000,
+  ...overrides,
+});
+
+test('waitForMainWindowReadyOrBlocker treats overlapping blocker/main candidate as ready', async () => {
+  const rows = [buildRow({ handle: '68810' })];
+  const result = await waitForMainWindowReadyOrBlocker({
+    processHintLc: 'notion',
+    expectedBounds: { width: 1920, height: 1080, state: 'maximized' },
+    timeoutMs: 5000,
+    pollMs: 10,
+    listWindows: async () => rows,
+    sleep: async () => {},
+    summarizeWindowRows: (items) => items,
+    scoreWindowCandidate: () => 100,
+  });
+
+  assert.equal(result.ready, true);
+  assert.equal(result.blocked, false);
+  assert.equal(result.handle, '68810');
+});
+
+test('waitForMainWindowReadyOrBlocker still blocks for true non-candidate modal', async () => {
+  const rows = [buildRow({
+    handle: '327934',
+    className: '#32770',
+    width: 620,
+    height: 420,
+    area: 260400,
+  })];
+  const result = await waitForMainWindowReadyOrBlocker({
+    processHintLc: 'obs64',
+    expectedBounds: { width: 1920, height: 1080, state: 'maximized' },
+    timeoutMs: 5000,
+    pollMs: 10,
+    listWindows: async () => rows,
+    sleep: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    },
+    summarizeWindowRows: (items) => items,
+    scoreWindowCandidate: () => 50,
+  });
+
+  assert.equal(result.ready, false);
+  assert.equal(result.blocked, true);
+  assert.equal(result.blockerKind, 'confirmation');
+  assert.equal(result.blockerHandle, '327934');
+});

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -68,6 +68,8 @@ export default function App() {
   const { launchFeedback, setLaunchFeedback, launchFeedbackTimeoutRef } =
     useLaunchFeedback();
   const launchStatusPollRef = useRef<number | null>(null);
+  const launchStatusPollTokenRef = useRef(0);
+  const activeLaunchRunRef = useRef<{ profileId: string; runId: string } | null>(null);
   const [isEditMode, setIsEditMode] = useState(false);
   const [
     selectedProfileForSettings,
@@ -82,11 +84,20 @@ export default function App() {
     useState<SelectedApp | null>(null);
 
   const stopLaunchStatusPolling = useCallback(() => {
+    launchStatusPollTokenRef.current += 1;
     if (launchStatusPollRef.current) {
       window.clearInterval(launchStatusPollRef.current);
       launchStatusPollRef.current = null;
     }
   }, []);
+  const isCurrentLaunchContext = useCallback(
+    (profileId: string, runId: string, pollToken: number) => (
+      launchStatusPollTokenRef.current === pollToken
+      && activeLaunchRunRef.current?.profileId === profileId
+      && activeLaunchRunRef.current?.runId === runId
+    ),
+    [],
+  );
   const [rightSidebarOpen, setRightSidebarOpen] =
     useState(false);
   const [showProfileDropdown, setShowProfileDropdown] =
@@ -1314,7 +1325,9 @@ export default function App() {
 
   const handleLaunch = async () => {
     if (!currentProfile?.id || !window.electron?.launchProfile) return;
+    const launchProfileId = currentProfile.id;
     stopLaunchStatusPolling();
+    activeLaunchRunRef.current = null;
 
     if (launchFeedbackTimeoutRef.current) {
       window.clearTimeout(launchFeedbackTimeoutRef.current);
@@ -1354,8 +1367,15 @@ export default function App() {
       }
 
       const launchResult = await window.electron.launchProfile(
-        currentProfile.id,
+        launchProfileId,
       );
+      const launchRunId = String(launchResult?.runId || "").trim();
+      if (launchRunId) {
+        activeLaunchRunRef.current = {
+          profileId: launchProfileId,
+          runId: launchRunId,
+        };
+      }
       const launchedApps = Number(launchResult?.launchedAppCount || 0);
       const launchedTabs = Number(launchResult?.launchedTabCount || 0);
       const failedCount = Array.isArray(launchResult?.failedApps)
@@ -1387,7 +1407,8 @@ export default function App() {
         if (failedCount > 0) summaryParts.push(`${failedCount} failed`);
         if (skippedCount > 0) summaryParts.push(`${skippedCount} skipped`);
         if (unresolvedPendingCount > 0) {
-          persistLaunchFeedback = true;
+          const canPollLaunchStatus = Boolean(launchRunId);
+          persistLaunchFeedback = canPollLaunchStatus;
           const pendingList = pendingNames.length > 0
             ? ` (${pendingNames.join(", ")}${unresolvedPendingCount > pendingNames.length ? ", ..." : ""})`
             : "";
@@ -1396,12 +1417,16 @@ export default function App() {
             status: "warning",
             message: `Launch in progress: ${summaryText}. Waiting for ${unresolvedPendingCount} confirmation${unresolvedPendingCount === 1 ? "" : "s"}${pendingList}.`,
           });
-          if (window.electron?.getLaunchProfileStatus) {
+          if (canPollLaunchStatus) {
+            const pollToken = launchStatusPollTokenRef.current;
             launchStatusPollRef.current = window.setInterval(async () => {
+              if (!isCurrentLaunchContext(launchProfileId, launchRunId, pollToken)) return;
               try {
-                const statusResult = await window.electron.getLaunchProfileStatus(currentProfile.id);
+                const statusResult = await window.electron.getLaunchProfileStatus(launchProfileId);
+                if (!isCurrentLaunchContext(launchProfileId, launchRunId, pollToken)) return;
                 const status = statusResult?.status;
                 if (!statusResult?.ok || !status) return;
+                if (String(status.runId || "").trim() !== launchRunId) return;
                 const unresolvedCount = Number(status.unresolvedPendingConfirmationCount || 0);
                 const pollingPendingNames = Array.isArray(status.pendingConfirmations)
                   ? status.pendingConfirmations
@@ -1414,6 +1439,7 @@ export default function App() {
                   : [];
                 if (unresolvedCount <= 0) {
                   stopLaunchStatusPolling();
+                  activeLaunchRunRef.current = null;
                   setLaunchFeedback({
                     status: "success",
                     message: `Launch complete: ${summaryText}.`,
@@ -1449,6 +1475,7 @@ export default function App() {
           });
         }
       } else {
+        activeLaunchRunRef.current = null;
         const errorMessage = launchResult?.error
           || "Could not launch this profile. Check app executable paths in app details.";
         setLaunchFeedback({
@@ -1461,6 +1488,7 @@ export default function App() {
         );
       }
     } catch (error) {
+      activeLaunchRunRef.current = null;
       console.error("Failed to launch profile:", error);
       const errorMessage =
         error instanceof Error && error.message
@@ -1473,6 +1501,7 @@ export default function App() {
     } finally {
       setIsLaunching(false);
       if (!persistLaunchFeedback) {
+        activeLaunchRunRef.current = null;
         launchFeedbackTimeoutRef.current = window.setTimeout(() => {
           setLaunchFeedback({
             status: "idle",

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -9,6 +9,8 @@ declare global {
       launchProfile: (profileId: string) => Promise<{
         ok: boolean;
         error?: string;
+        runId?: string;
+        replacedRunId?: string | null;
         storeErrorCode?: string;
         requestedProfileId?: string;
         profile?: Profile;
@@ -42,6 +44,7 @@ declare global {
         error?: string;
         status?: {
           profileId: string;
+          runId: string;
           state: "idle" | "in-progress" | "awaiting-confirmations" | "complete" | "failed" | string;
           launchedAppCount: number;
           launchedTabCount: number;


### PR DESCRIPTION
## Summary
- isolate launch status by run id and add active-run guards so stale confirmation updates cannot mutate current launch state
- harden blocker detection and main-candidate selection in the window ready gate to reduce confirmation misclassification and unblock post-confirmation placement
- add regression tests for launch status store and window ready gate confirmation/candidate overlap behavior

## Test plan
- [x] `npm run test`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] manual work-profile validation (OBS + Steam + Notion confirmation flow)