### PR TITLE
feat: Shell UI refresh (header, sidebar, launch, menus)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,17 @@ This file is the repository-level source of truth for git workflow and change cl
 - Do not commit debug leftovers (`console.log`, commented-out code, unused imports).
 - Run lint and typecheck before committing.
 
+## Agent handoff before commit (human review first)
+
+Automated agents should **not** create a git commit unless the user **explicitly** asked to commit in that same request (for example: “commit this”, “ship it”, “merge when ready”).
+
+When finishing work (whether or not a commit is made), provide:
+
+1. **Plain-language summary** — a short bullet list (about three to six bullets) of what changed and why, written for a human skimming the message.
+2. **Manual test checklist** — concrete steps to verify the change in the app (or one line such as “Smoke only: open app and confirm no obvious regressions” when that is enough).
+
+The human uses that summary to review, then commits, requests edits, or discards. Commits made by an agent should still follow one logical change per commit, conventional prefixes, and lint plus typecheck before commit.
+
 ## Branch Strategy
 
 - `main` = stable

--- a/docs/superpowers/feature-braindump.md
+++ b/docs/superpowers/feature-braindump.md
@@ -11,6 +11,10 @@ After review, move them to `Reviewed Raw Archive` and keep this section small.
 
 - check computer temps/task manager consumption or overall machine load and use it to adapt launch behavior or warn users when launch workload may over-tax CPU/memory.
 - support for ultra wide monitors along with presets for window layouts for ultrawides
+- Change what is pinned to the taskbar per profile
+- Option to restrict profiles at times or based on other criteria to prevent distractions or for kids
+- Standardize styling for reused features like dropdowns, settings modals, etc
+- What if the whole header section was a big launch button since that is the primary function users will be doing? Or just a very large launch button. Or if the launch button said Launch 'name of profie here' to make it even more obvious
 
 ## Reviewed Raw Archive (Reference Only)
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -138,6 +138,10 @@
   .app-drag-region {
     -webkit-app-region: drag;
   }
+
+  .app-no-drag {
+    -webkit-app-region: no-drag;
+  }
   
   body {
     @apply bg-flow-bg-primary text-flow-text-primary;
@@ -184,6 +188,15 @@
     @apply text-[11px] font-medium text-flow-text-secondary uppercase tracking-wider;
   }
 
+  /** Sidebar sub-panels (Profiles / Apps / Content) — same label + meta rhythm */
+  .flow-sidebar-section-title {
+    @apply text-[11px] font-semibold uppercase tracking-wider text-flow-text-secondary;
+  }
+
+  .flow-sidebar-meta {
+    @apply text-xs text-flow-text-muted tabular-nums;
+  }
+
   .flow-card-quiet {
     @apply rounded-xl transition-all duration-150 ease-out;
     border: 1px solid color-mix(in oklch, var(--flow-border) 62%, transparent);
@@ -196,13 +209,13 @@
   }
 
   .flow-segment-track {
-    @apply flex rounded-lg p-0.5 gap-0.5;
+    @apply flex w-full rounded-lg p-1 gap-1;
     border: 1px solid color-mix(in oklch, var(--flow-border) 55%, transparent);
     background-color: color-mix(in oklch, var(--flow-surface) 72%, transparent);
   }
 
   .flow-segment-tab {
-    @apply flex-1 rounded-md text-xs font-medium transition-all duration-150 ease-out;
+    @apply flex min-h-[2.5rem] flex-1 items-center justify-center rounded-md text-sm font-semibold transition-all duration-150 ease-out;
   }
 
   .flow-segment-tab-active {
@@ -225,6 +238,79 @@
   .flow-header-well-interactive:hover {
     @apply bg-flow-surface-elevated;
     border-color: color-mix(in oklch, var(--flow-border-accent) 38%, transparent);
+  }
+
+  /** Opaque app menus (title bar, overflow, inline popovers) — do not use translucent panel bg */
+  .flow-menu-panel {
+    min-width: 13.5rem;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    border: 1px solid color-mix(in oklch, white 12%, transparent);
+    background-color: var(--flow-bg-secondary);
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    box-shadow:
+      0 18px 50px -14px rgb(0 0 0 / 0.65),
+      0 0 0 1px color-mix(in oklch, white 4%, transparent);
+  }
+
+  .flow-menu-item {
+    @apply flex w-full items-center gap-2 px-3 py-2.5 text-left text-sm text-flow-text-primary;
+  }
+
+  .flow-menu-item:hover:not(:disabled) {
+    @apply bg-flow-surface-elevated;
+  }
+
+  .flow-menu-item-danger {
+    @apply text-flow-accent-red;
+  }
+
+  .flow-menu-item-danger:hover {
+    background-color: color-mix(in oklch, var(--flow-accent-red) 12%, transparent);
+    @apply text-flow-accent-red;
+  }
+
+  .flow-sidebar-search {
+    @apply w-full rounded-lg border border-white/[0.1] bg-flow-surface py-2 pl-9 pr-3 text-sm text-flow-text-primary shadow-inner placeholder:text-flow-text-muted;
+  }
+
+  .flow-sidebar-search:focus {
+    outline: none;
+    border-color: color-mix(in oklch, var(--flow-accent-blue) 45%, transparent);
+    box-shadow:
+      inset 0 2px 4px 0 rgb(0 0 0 / 0.12),
+      0 0 0 2px color-mix(in oklch, var(--flow-accent-blue) 30%, transparent);
+  }
+
+  /** Sidebar view switcher: dense, icon + label */
+  .flow-nav-tab-strip {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.125rem;
+    border-radius: 0.75rem;
+    padding: 0.1875rem;
+    border: 1px solid color-mix(in oklch, var(--flow-border) 65%, transparent);
+    background-color: color-mix(in oklch, var(--flow-bg-primary) 88%, transparent);
+  }
+
+  .flow-nav-tab {
+    @apply flex min-h-[2.75rem] flex-col items-center justify-center gap-0.5 rounded-md px-1 py-1.5 text-[11px] font-semibold leading-tight text-flow-text-muted transition-colors duration-150 ease-out sm:min-h-[2.5rem] sm:flex-row sm:gap-1.5 sm:px-2 sm:text-xs;
+  }
+
+  .flow-nav-tab:hover {
+    @apply bg-flow-surface text-flow-text-secondary;
+  }
+
+  .flow-nav-tab-active {
+    @apply bg-flow-surface-elevated text-flow-text-primary shadow-sm;
+    box-shadow:
+      0 1px 2px rgb(0 0 0 / 0.12),
+      inset 0 1px 0 color-mix(in oklch, white 8%, transparent);
+  }
+
+  .flow-nav-tab-idle {
+    @apply text-flow-text-muted;
   }
 }
 

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -29,7 +29,6 @@ import {
   ChevronRight,
   ChevronLeft,
   X,
-  ChevronDown,
   Check,
   AlertTriangle,
   Layers,
@@ -55,10 +54,7 @@ import {
   useMainLayoutProfileMutations,
   type MainLayoutSelectedApp,
 } from "./hooks/useMainLayoutProfileMutations";
-import {
-  ProfileIconGlyph,
-  shortenProfileDescriptionForHeader,
-} from "./utils/profileHeaderPresentation";
+import { ProfileIconGlyph } from "./utils/profileHeaderPresentation";
 import { formatUnit } from "../utils/pluralize";
 
 const GENERIC_LAUNCH_PROFILE_MESSAGE = "Launching profile...";
@@ -103,11 +99,6 @@ export default function App() {
 
   const [rightSidebarOpen, setRightSidebarOpen] =
     useState(false);
-  const [showProfileDropdown, setShowProfileDropdown] =
-    useState(false);
-
-  // Ref for the dropdown container
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   // CUSTOM DRAG SYSTEM STATE
   const [dragState, setDragState] = useState<DragState>({
@@ -198,33 +189,6 @@ export default function App() {
     currentProfile,
     profileDragActionsRef,
   });
-
-  // FIXED: Document click listener for dropdown
-  useEffect(() => {
-    const handleDocumentClick = (event: MouseEvent) => {
-      if (
-        showProfileDropdown &&
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setShowProfileDropdown(false);
-      }
-    };
-
-    if (showProfileDropdown) {
-      // Add listener with slight delay to avoid immediate closure
-      setTimeout(() => {
-        document.addEventListener("click", handleDocumentClick);
-      }, 10);
-    }
-
-    return () => {
-      document.removeEventListener(
-        "click",
-        handleDocumentClick,
-      );
-    };
-  }, [showProfileDropdown]);
 
   // SELECTED APP HANDLERS
   const handleClearAppSelection = useCallback(() => {
@@ -638,7 +602,6 @@ export default function App() {
 
       if (profileId === selectedProfile) {
         console.log("⚠️ PROFILE ALREADY SELECTED:", profileId);
-        setShowProfileDropdown(false);
         return;
       }
 
@@ -651,30 +614,9 @@ export default function App() {
       setSelectedApp(null);
       setRightSidebarOpen(false);
 
-      // Close dropdown
-      setShowProfileDropdown(false);
       console.log("🎉 PROFILE SWITCH COMPLETED:", profileId);
     },
     [isEditMode, selectedProfile],
-  );
-
-  // Handle dropdown toggle
-  const handleDropdownToggle = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (isEditMode) {
-        console.log(
-          "🚫 DROPDOWN TOGGLE BLOCKED - Edit mode is active",
-        );
-        return;
-      }
-
-      console.log("🔽 DROPDOWN TOGGLE:", !showProfileDropdown);
-      setShowProfileDropdown(!showProfileDropdown);
-    },
-    [isEditMode, showProfileDropdown],
   );
 
   const handleDragStart = () => {
@@ -713,8 +655,8 @@ export default function App() {
         {/* Left Sidebar - FIXED: Better height management */}
         <div className="w-[clamp(16rem,24vw,24rem)] min-w-[16rem] flow-shell-nav flex flex-col">
           {/* Header - Fixed height */}
-          <div className="flex-shrink-0 p-4 border-b border-flow-border/50">
-            <div className="flex items-center justify-between mb-3">
+          <div className="flex-shrink-0 border-b border-flow-border/50 px-4 py-2 md:px-6">
+            <div className="mb-2 flex items-center justify-between md:mb-2.5">
               <div>
                 <h1 className="text-base text-flow-text-primary font-semibold tracking-tight">
                   FlowSwitch
@@ -966,159 +908,65 @@ export default function App() {
         >
           {/* Header - Spans across Main Content and Right Sidebar area */}
           {currentProfile ? (
-            <header className="relative z-10 border-b border-flow-border/50 bg-flow-bg-secondary/80 px-4 py-3 backdrop-blur-sm md:px-6 md:py-3.5 xl:px-8">
-              <div className="flex min-w-0 flex-col gap-3 xl:flex-row xl:items-start xl:justify-between xl:gap-6">
-                <div className="flex min-w-0 flex-1 justify-center xl:justify-start">
-                  <div className="relative w-full max-w-xl" ref={dropdownRef}>
-                    <button
-                      type="button"
-                      onClick={handleDropdownToggle}
-                      disabled={isEditMode}
-                      className={`flow-header-well flex w-full items-start gap-3 rounded-xl p-2.5 text-left md:gap-3 md:p-3 ${
-                        isEditMode
-                          ? "cursor-not-allowed text-flow-text-muted opacity-50"
-                          : "flow-header-well-interactive cursor-pointer text-flow-text-primary"
-                      }`}
-                    >
-                      <div className="flex shrink-0 items-center justify-center rounded-lg bg-flow-bg-tertiary/90 p-2 md:p-2.5">
-                        <ProfileIconGlyph
-                          icon={currentProfile.icon}
-                          className="h-5 w-5 text-flow-text-secondary md:h-6 md:w-6"
-                        />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
-                          <h2 className="max-w-[20rem] truncate text-base font-semibold tracking-tight text-flow-text-primary md:text-lg">
-                            {currentProfile.name}
-                          </h2>
-                          {currentProfile.autoLaunchOnBoot && (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-green/30 bg-flow-accent-green/20 px-2 py-0.5 text-xs font-medium text-flow-accent-green">
-                              <Zap className="h-3 w-3" />
-                              Boot
-                            </span>
-                          )}
-                          {currentProfile.autoSwitchTime && (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-purple/30 bg-flow-accent-purple/20 px-2 py-0.5 text-xs font-medium text-flow-accent-purple">
-                              <Clock className="h-3 w-3" />
-                              {currentProfile.autoSwitchTime}
-                            </span>
-                          )}
-                          {currentProfile.hotkey && (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-blue/30 bg-flow-accent-blue/20 px-2 py-0.5 text-xs font-medium text-flow-accent-blue">
-                              {currentProfile.hotkey}
-                            </span>
-                          )}
-                        </div>
-                        <p className="truncate text-xs text-flow-text-secondary md:text-sm">
-                          {shortenProfileDescriptionForHeader(
-                            currentProfile.description,
-                          )}
-                        </p>
-                        <div className="mt-2 flex flex-wrap gap-1.5">
-                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
-                            <Zap className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
-                            ~
-                            {currentProfile.estimatedStartupTime}
-                            s startup
-                          </span>
-                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
-                            <Layers className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
-                            {formatUnit(currentProfile.appCount, "app")}
-                          </span>
-                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
-                            <Globe className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
-                            {formatUnit(currentProfile.tabCount, "tab")}
-                          </span>
-                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
-                            <Folder className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
-                            {formatUnit(
-                              currentProfile.fileCount || 0,
-                              "file",
-                            )}
-                          </span>
-                          {currentProfile.launchOrder === "sequential" ? (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
-                              Sequential launch
-                            </span>
-                          ) : null}
-                        </div>
-                      </div>
-                      {!isEditMode ? (
-                        <ChevronDown
-                          className={`mt-1 h-4 w-4 shrink-0 text-flow-text-muted transition-transform duration-150 ease-out ${
-                            showProfileDropdown ? "rotate-180" : ""
-                          }`}
-                          aria-hidden
-                        />
-                      ) : null}
-                    </button>
-
-                    {/* Profile Dropdown */}
-                    {showProfileDropdown && !isEditMode && (
-                      <div
-                        className="absolute top-full left-0 mt-2 w-full min-w-[20rem] bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg overflow-hidden z-[60]"
-                        style={{ pointerEvents: "auto" }}
-                      >
-                        <div className="max-h-80 overflow-y-auto scrollbar-elegant">
-                          {profiles.map((profile) => (
-                            <button
-                              key={profile.id}
-                              onClick={() => {
-                                handleProfileSwitch(profile.id);
-                              }}
-                              className="w-full flex items-center gap-3 p-3.5 text-left hover:bg-flow-surface/80 transition-colors duration-150 border-b border-flow-border/30 last:border-b-0"
-                            >
-                              <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2 mb-1">
-                                  <h3 className="text-sm font-semibold text-flow-text-primary tracking-tight">
-                                    {profile.name}
-                                  </h3>
-                                  {profile.id ===
-                                    selectedProfile && (
-                                    <div className="flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30">
-                                      <Check className="w-3 h-3 flex-shrink-0" />
-                                      Active
-                                    </div>
-                                  )}
-                                  {profile.autoLaunchOnBoot && (
-                                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded bg-flow-accent-green/20 text-flow-accent-green">
-                                      <Zap className="w-2.5 h-2.5" />
-                                      Boot
-                                    </span>
-                                  )}
-                                  {profile.autoSwitchTime && (
-                                    <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded bg-flow-accent-purple/20 text-flow-accent-purple">
-                                      <Clock className="w-2.5 h-2.5" />
-                                      {profile.autoSwitchTime}
-                                    </span>
-                                  )}
-                                  {profile.hotkey && (
-                                    <span className="inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded bg-flow-accent-blue/20 text-flow-accent-blue">
-                                      {profile.hotkey}
-                                    </span>
-                                  )}
-                                </div>
-                                <p className="text-sm text-flow-text-secondary mb-2 truncate">
-                                  {profile.description}
-                                </p>
-                                <div className="flex flex-wrap items-center gap-2 text-xs text-flow-text-muted">
-                                  <span>{formatUnit(profile.appCount, "app")}</span>
-                                  <span>{formatUnit(profile.tabCount, "tab")}</span>
-                                  <span>
-                                    {formatUnit(profile.fileCount || 0, "file")}
-                                  </span>
-                                  <span>
-                                    ~
-                                    {profile.estimatedStartupTime}
-                                    s
-                                  </span>
-                                </div>
-                              </div>
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+            <header className="relative z-10 shrink-0 border-b border-flow-border/50 bg-flow-bg-secondary/80 px-4 py-2 backdrop-blur-sm md:px-6 xl:px-8">
+              <div className="flex min-w-0 flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-3">
+                <div
+                  className={`flex min-w-0 flex-1 items-center gap-2 ${
+                    isEditMode ? "opacity-50" : ""
+                  }`}
+                  aria-label="Active profile"
+                >
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-flow-border/35 bg-flow-bg-tertiary/70">
+                    <ProfileIconGlyph
+                      icon={currentProfile.icon}
+                      className="h-4 w-4 text-flow-text-secondary"
+                    />
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+                    <h2 className="max-w-[min(100%,14rem)] truncate text-sm font-semibold tracking-tight text-flow-text-primary sm:max-w-[22rem] md:text-base">
+                      {currentProfile.name}
+                    </h2>
+                    {currentProfile.autoLaunchOnBoot && (
+                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-green/30 bg-flow-accent-green/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-green">
+                        <Zap className="h-2.5 w-2.5 shrink-0" />
+                        Boot
+                      </span>
                     )}
+                    {currentProfile.autoSwitchTime && (
+                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-purple/30 bg-flow-accent-purple/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-purple">
+                        <Clock className="h-2.5 w-2.5 shrink-0" />
+                        {currentProfile.autoSwitchTime}
+                      </span>
+                    )}
+                    {currentProfile.hotkey && (
+                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-blue/30 bg-flow-accent-blue/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-blue">
+                        {currentProfile.hotkey}
+                      </span>
+                    )}
+                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
+                      <Zap className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
+                      ~{currentProfile.estimatedStartupTime}s
+                    </span>
+                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
+                      <Layers className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
+                      {formatUnit(currentProfile.appCount, "app")}
+                    </span>
+                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
+                      <Globe className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
+                      {formatUnit(currentProfile.tabCount, "tab")}
+                    </span>
+                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
+                      <Folder className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
+                      {formatUnit(
+                        currentProfile.fileCount || 0,
+                        "file",
+                      )}
+                    </span>
+                    {currentProfile.launchOrder === "sequential" ? (
+                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
+                        Sequential
+                      </span>
+                    ) : null}
                   </div>
                 </div>
 

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -4,6 +4,8 @@ import {
   useCallback,
   useEffect,
 } from "react";
+import { LaunchControl } from "./components/LaunchControl";
+import { ProfileHeaderOverflowMenu } from "./components/ProfileHeaderOverflowMenu";
 import { ProfileCard } from "./components/ProfileCard";
 import { MonitorLayout } from "./components/MonitorLayout";
 import { ProfileSettings } from "./components/ProfileSettings";
@@ -30,6 +32,9 @@ import {
   ChevronDown,
   Check,
   AlertTriangle,
+  Layers,
+  Folder,
+  Globe,
 } from "lucide-react";
 import { DragState } from "./types/dragTypes";
 import { safeIconSrc } from "../utils/safeIconSrc";
@@ -50,6 +55,13 @@ import {
   useMainLayoutProfileMutations,
   type MainLayoutSelectedApp,
 } from "./hooks/useMainLayoutProfileMutations";
+import {
+  ProfileIconGlyph,
+  shortenProfileDescriptionForHeader,
+} from "./utils/profileHeaderPresentation";
+import { formatUnit } from "../utils/pluralize";
+
+const GENERIC_LAUNCH_PROFILE_MESSAGE = "Launching profile...";
 
 /**
  * Application shell: profile grid, monitor layout editor, app/content managers, and the custom
@@ -124,6 +136,20 @@ export default function App() {
   const profileForSettings = profiles.find(
     (p) => p.id === selectedProfileForSettings,
   ) || null;
+
+  const showLaunchFeedbackStrip =
+    launchFeedback.status !== "idle"
+    && !(
+      launchFeedback.status === "in-progress"
+      && launchFeedback.message === GENERIC_LAUNCH_PROFILE_MESSAGE
+    );
+
+  const launchControlShowCancel = Boolean(
+    (isLaunching
+      || launchFeedback.status === "in-progress"
+      || launchFeedback.status === "warning")
+    && window.electron?.cancelProfileLaunch,
+  );
 
   const currentProfileRef = useRef<FlowProfile | null>(null);
   currentProfileRef.current = currentProfile;
@@ -697,7 +723,11 @@ export default function App() {
                   Profiles, apps, layouts
                 </p>
               </div>
-              <div className="flex items-center gap-1.5">
+              <div
+                className="flex items-center gap-0.5 rounded-lg border border-flow-border/45 bg-flow-surface/35 p-0.5"
+                role="toolbar"
+                aria-label="Profile file actions"
+              >
                 <input
                   type="file"
                   accept=".json"
@@ -707,28 +737,48 @@ export default function App() {
                 />
                 <label
                   htmlFor="import-profile"
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out cursor-pointer"
-                  title="Import Profile"
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out cursor-pointer"
+                  title="Import profile"
                   aria-label="Import profile"
                 >
                   <Upload className="w-3.5 h-3.5" />
                 </label>
                 <button
+                  type="button"
                   onClick={() =>
                     currentProfile &&
                     exportProfile(currentProfile.id)
                   }
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out"
-                  title="Export Current Profile"
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out disabled:opacity-40 disabled:pointer-events-none"
+                  title={
+                    currentProfile
+                      ? "Export current profile"
+                      : "Select a profile to export"
+                  }
                   aria-label="Export current profile"
+                  disabled={!currentProfile}
                 >
                   <Download className="w-3.5 h-3.5" />
                 </button>
-                <span className="h-4 w-px bg-flow-border/40 mx-0.5" aria-hidden="true" />
+                <span
+                  className="mx-0.5 h-4 w-px shrink-0 bg-flow-border/50"
+                  aria-hidden="true"
+                />
                 <button
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-all duration-150 ease-out"
-                  title="Open settings"
-                  aria-label="Open settings"
+                  type="button"
+                  onClick={() => {
+                    if (currentProfile) {
+                      setSelectedProfileForSettings(currentProfile.id);
+                    }
+                  }}
+                  disabled={!currentProfile}
+                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out disabled:opacity-40 disabled:pointer-events-none"
+                  title={
+                    currentProfile
+                      ? "Profile settings"
+                      : "Select a profile for settings"
+                  }
+                  aria-label="Open profile settings"
                 >
                   <Settings className="w-3.5 h-3.5" />
                 </button>
@@ -916,80 +966,91 @@ export default function App() {
         >
           {/* Header - Spans across Main Content and Right Sidebar area */}
           {currentProfile ? (
-            <header className="px-4 md:px-6 xl:px-8 py-2.5 md:py-3 border-b border-flow-border/50 bg-flow-bg-secondary/80 backdrop-blur-sm relative z-10">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  {/* Profile Switcher - Now without settings button */}
-                  <div className="relative" ref={dropdownRef}>
+            <header className="relative z-10 border-b border-flow-border/50 bg-flow-bg-secondary/80 px-4 py-3 backdrop-blur-sm md:px-6 md:py-3.5 xl:px-8">
+              <div className="flex min-w-0 flex-col gap-3 xl:flex-row xl:items-start xl:justify-between xl:gap-6">
+                <div className="flex min-w-0 flex-1 justify-center xl:justify-start">
+                  <div className="relative w-full max-w-xl" ref={dropdownRef}>
                     <button
+                      type="button"
                       onClick={handleDropdownToggle}
                       disabled={isEditMode}
-                      className={`flow-header-well flex items-center gap-2 md:gap-3 p-2 md:p-2.5 max-w-[52vw] ${
+                      className={`flow-header-well flex w-full items-start gap-3 rounded-xl p-2.5 text-left md:gap-3 md:p-3 ${
                         isEditMode
-                          ? "opacity-50 cursor-not-allowed text-flow-text-muted"
-                          : "flow-header-well-interactive text-flow-text-primary cursor-pointer"
+                          ? "cursor-not-allowed text-flow-text-muted opacity-50"
+                          : "flow-header-well-interactive cursor-pointer text-flow-text-primary"
                       }`}
                     >
-                      <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-1">
-                          <h2 className="text-base md:text-lg text-flow-text-primary font-semibold tracking-tight truncate max-w-[22rem]">
+                      <div className="flex shrink-0 items-center justify-center rounded-lg bg-flow-bg-tertiary/90 p-2 md:p-2.5">
+                        <ProfileIconGlyph
+                          icon={currentProfile.icon}
+                          className="h-5 w-5 text-flow-text-secondary md:h-6 md:w-6"
+                        />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="mb-0.5 flex flex-wrap items-center gap-2">
+                          <h2 className="max-w-[20rem] truncate text-base font-semibold tracking-tight text-flow-text-primary md:text-lg">
                             {currentProfile.name}
                           </h2>
                           {currentProfile.autoLaunchOnBoot && (
-                            <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-flow-accent-green/20 text-flow-accent-green border border-flow-accent-green/30">
-                              <Zap className="w-3 h-3" />
+                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-green/30 bg-flow-accent-green/20 px-2 py-0.5 text-xs font-medium text-flow-accent-green">
+                              <Zap className="h-3 w-3" />
                               Boot
                             </span>
                           )}
                           {currentProfile.autoSwitchTime && (
-                            <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-flow-accent-purple/20 text-flow-accent-purple border border-flow-accent-purple/30">
-                              <Clock className="w-3 h-3" />
+                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-purple/30 bg-flow-accent-purple/20 px-2 py-0.5 text-xs font-medium text-flow-accent-purple">
+                              <Clock className="h-3 w-3" />
                               {currentProfile.autoSwitchTime}
                             </span>
                           )}
                           {currentProfile.hotkey && (
-                            <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30">
+                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-blue/30 bg-flow-accent-blue/20 px-2 py-0.5 text-xs font-medium text-flow-accent-blue">
                               {currentProfile.hotkey}
                             </span>
                           )}
                         </div>
-                        <p className="text-flow-text-secondary text-xs md:text-sm truncate">
-                          {currentProfile.description}
-                        </p>
-                        <div className="flex items-center gap-2 md:gap-4 mt-1.5 flex-wrap">
-                          <div className="flex items-center gap-1 text-flow-text-muted text-xs">
-                            <Clock className="w-3 h-3" />
-                            <span>
-                              ~
-                              {
-                                currentProfile.estimatedStartupTime
-                              }
-                              s startup
-                            </span>
-                          </div>
-                          <div className="text-flow-text-muted text-xs">
-                            {currentProfile.appCount} apps •{" "}
-                            {currentProfile.tabCount} tabs •{" "}
-                            {currentProfile.fileCount || 0}{" "}
-                            files
-                          </div>
-                          {currentProfile.launchOrder ===
-                            "sequential" && (
-                            <div className="text-flow-text-muted text-xs">
-                              Sequential launch
-                            </div>
+                        <p className="truncate text-xs text-flow-text-secondary md:text-sm">
+                          {shortenProfileDescriptionForHeader(
+                            currentProfile.description,
                           )}
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
+                            <Zap className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
+                            ~
+                            {currentProfile.estimatedStartupTime}
+                            s startup
+                          </span>
+                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
+                            <Layers className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
+                            {formatUnit(currentProfile.appCount, "app")}
+                          </span>
+                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
+                            <Globe className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
+                            {formatUnit(currentProfile.tabCount, "tab")}
+                          </span>
+                          <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
+                            <Folder className="h-3 w-3 shrink-0 opacity-80" aria-hidden />
+                            {formatUnit(
+                              currentProfile.fileCount || 0,
+                              "file",
+                            )}
+                          </span>
+                          {currentProfile.launchOrder === "sequential" ? (
+                            <span className="inline-flex items-center gap-1 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/60 px-2 py-0.5 text-[11px] font-medium text-flow-text-muted">
+                              Sequential launch
+                            </span>
+                          ) : null}
                         </div>
                       </div>
-                      {!isEditMode && (
+                      {!isEditMode ? (
                         <ChevronDown
-                          className={`w-4 h-4 text-flow-text-muted transition-transform duration-150 ease-out ${
-                            showProfileDropdown
-                              ? "rotate-180"
-                              : ""
+                          className={`mt-1 h-4 w-4 shrink-0 text-flow-text-muted transition-transform duration-150 ease-out ${
+                            showProfileDropdown ? "rotate-180" : ""
                           }`}
+                          aria-hidden
                         />
-                      )}
+                      ) : null}
                     </button>
 
                     {/* Profile Dropdown */}
@@ -1040,22 +1101,15 @@ export default function App() {
                                 <p className="text-sm text-flow-text-secondary mb-2 truncate">
                                   {profile.description}
                                 </p>
-                                <div className="flex items-center gap-3 text-xs text-flow-text-muted">
+                                <div className="flex flex-wrap items-center gap-2 text-xs text-flow-text-muted">
+                                  <span>{formatUnit(profile.appCount, "app")}</span>
+                                  <span>{formatUnit(profile.tabCount, "tab")}</span>
                                   <span>
-                                    {profile.appCount} apps
-                                  </span>
-                                  <span>
-                                    {profile.tabCount} tabs
-                                  </span>
-                                  <span>
-                                    {profile.fileCount || 0}{" "}
-                                    files
+                                    {formatUnit(profile.fileCount || 0, "file")}
                                   </span>
                                   <span>
                                     ~
-                                    {
-                                      profile.estimatedStartupTime
-                                    }
+                                    {profile.estimatedStartupTime}
                                     s
                                   </span>
                                 </div>
@@ -1068,94 +1122,70 @@ export default function App() {
                   </div>
                 </div>
 
-                {/* MOVED: Action buttons with edit/save button first */}
-                <div className="flex flex-col items-end gap-2">
-                  <div className="flex items-center gap-2 md:gap-3 flex-wrap justify-end">
+                <div className="flex shrink-0 flex-col items-stretch gap-2 sm:items-end">
+                  <div className="flex flex-wrap items-center justify-end gap-2 md:gap-2.5">
                     <button
+                      type="button"
                       onClick={() => setIsEditMode(!isEditMode)}
-                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out ${
+                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-all duration-150 ease-out md:px-4 md:py-2.5 md:text-sm ${
                         isEditMode
-                          ? "bg-flow-accent-blue text-flow-text-primary border border-flow-accent-blue/80 hover:bg-flow-accent-blue-hover shadow-md ring-1 ring-flow-accent-blue/25"
-                          : "bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50"
+                          ? "border border-flow-accent-blue/80 bg-flow-accent-blue text-flow-text-primary shadow-md ring-1 ring-flow-accent-blue/25 hover:bg-flow-accent-blue-hover"
+                          : "border border-flow-border/60 bg-flow-surface/90 text-flow-text-secondary hover:border-flow-border-accent/50 hover:bg-flow-surface-elevated hover:text-flow-text-primary"
                       }`}
                     >
                       {isEditMode ? (
-                        <Save className="w-4 h-4" />
+                        <Save className="h-4 w-4 shrink-0" />
                       ) : (
-                        <Edit className="w-4 h-4" />
+                        <Edit className="h-4 w-4 shrink-0" />
                       )}
-                      {isEditMode
-                        ? "Save Profile"
-                        : "Edit Profile"}
+                      {isEditMode ? "Save Profile" : "Edit Profile"}
                     </button>
-                    <button
-                      onClick={() =>
-                        setSelectedProfileForSettings(
-                          currentProfile.id,
-                        )
+                    <ProfileHeaderOverflowMenu
+                      disabled={isEditMode}
+                      onSettings={() =>
+                        setSelectedProfileForSettings(currentProfile.id)
                       }
-                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50"
-                      title="Profile Settings"
-                    >
-                      <Settings className="w-4 h-4" />
-                      Settings
-                    </button>
-                    <button
-                      onClick={handleLaunch}
-                      disabled={isLaunching || isEditMode}
-                      className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/90 disabled:opacity-50 shadow-sm"
-                    >
-                      {isLaunching ? (
-                        <>
-                          <div className="w-4 h-4 border-2 border-flow-text-primary/30 border-t-flow-text-primary rounded-full animate-spin" />
-                          Launching...
-                        </>
-                      ) : (
-                        <>
-                          <Play className="w-4 h-4" />
-                          Launch Profile
-                        </>
-                      )}
-                    </button>
-                    {(isLaunching
-                      || launchFeedback.status === "in-progress"
-                      || launchFeedback.status === "warning")
-                      && window.electron?.cancelProfileLaunch ? (
-                        <button
-                          type="button"
-                          onClick={() => void handleCancelLaunch()}
-                          disabled={isEditMode}
-                          className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out bg-flow-surface/90 border border-flow-border/60 text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50 disabled:opacity-50"
-                        >
-                          <X className="w-4 h-4" />
-                          Cancel launch
-                        </button>
-                      ) : null}
+                      onDuplicate={() => duplicateProfile(currentProfile.id)}
+                      onDelete={() => deleteProfile(currentProfile.id)}
+                      onNewProfile={() => setShowCreateProfile(true)}
+                    />
+                    <LaunchControl
+                      isEditMode={isEditMode}
+                      isLaunching={isLaunching}
+                      onLaunch={handleLaunch}
+                      onCancel={handleCancelLaunch}
+                      showCancel={launchControlShowCancel}
+                    />
                   </div>
-                  {launchFeedback.status !== "idle" && (
+                  {showLaunchFeedbackStrip ? (
                     <div
-                      className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs ${
+                      className={`inline-flex max-w-full items-center gap-2 rounded-md border px-3 py-1.5 text-xs ${
                         launchFeedback.status === "success"
                           ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-300"
                           : launchFeedback.status === "warning"
                             ? "border-amber-400/40 bg-amber-500/10 text-amber-300"
-                          : launchFeedback.status === "error"
-                            ? "border-rose-400/40 bg-rose-500/10 text-rose-300"
-                            : "border-flow-border-accent bg-flow-surface-elevated text-flow-text-secondary"
+                            : launchFeedback.status === "error"
+                              ? "border-rose-400/40 bg-rose-500/10 text-rose-300"
+                              : "border-flow-border-accent bg-flow-surface-elevated text-flow-text-secondary"
                       }`}
                     >
                       {launchFeedback.status === "success" ? (
-                        <Check className="w-3.5 h-3.5" />
+                        <Check className="h-3.5 w-3.5 shrink-0" />
                       ) : launchFeedback.status === "warning" ? (
-                        <AlertTriangle className="w-3.5 h-3.5" />
+                        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
                       ) : launchFeedback.status === "error" ? (
-                        <X className="w-3.5 h-3.5" />
+                        <X className="h-3.5 w-3.5 shrink-0" />
                       ) : (
-                        <div className="w-3.5 h-3.5 border border-current border-t-transparent rounded-full animate-spin" />
+                        <div
+                          className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border border-current border-t-transparent"
+                          aria-hidden
+                        />
                       )}
-                      <span>{launchFeedback.message}</span>
+                      <span className="min-w-0 break-words text-left">
+                        {launchFeedback.message}
+                      </span>
                     </div>
-                  )}
+                  ) : null}
                 </div>
               </div>
             </header>

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -3,8 +3,11 @@ import {
   useRef,
   useCallback,
   useEffect,
+  useMemo,
 } from "react";
 import { LaunchControl } from "./components/LaunchControl";
+import { TitleBarAppMenu } from "./components/TitleBarAppMenu";
+import { AppChromeModals } from "./components/AppChromeModals";
 import { ProfileHeaderOverflowMenu } from "./components/ProfileHeaderOverflowMenu";
 import { ProfileCard } from "./components/ProfileCard";
 import { MonitorLayout } from "./components/MonitorLayout";
@@ -18,22 +21,19 @@ import {
   Plus,
   Settings,
   Edit,
-  Save,
+  PenLine,
   Clock,
   Zap,
-  Upload,
-  Download,
   LayoutGrid,
   Link,
+  Users,
+  Search,
   ArrowRight,
   ChevronRight,
   ChevronLeft,
   X,
   Check,
   AlertTriangle,
-  Layers,
-  Folder,
-  Globe,
 } from "lucide-react";
 import { DragState } from "./types/dragTypes";
 import { safeIconSrc } from "../utils/safeIconSrc";
@@ -54,7 +54,7 @@ import {
   useMainLayoutProfileMutations,
   type MainLayoutSelectedApp,
 } from "./hooks/useMainLayoutProfileMutations";
-import { ProfileIconGlyph } from "./utils/profileHeaderPresentation";
+import { ProfileIconFrame } from "./utils/profileHeaderPresentation";
 import { formatUnit } from "../utils/pluralize";
 
 const GENERIC_LAUNCH_PROFILE_MESSAGE = "Launching profile...";
@@ -76,13 +76,6 @@ export default function App() {
   const [isLaunching, setIsLaunching] = useState(false);
   const { launchFeedback, setLaunchFeedback, launchFeedbackTimeoutRef } =
     useLaunchFeedback();
-  const { handleLaunch, handleCancelLaunch } = useProfileLaunch({
-    profiles,
-    selectedProfileId: selectedProfile,
-    setIsLaunching,
-    setLaunchFeedback,
-    launchFeedbackTimeoutRef,
-  });
   const [isEditMode, setIsEditMode] = useState(false);
   const isEditModeRef = useRef(false);
   const [
@@ -91,6 +84,10 @@ export default function App() {
   ] = useState<string | null>(null);
   const [showCreateProfile, setShowCreateProfile] =
     useState(false);
+  const [appChromeModal, setAppChromeModal] = useState<
+    null | "preferences" | "about"
+  >(null);
+  const [sidebarSearchQuery, setSidebarSearchQuery] = useState("");
   const [currentView, setCurrentView] = useState<
     "profiles" | "apps" | "content"
   >("profiles");
@@ -124,6 +121,31 @@ export default function App() {
   const currentProfile = profiles.find(
     (p) => p.id === selectedProfile,
   ) || null;
+
+  useEffect(() => {
+    setSidebarSearchQuery("");
+  }, [currentView]);
+
+  const filteredProfiles = useMemo(() => {
+    const q = sidebarSearchQuery.trim().toLowerCase();
+    if (!q) return profiles;
+    return profiles.filter((p) => p.name.toLowerCase().includes(q));
+  }, [profiles, sidebarSearchQuery]);
+
+  const profileLaunchSummaryParts = useMemo(() => {
+    if (!currentProfile) return [] as string[];
+    const parts: string[] = [];
+    if (currentProfile.appCount > 0) {
+      parts.push(formatUnit(currentProfile.appCount, "app"));
+    }
+    if (currentProfile.tabCount > 0) {
+      parts.push(formatUnit(currentProfile.tabCount, "tab"));
+    }
+    if ((currentProfile.fileCount || 0) > 0) {
+      parts.push(formatUnit(currentProfile.fileCount || 0, "file"));
+    }
+    return parts;
+  }, [currentProfile]);
   const profileForSettings = profiles.find(
     (p) => p.id === selectedProfileForSettings,
   ) || null;
@@ -188,6 +210,19 @@ export default function App() {
     setSelectedApp,
     currentProfile,
     profileDragActionsRef,
+  });
+
+  const { handleLaunch, handleCancelLaunch } = useProfileLaunch({
+    profiles,
+    selectedProfileId: selectedProfile,
+    setIsLaunching,
+    setLaunchFeedback,
+    launchFeedbackTimeoutRef,
+    onLaunchCompletedDuration: (profileId, durationSeconds) => {
+      updateProfile(profileId, {
+        estimatedStartupTime: durationSeconds,
+      });
+    },
   });
 
   // SELECTED APP HANDLERS
@@ -639,107 +674,38 @@ export default function App() {
           Autosave is disabled until you restart the app after the issue is resolved, to avoid overwriting your data.
         </div>
       ) : null}
-      <div className="app-drag-region h-9 px-3 flow-shell-titlebar flex items-center justify-between select-none">
-        <div className="flex items-center gap-2">
-          <img
-            src="/flowswitch-logo.png"
-            alt="FlowSwitch logo"
-            className="h-8 w-8 rounded-md object-contain"
-          />
-        </div>
-        <span className="text-[11px] text-flow-text-muted tracking-wide">
-          Workspace automation
-        </span>
+      <div className="app-drag-region flow-shell-titlebar flex h-9 shrink-0 items-stretch px-2 select-none md:px-3">
+        <TitleBarAppMenu
+          onAppPreferences={() => setAppChromeModal("preferences")}
+          onAbout={() => setAppChromeModal("about")}
+        />
+        <div className="min-h-0 min-w-0 flex-1" aria-hidden />
       </div>
+      <input
+        type="file"
+        accept=".json"
+        onChange={importProfile}
+        className="hidden"
+        id="flowswitch-import-profile"
+        aria-hidden
+      />
       <div className="flex h-[calc(100vh-2.25rem)]">
         {/* Left Sidebar - FIXED: Better height management */}
         <div className="w-[clamp(16rem,24vw,24rem)] min-w-[16rem] flow-shell-nav flex flex-col">
-          {/* Header - Fixed height */}
-          <div className="flex-shrink-0 border-b border-flow-border/50 px-4 py-2 md:px-6">
-            <div className="mb-2 flex items-center justify-between md:mb-2.5">
-              <div>
-                <h1 className="text-base text-flow-text-primary font-semibold tracking-tight">
-                  FlowSwitch
-                </h1>
-                <p className="text-[11px] text-flow-text-muted mt-0.5">
-                  Profiles, apps, layouts
-                </p>
-              </div>
-              <div
-                className="flex items-center gap-0.5 rounded-lg border border-flow-border/45 bg-flow-surface/35 p-0.5"
-                role="toolbar"
-                aria-label="Profile file actions"
-              >
-                <input
-                  type="file"
-                  accept=".json"
-                  onChange={importProfile}
-                  className="hidden"
-                  id="import-profile"
-                />
-                <label
-                  htmlFor="import-profile"
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out cursor-pointer"
-                  title="Import profile"
-                  aria-label="Import profile"
-                >
-                  <Upload className="w-3.5 h-3.5" />
-                </label>
-                <button
-                  type="button"
-                  onClick={() =>
-                    currentProfile &&
-                    exportProfile(currentProfile.id)
-                  }
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out disabled:opacity-40 disabled:pointer-events-none"
-                  title={
-                    currentProfile
-                      ? "Export current profile"
-                      : "Select a profile to export"
-                  }
-                  aria-label="Export current profile"
-                  disabled={!currentProfile}
-                >
-                  <Download className="w-3.5 h-3.5" />
-                </button>
-                <span
-                  className="mx-0.5 h-4 w-px shrink-0 bg-flow-border/50"
-                  aria-hidden="true"
-                />
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (currentProfile) {
-                      setSelectedProfileForSettings(currentProfile.id);
-                    }
-                  }}
-                  disabled={!currentProfile}
-                  className="inline-flex items-center justify-center p-1.5 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-md transition-all duration-150 ease-out disabled:opacity-40 disabled:pointer-events-none"
-                  title={
-                    currentProfile
-                      ? "Profile settings"
-                      : "Select a profile for settings"
-                  }
-                  aria-label="Open profile settings"
-                >
-                  <Settings className="w-3.5 h-3.5" />
-                </button>
-              </div>
-            </div>
-
-            {/* View Toggle - Compact */}
-            <div className="flow-segment-track" role="tablist" aria-label="Sidebar view">
+          <div className="flex shrink-0 flex-col gap-2 border-b border-white/[0.06] px-3 py-2.5 md:px-4">
+            <div className="flow-nav-tab-strip" role="tablist" aria-label="Sidebar view">
               <button
                 type="button"
                 role="tab"
                 aria-selected={currentView === "profiles"}
                 onClick={() => setCurrentView("profiles")}
-                className={`flow-segment-tab px-2 py-1.5 ${
+                className={`flow-nav-tab ${
                   currentView === "profiles"
-                    ? "flow-segment-tab-active"
-                    : "flow-segment-tab-idle"
+                    ? "flow-nav-tab-active"
+                    : "flow-nav-tab-idle"
                 }`}
               >
+                <Users className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
                 Profiles
               </button>
               <button
@@ -747,13 +713,13 @@ export default function App() {
                 role="tab"
                 aria-selected={currentView === "apps"}
                 onClick={() => setCurrentView("apps")}
-                className={`flow-segment-tab flex items-center justify-center gap-1 px-2 py-1.5 ${
+                className={`flow-nav-tab ${
                   currentView === "apps"
-                    ? "flow-segment-tab-active"
-                    : "flow-segment-tab-idle"
+                    ? "flow-nav-tab-active"
+                    : "flow-nav-tab-idle"
                 }`}
               >
-                <LayoutGrid className="w-3 h-3 shrink-0" />
+                <LayoutGrid className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
                 Apps
               </button>
               <button
@@ -761,15 +727,42 @@ export default function App() {
                 role="tab"
                 aria-selected={currentView === "content"}
                 onClick={() => setCurrentView("content")}
-                className={`flow-segment-tab flex items-center justify-center gap-1 px-2 py-1.5 ${
+                className={`flow-nav-tab ${
                   currentView === "content"
-                    ? "flow-segment-tab-active"
-                    : "flow-segment-tab-idle"
+                    ? "flow-nav-tab-active"
+                    : "flow-nav-tab-idle"
                 }`}
               >
-                <Link className="w-3 h-3 shrink-0" />
+                <Link className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
                 Content
               </button>
+            </div>
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-flow-text-muted"
+                strokeWidth={1.75}
+                aria-hidden
+              />
+              <input
+                type="search"
+                value={sidebarSearchQuery}
+                onChange={(e) => setSidebarSearchQuery(e.target.value)}
+                placeholder={
+                  currentView === "profiles"
+                    ? "Search profiles…"
+                    : currentView === "apps"
+                      ? "Search apps…"
+                      : "Search content…"
+                }
+                className="flow-sidebar-search"
+                aria-label={
+                  currentView === "profiles"
+                    ? "Search profiles"
+                    : currentView === "apps"
+                      ? "Search apps"
+                      : "Search content"
+                }
+              />
             </div>
           </div>
 
@@ -777,11 +770,18 @@ export default function App() {
           <div className="flex-1 min-h-0 flex flex-col">
             {currentView === "profiles" && (
               <div className="flex-1 flex flex-col min-h-0">
-                <div className="flex-shrink-0 p-3 border-b border-flow-border/50">
+                <div className="flex-shrink-0 border-b border-flow-border/50 p-3">
                   <div className="flex items-center justify-between">
-                    <h2 className="flow-section-label">
-                      Profiles
-                    </h2>
+                    <div className="flex items-center gap-2">
+                      <Users
+                        className="h-3.5 w-3.5 shrink-0 text-flow-text-muted"
+                        strokeWidth={1.75}
+                        aria-hidden
+                      />
+                      <h2 className="flow-sidebar-section-title">
+                        Profiles
+                      </h2>
+                    </div>
                     <button
                       onClick={() => setShowCreateProfile(true)}
                       disabled={isEditMode}
@@ -816,49 +816,57 @@ export default function App() {
 
                 <div className="flex-1 overflow-y-auto scrollbar-elegant p-3">
                   <div className="space-y-2.5">
-                    {profiles.map((profile) => (
-                      <ProfileCard
-                        key={profile.id}
-                        profile={{
-                          ...profile,
-                          isActive:
-                            profile.id === selectedProfile,
-                        }}
-                        onClick={() =>
-                          handleProfileSwitch(profile.id)
-                        }
-                        onSettings={
-                          isEditMode
-                            ? undefined
-                            : () =>
-                                setSelectedProfileForSettings(
-                                  profile.id,
-                                )
-                        }
-                        onDuplicate={
-                          isEditMode
-                            ? undefined
-                            : () => duplicateProfile(profile.id)
-                        }
-                        onDelete={
-                          isEditMode
-                            ? undefined
-                            : () => deleteProfile(profile.id)
-                        }
-                        onExport={
-                          isEditMode
-                            ? undefined
-                            : () => exportProfile(profile.id)
-                        }
-                        onSetOnStartup={
-                          isEditMode
-                            ? undefined
-                            : () =>
-                                setOnStartupProfile(profile.id)
-                        }
-                        disabled={isEditMode}
-                      />
-                    ))}
+                    {filteredProfiles.length === 0 ? (
+                      <p className="py-6 text-center text-xs text-flow-text-muted">
+                        {profiles.length === 0
+                          ? "No profiles yet. Create one with New."
+                          : "No profiles match this search."}
+                      </p>
+                    ) : (
+                      filteredProfiles.map((profile) => (
+                        <ProfileCard
+                          key={profile.id}
+                          profile={{
+                            ...profile,
+                            isActive:
+                              profile.id === selectedProfile,
+                          }}
+                          onClick={() =>
+                            handleProfileSwitch(profile.id)
+                          }
+                          onSettings={
+                            isEditMode
+                              ? undefined
+                              : () =>
+                                  setSelectedProfileForSettings(
+                                    profile.id,
+                                  )
+                          }
+                          onDuplicate={
+                            isEditMode
+                              ? undefined
+                              : () => duplicateProfile(profile.id)
+                          }
+                          onDelete={
+                            isEditMode
+                              ? undefined
+                              : () => deleteProfile(profile.id)
+                          }
+                          onExport={
+                            isEditMode
+                              ? undefined
+                              : () => exportProfile(profile.id)
+                          }
+                          onSetOnStartup={
+                            isEditMode
+                              ? undefined
+                              : () =>
+                                  setOnStartupProfile(profile.id)
+                          }
+                          disabled={isEditMode}
+                        />
+                      ))
+                    )}
                   </div>
                 </div>
               </div>
@@ -881,6 +889,8 @@ export default function App() {
                   onCustomDragStart={handleCustomDragStart}
                   currentProfile={currentProfile}
                   compact={true}
+                  sidebarSearchQuery={sidebarSearchQuery}
+                  onSidebarSearchQueryChange={setSidebarSearchQuery}
                 />
               </div>
             )}
@@ -894,6 +904,8 @@ export default function App() {
                   onDragStart={handleDragStart}
                   onCustomDragStart={handleCustomDragStart}
                   compact={true}
+                  sidebarSearchQuery={sidebarSearchQuery}
+                  onSidebarSearchQueryChange={setSidebarSearchQuery}
                 />
               </div>
             )}
@@ -908,88 +920,68 @@ export default function App() {
         >
           {/* Header - Spans across Main Content and Right Sidebar area */}
           {currentProfile ? (
-            <header className="relative z-10 shrink-0 border-b border-flow-border/50 bg-flow-bg-secondary/80 px-4 py-2 backdrop-blur-sm md:px-6 xl:px-8">
-              <div className="flex min-w-0 flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-3">
+            <header className="relative z-10 flex min-h-[5.75rem] shrink-0 items-center border-b border-white/[0.06] bg-flow-bg-secondary/90 px-4 py-3 backdrop-blur-sm md:px-6 xl:px-8">
+              <div className="flex w-full min-w-0 flex-col gap-3 lg:flex-row lg:items-center lg:justify-between lg:gap-4">
                 <div
-                  className={`flex min-w-0 flex-1 items-center gap-2 ${
+                  className={`flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center lg:gap-6 ${
                     isEditMode ? "opacity-50" : ""
                   }`}
                   aria-label="Active profile"
                 >
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-flow-border/35 bg-flow-bg-tertiary/70">
-                    <ProfileIconGlyph
-                      icon={currentProfile.icon}
-                      className="h-4 w-4 text-flow-text-secondary"
-                    />
+                  <div className="flex min-w-0 flex-wrap items-start gap-3">
+                    <div className="ring-2 ring-flow-accent-blue/35 ring-offset-2 ring-offset-flow-bg-secondary rounded-xl">
+                      <ProfileIconFrame icon={currentProfile.icon} />
+                    </div>
+                    <div className="flex min-w-0 flex-col gap-1.5">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <h2 className="min-w-0 truncate text-xl font-extrabold tracking-tight text-flow-text-primary md:text-2xl">
+                          {currentProfile.name}
+                        </h2>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {currentProfile.autoLaunchOnBoot && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-emerald-500/[0.14] px-2 py-0.5 text-[11px] font-medium text-emerald-200/95">
+                            <Zap className="h-3 w-3 shrink-0" strokeWidth={1.75} />
+                            Boot
+                          </span>
+                        )}
+                        {currentProfile.autoSwitchTime && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-violet-500/[0.14] px-2 py-0.5 text-[11px] font-medium text-violet-100/90">
+                            <Clock className="h-3 w-3 shrink-0" strokeWidth={1.75} />
+                            {currentProfile.autoSwitchTime}
+                          </span>
+                        )}
+                        {currentProfile.hotkey && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-sky-500/[0.14] px-2 py-0.5 text-[11px] font-medium text-sky-100/90">
+                            {currentProfile.hotkey}
+                          </span>
+                        )}
+                      </div>
+                    </div>
                   </div>
-                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-1">
-                    <h2 className="max-w-[min(100%,14rem)] truncate text-sm font-semibold tracking-tight text-flow-text-primary sm:max-w-[22rem] md:text-base">
-                      {currentProfile.name}
-                    </h2>
-                    {currentProfile.autoLaunchOnBoot && (
-                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-green/30 bg-flow-accent-green/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-green">
-                        <Zap className="h-2.5 w-2.5 shrink-0" />
-                        Boot
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2.5 lg:gap-3">
+                    <div className="inline-flex items-center gap-2 rounded-lg bg-amber-500/[0.09] px-3 py-1.5 text-xs font-medium text-amber-100/95">
+                      <Clock className="h-3.5 w-3.5 shrink-0 text-amber-200/90" strokeWidth={1.75} aria-hidden />
+                      <span>
+                        ~{currentProfile.estimatedStartupTime}s startup
+                        {currentProfile.launchOrder === "sequential"
+                          ? " · sequential"
+                          : ""}
                       </span>
-                    )}
-                    {currentProfile.autoSwitchTime && (
-                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-purple/30 bg-flow-accent-purple/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-purple">
-                        <Clock className="h-2.5 w-2.5 shrink-0" />
-                        {currentProfile.autoSwitchTime}
-                      </span>
-                    )}
-                    {currentProfile.hotkey && (
-                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-accent-blue/30 bg-flow-accent-blue/15 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-accent-blue">
-                        {currentProfile.hotkey}
-                      </span>
-                    )}
-                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
-                      <Zap className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
-                      ~{currentProfile.estimatedStartupTime}s
-                    </span>
-                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
-                      <Layers className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
-                      {formatUnit(currentProfile.appCount, "app")}
-                    </span>
-                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
-                      <Globe className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
-                      {formatUnit(currentProfile.tabCount, "tab")}
-                    </span>
-                    <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
-                      <Folder className="h-2.5 w-2.5 shrink-0 opacity-80" aria-hidden />
-                      {formatUnit(
-                        currentProfile.fileCount || 0,
-                        "file",
-                      )}
-                    </span>
-                    {currentProfile.launchOrder === "sequential" ? (
-                      <span className="inline-flex items-center gap-0.5 rounded-full border border-flow-border/35 bg-flow-bg-tertiary/50 px-1.5 py-0 text-[10px] font-medium leading-tight text-flow-text-muted">
-                        Sequential
-                      </span>
-                    ) : null}
+                    </div>
                   </div>
                 </div>
 
-                <div className="flex shrink-0 flex-col items-stretch gap-2 sm:items-end">
-                  <div className="flex flex-wrap items-center justify-end gap-2 md:gap-2.5">
-                    <button
-                      type="button"
-                      onClick={() => setIsEditMode(!isEditMode)}
-                      className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-medium transition-all duration-150 ease-out md:px-4 md:py-2.5 md:text-sm ${
-                        isEditMode
-                          ? "border border-flow-accent-blue/80 bg-flow-accent-blue text-flow-text-primary shadow-md ring-1 ring-flow-accent-blue/25 hover:bg-flow-accent-blue-hover"
-                          : "border border-flow-border/60 bg-flow-surface/90 text-flow-text-secondary hover:border-flow-border-accent/50 hover:bg-flow-surface-elevated hover:text-flow-text-primary"
-                      }`}
-                    >
-                      {isEditMode ? (
-                        <Save className="h-4 w-4 shrink-0" />
-                      ) : (
-                        <Edit className="h-4 w-4 shrink-0" />
-                      )}
-                      {isEditMode ? "Save Profile" : "Edit Profile"}
-                    </button>
+                <div className="flex shrink-0 flex-col items-stretch gap-2 sm:items-end lg:items-center">
+                  <div className="flex flex-wrap items-center justify-end gap-2 lg:gap-2.5">
                     <ProfileHeaderOverflowMenu
                       disabled={isEditMode}
+                      importInputId="flowswitch-import-profile"
+                      exportDisabled={!currentProfile}
+                      onExport={() =>
+                        currentProfile &&
+                        exportProfile(currentProfile.id)
+                      }
                       onSettings={() =>
                         setSelectedProfileForSettings(currentProfile.id)
                       }
@@ -1003,6 +995,7 @@ export default function App() {
                       onLaunch={handleLaunch}
                       onCancel={handleCancelLaunch}
                       showCancel={launchControlShowCancel}
+                      profileSummaryParts={profileLaunchSummaryParts}
                     />
                   </div>
                   {showLaunchFeedbackStrip ? (
@@ -1053,19 +1046,22 @@ export default function App() {
 
                 <div className="flex items-center gap-3">
                   <button
+                    type="button"
                     disabled
+                    title="Select a profile to edit its monitor layout"
                     className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium bg-flow-surface border border-flow-border text-flow-text-muted opacity-60 cursor-not-allowed"
                   >
-                    <Edit className="w-4 h-4" />
-                    Edit Profile
+                    <PenLine className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+                    Edit layout
                   </button>
                   <button
+                    type="button"
                     disabled
+                    title="Select a profile for preferences and import/export"
                     className="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium bg-flow-surface border border-flow-border text-flow-text-muted opacity-60 cursor-not-allowed"
-                    title="Profile Settings"
                   >
                     <Settings className="w-4 h-4" />
-                    Settings
+                    Preferences
                   </button>
                   <button
                     disabled
@@ -1082,13 +1078,17 @@ export default function App() {
           {/* Main Content Area */}
           {currentProfile && (
             <main className="flex-1 overflow-hidden relative flow-shell-canvas">
-              <div className="h-full px-4 md:px-6 xl:px-8 py-4 md:py-6">
+              <div className="h-full px-4 pb-4 pt-0 md:px-6 md:pb-6 xl:px-8">
                 <MonitorLayout
                   monitors={currentProfile.monitors}
                   minimizedApps={currentProfile.minimizedApps}
                   minimizedFiles={[]} // REMOVED: No more standalone files
                   browserTabs={currentProfile.browserTabs}
                   isEditMode={isEditMode}
+                  onToggleLayoutEdit={() =>
+                    setIsEditMode((prev) => !prev)
+                  }
+                  layoutToolbarConnected
                   dragState={dragState}
                   selectedApp={selectedApp}
                   onUpdateApp={(monitorId, appIndex, updates) =>
@@ -1399,6 +1399,13 @@ export default function App() {
             setProfiles((prev) => [...prev, newProfile]);
             setShowCreateProfile(false);
           }}
+        />
+
+        <AppChromeModals
+          preferencesOpen={appChromeModal === "preferences"}
+          aboutOpen={appChromeModal === "about"}
+          onClosePreferences={() => setAppChromeModal(null)}
+          onCloseAbout={() => setAppChromeModal(null)}
         />
       </div>
     </div>

--- a/src/renderer/layout/components/AppChromeModals.tsx
+++ b/src/renderer/layout/components/AppChromeModals.tsx
@@ -1,0 +1,115 @@
+import { X } from "lucide-react";
+
+const APP_VERSION = "0.1.0";
+
+type AppChromeModalsProps = {
+  preferencesOpen: boolean;
+  aboutOpen: boolean;
+  onClosePreferences: () => void;
+  onCloseAbout: () => void;
+};
+
+export function AppChromeModals({
+  preferencesOpen,
+  aboutOpen,
+  onClosePreferences,
+  onCloseAbout,
+}: AppChromeModalsProps) {
+  return (
+    <>
+      {preferencesOpen ? (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/55 p-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="app-prefs-title"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) onClosePreferences();
+          }}
+        >
+          <div className="app-no-drag w-full max-w-md overflow-hidden rounded-xl border border-white/[0.1] bg-flow-bg-secondary shadow-2xl">
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-3">
+              <h2
+                id="app-prefs-title"
+                className="text-base font-semibold text-flow-text-primary"
+              >
+                App preferences
+              </h2>
+              <button
+                type="button"
+                onClick={onClosePreferences}
+                className="rounded-lg p-2 text-flow-text-secondary hover:bg-white/[0.06] hover:text-flow-text-primary"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" strokeWidth={1.75} />
+              </button>
+            </div>
+            <div className="px-4 py-4 text-sm leading-relaxed text-flow-text-secondary">
+              Global options (startup behavior, defaults, and updates) will live
+              here as the app grows. Profile-specific options stay under the
+              profile menu (⋯) → Profile preferences.
+            </div>
+            <div className="flex justify-end border-t border-white/[0.06] px-4 py-3">
+              <button
+                type="button"
+                onClick={onClosePreferences}
+                className="rounded-lg bg-flow-accent-blue px-4 py-2 text-sm font-medium text-flow-text-primary hover:bg-flow-accent-blue-hover"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {aboutOpen ? (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/55 p-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="about-title"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) onCloseAbout();
+          }}
+        >
+          <div className="app-no-drag w-full max-w-md overflow-hidden rounded-xl border border-white/[0.1] bg-flow-bg-secondary shadow-2xl">
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-3">
+              <h2
+                id="about-title"
+                className="text-base font-semibold text-flow-text-primary"
+              >
+                About FlowSwitch
+              </h2>
+              <button
+                type="button"
+                onClick={onCloseAbout}
+                className="rounded-lg p-2 text-flow-text-secondary hover:bg-white/[0.06] hover:text-flow-text-primary"
+                aria-label="Close"
+              >
+                <X className="h-5 w-5" strokeWidth={1.75} />
+              </button>
+            </div>
+            <div className="flex flex-col gap-3 px-4 py-4 text-sm leading-relaxed text-flow-text-secondary">
+              <p className="text-flow-text-primary">
+                Version <span className="tabular-nums">{APP_VERSION}</span>
+              </p>
+              <p>
+                FlowSwitch captures monitor layouts and launches your workspace
+                profiles on demand.
+              </p>
+            </div>
+            <div className="flex justify-end border-t border-white/[0.06] px-4 py-3">
+              <button
+                type="button"
+                onClick={onCloseAbout}
+                className="rounded-lg bg-flow-accent-blue px-4 py-2 text-sm font-medium text-flow-text-primary hover:bg-flow-accent-blue-hover"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { safeIconSrc } from "../../utils/safeIconSrc";
-import { Search, Settings, Trash2, Power, Save, Move } from "lucide-react";
+import { Search, Settings, Trash2, Power, Save, Move, LayoutGrid } from "lucide-react";
 import { useInstalledApps } from "../../hooks/useInstalledApps";
 
 interface AppManagerProps {
@@ -12,6 +12,9 @@ interface AppManagerProps {
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
   currentProfile?: any;
   compact?: boolean;
+  /** When both set with `compact`, hides the local search field and uses this query. */
+  sidebarSearchQuery?: string;
+  onSidebarSearchQueryChange?: (query: string) => void;
 }
 
 
@@ -53,9 +56,18 @@ export function AppManager({
   onDragStart,
   onCustomDragStart,
   currentProfile, 
-  compact = false 
+  compact = false,
+  sidebarSearchQuery,
+  onSidebarSearchQueryChange,
 }: AppManagerProps) {
   const [searchTerm, setSearchTerm] = useState('');
+  const sidebarSearchControlled =
+    Boolean(compact)
+    && typeof sidebarSearchQuery === "string"
+    && typeof onSidebarSearchQueryChange === "function";
+  const effectiveSearchTerm = sidebarSearchControlled
+    ? sidebarSearchQuery
+    : searchTerm;
   const [selectedApp, setSelectedApp] = useState<any>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [showAppSettings, setShowAppSettings] = useState(false);
@@ -80,10 +92,14 @@ export function AppManager({
     return { lastAccessed: 0, size: 0 };
   }
 
-  const categories = Array.from(new Set(allApps.map(app => app.category)));
-  let filteredApps = allApps.filter(app => {
-    const matchesSearch = app.name.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = !selectedCategory || app.category === selectedCategory;
+  let filteredApps = allApps.filter((app) => {
+    const matchesSearch = app.name
+      .toLowerCase()
+      .includes(effectiveSearchTerm.toLowerCase());
+    const matchesCategory =
+      compact
+      || !selectedCategory
+      || app.category === selectedCategory;
     return matchesSearch && matchesCategory;
   });
 
@@ -221,79 +237,41 @@ export function AppManager({
 
   if (compact) {
     return (
-      <div className="p-4">
-        {/* Header - CLEAN: Consistent with UI */}
-        <div className="flex items-center justify-between mb-3">
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex shrink-0 items-center justify-between border-b border-flow-border/50 px-3 py-3">
           <div className="flex items-center gap-2">
-            <Settings className="w-3.5 h-3.5 text-flow-text-muted" />
-            <h2 className="text-[11px] font-medium text-flow-text-secondary uppercase tracking-wider">Apps</h2>
-          </div>
-          <span className="text-flow-text-muted text-xs">{filteredApps.length} available</span>
-        </div>
-
-        {/* Search and Filters - CLEAN: Consistent with content section */}
-
-        <div className="space-y-3 mb-4">
-          {/* Search Bar */}
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-3 h-3 text-flow-text-muted" />
-            <input
-              type="text"
-              placeholder="Search apps..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 pr-3 py-2 bg-flow-surface border border-flow-border rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
+            <LayoutGrid
+              className="h-3.5 w-3.5 shrink-0 text-flow-text-muted"
+              strokeWidth={1.75}
+              aria-hidden
             />
+            <h2 className="flow-sidebar-section-title">Apps</h2>
           </div>
-
-          {/* Category and Sort Filter - Compact design */}
-          <div className="flex items-center gap-2">
-            <select
-              value={selectedCategory || ''}
-              onChange={(e) => setSelectedCategory(e.target.value || null)}
-              className="flex-1 px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-              title="Filter by category"
-            >
-              <option value="">All</option>
-              {categories.map((cat) => (
-                <option key={cat || 'other'} value={cat || ''}>{cat || 'Other'}</option>
-              ))}
-            </select>
-            <select
-              value={sortOption}
-              onChange={e => setSortOption(e.target.value as 'name' | 'lastAccessed' | 'size')}
-              className="px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-              title="Sort apps"
-            >
-              <option value="name">A-Z</option>
-              <option value="lastAccessed">Last Opened</option>
-              <option value="size">Size</option>
-            </select>
-            <button
-              onClick={() => setExpandedApp(expandedApp ? null : 'toggle-all')}
-              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded transition-colors ${
-                expandedApp
-                  ? 'bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30'
-                  : 'bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent'
-              }`}
-              title="Show app details"
-            >
-              <Settings className="w-3 h-3" />
-              <span className="whitespace-nowrap">Details</span>
-            </button>
-          </div>
+          <span className="flow-sidebar-meta">{filteredApps.length} available</span>
         </div>
 
-        {/* Drag Instructions - Compact */}
-        <div className="rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3 mb-4">
-          <div className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
-            <Move className="w-3.5 h-3.5 text-flow-accent-blue shrink-0" />
-            <span>Drag apps onto a monitor or into the minimized row.</span>
-          </div>
-        </div>
+        <div className="flex min-h-0 flex-1 flex-col px-3 pb-3 pt-3">
+          {!sidebarSearchControlled ? (
+            <div className="relative mb-3">
+              <Search className="absolute left-3 top-1/2 h-3 w-3 -translate-y-1/2 transform text-flow-text-muted" />
+              <input
+                type="text"
+                placeholder="Search apps..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="flow-sidebar-search w-full py-2 pl-9 pr-3"
+              />
+            </div>
+          ) : null}
 
-        {/* App List - CLEAN: Smart scrolling with elegant scrollbar, no horizontal scroll */}
-        <div className="space-y-2 max-h-[60vh] overflow-y-auto overflow-x-hidden scrollbar-elegant">
+          <div className="mb-3 rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3">
+            <div className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
+              <Move className="h-3.5 w-3.5 shrink-0 text-flow-accent-blue" strokeWidth={1.75} />
+              <span>Drag apps onto a monitor or into the minimized row.</span>
+            </div>
+          </div>
+
+        <div className="scrollbar-elegant max-h-[60vh] min-h-0 flex-1 space-y-2 overflow-x-hidden overflow-y-auto">
           {filteredApps.map((app, index) => {
             const usage = getAppUsage(app.name);
             const isExpanded = expandedApp === app.name || expandedApp === 'toggle-all';
@@ -414,6 +392,7 @@ export function AppManager({
               </div>
             );
           })}
+        </div>
         </div>
 
         {/* App Settings Modal */}

--- a/src/renderer/layout/components/ContentManager.tsx
+++ b/src/renderer/layout/components/ContentManager.tsx
@@ -48,6 +48,9 @@ interface ContentManagerProps {
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
   onDragStart?: () => void;
   compact?: boolean;
+  /** When both set with `compact`, hides the local search field and uses this query. */
+  sidebarSearchQuery?: string;
+  onSidebarSearchQueryChange?: (query: string) => void;
 }
 
 // Available apps for users to choose from
@@ -152,11 +155,20 @@ export function ContentManager({
   onUpdateProfile, 
   onCustomDragStart, 
   onDragStart, 
-  compact = false 
+  compact = false,
+  sidebarSearchQuery,
+  onSidebarSearchQueryChange,
 }: ContentManagerProps) {
   const [content, setContent] = useState<ContentItem[]>([]);
   const [folders, setFolders] = useState<ContentFolder[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const sidebarSearchControlled =
+    Boolean(compact)
+    && typeof sidebarSearchQuery === "string"
+    && typeof onSidebarSearchQueryChange === "function";
+  const effectiveSearchQuery = sidebarSearchControlled
+    ? sidebarSearchQuery
+    : searchQuery;
   const [selectedType, setSelectedType] = useState<'all' | 'link' | 'file' | 'folder'>('all');
   const [sortBy, setSortBy] = useState<SortOption>('name');
   const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
@@ -286,8 +298,8 @@ export function ContentManager({
     console.log(`📊 Display results: ${displayFolders.length} folders, ${displayContent.length} items`);
 
     // Apply search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
+    if (effectiveSearchQuery) {
+      const query = effectiveSearchQuery.toLowerCase();
       displayFolders = displayFolders.filter(folder => 
         folder.name.toLowerCase().includes(query)
       );
@@ -1212,83 +1224,121 @@ export function ContentManager({
   const currentFolder = currentFolderId ? folders.find(f => f.id === currentFolderId) : null;
 
   return (
-    <div className="p-4">
+    <div
+      className={
+        compact
+          ? "flex min-h-0 min-w-0 flex-1 flex-col"
+          : "p-4"
+      }
+    >
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          <Link className="w-4 h-4 text-flow-text-muted" />
-          <h2 className="text-sm font-medium text-flow-text-secondary uppercase tracking-wide">Content</h2>
-          
-          {/* Help Tooltip */}
-          <div className="relative">
-            <button
-              onMouseEnter={() => setShowHelpTooltip(true)}
-              onMouseLeave={() => setShowHelpTooltip(false)}
-              className="inline-flex items-center justify-center p-1 text-flow-text-muted hover:text-flow-text-secondary rounded transition-colors"
-              aria-label="Show help"
-            >
-              <Info className="w-3 h-3" />
-            </button>
-            
-            {showHelpTooltip && (
-              <div className="absolute left-0 top-full mt-2 w-64 p-3 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg z-50">
-                <div className="text-xs text-flow-text-secondary font-medium mb-2">Actions:</div>
-                <div className="space-y-1 text-xs text-flow-text-muted">
-                  {getHelpTooltipContent().map((line, index) => (
-                    <div key={index}>{line}</div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-          
+      <div
+        className={`flex items-center justify-between ${
+          compact
+            ? "shrink-0 border-b border-flow-border/50 px-3 py-3"
+            : "mb-4"
+        }`}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <Link
+            className={`shrink-0 text-flow-text-muted ${
+              compact ? "h-3.5 w-3.5" : "h-4 w-4"
+            }`}
+            strokeWidth={1.75}
+            aria-hidden
+          />
+          <h2
+            className={
+              compact
+                ? "flow-sidebar-section-title"
+                : "text-sm font-medium uppercase tracking-wide text-flow-text-secondary"
+            }
+          >
+            Content
+          </h2>
 
-          {currentFolder && selectedType === 'all' && (
-            <span className="text-xs text-flow-text-muted">
-              in {currentFolder.name}
-            </span>
-          )}
-          {(selectedType === 'link' || selectedType === 'file') && (
-            <span className="text-xs text-flow-text-muted">
-              {selectedType}s from all folders
-            </span>
-          )}
+          {!compact ? (
+            <>
+              <div className="relative">
+                <button
+                  type="button"
+                  onMouseEnter={() => setShowHelpTooltip(true)}
+                  onMouseLeave={() => setShowHelpTooltip(false)}
+                  className="inline-flex items-center justify-center rounded p-1 text-flow-text-muted transition-colors hover:text-flow-text-secondary"
+                  aria-label="Show help"
+                >
+                  <Info className="h-3 w-3" />
+                </button>
+
+                {showHelpTooltip && (
+                  <div className="absolute left-0 top-full z-50 mt-2 w-64 rounded-lg border border-flow-border bg-flow-surface-elevated p-3 shadow-lg">
+                    <div className="mb-2 text-xs font-medium text-flow-text-secondary">
+                      Actions:
+                    </div>
+                    <div className="space-y-1 text-xs text-flow-text-muted">
+                      {getHelpTooltipContent().map((line, index) => (
+                        <div key={index}>{line}</div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {currentFolder && selectedType === "all" && (
+                <span className="text-xs text-flow-text-muted">
+                  in {currentFolder.name}
+                </span>
+              )}
+              {(selectedType === "link" || selectedType === "file") && (
+                <span className="text-xs text-flow-text-muted">
+                  {selectedType}s from all folders
+                </span>
+              )}
+            </>
+          ) : null}
         </div>
-        <div className="flex items-center gap-1">
-          {/* Enhanced Add Button */}
+        <div className="flex shrink-0 items-center gap-2">
+          {compact ? (
+            <span className="flow-sidebar-meta">
+              {displayFolders.length + displayContent.length} in view
+            </span>
+          ) : null}
           <div className="relative">
             <button
+              type="button"
               onClick={() => setShowAddMenu(!showAddMenu)}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary rounded-lg transition-colors"
+              className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-flow-text-secondary transition-colors hover:bg-flow-surface hover:text-flow-text-primary"
               title="Add Content"
             >
-              <Plus className="w-3 h-3" />
+              <Plus className="h-3 w-3" />
               Add
-              <ChevronDown className="w-3 h-3" />
+              <ChevronDown className="h-3 w-3" />
             </button>
-            
+
             {showAddMenu && (
-              <div className="absolute top-full right-0 mt-1 w-40 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
+              <div className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 w-40 min-w-0 py-0.5">
                 <button
+                  type="button"
                   onClick={() => {
                     setAddModalType('link');
                     setShowAddModal(true);
                     setShowAddMenu(false);
                   }}
-                  className="w-full flex items-center gap-2 px-3 py-2 text-xs text-flow-text-primary hover:bg-flow-surface transition-colors"
+                  className="flow-menu-item text-xs"
                 >
-                  <ExternalLink className="w-3 h-3 text-blue-400" />
+                  <ExternalLink className="h-3.5 w-3.5 shrink-0 text-blue-400" />
                   Add Link
                 </button>
                 <button
+                  type="button"
                   onClick={() => {
                     setAddModalType('file');
                     setShowAddModal(true);
                     setShowAddMenu(false);
                   }}
-                  className="w-full flex items-center gap-2 px-3 py-2 text-xs text-flow-text-primary hover:bg-flow-surface transition-colors"
+                  className="flow-menu-item text-xs"
                 >
-                  <Upload className="w-3 h-3 text-green-400" />
+                  <Upload className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
                   Add File/Folder
                 </button>
               </div>
@@ -1297,82 +1347,102 @@ export function ContentManager({
         </div>
       </div>
 
-      {/* Search and Filters - CLEAN: Consistent with UI */}
-      <div className="space-y-3 mb-4">
-        {/* Search Bar */}
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-3 h-3 text-flow-text-muted" />
-          <input
-            type="text"
-            placeholder="Search content..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 bg-flow-surface border border-flow-border rounded-lg text-sm text-flow-text-primary placeholder-flow-text-muted focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-          />
-        </div>
-
-        {/* Inline Filter Controls - Compact design */}
-        <div className="space-y-3">
-          {/* Type and Sort Row */}
-          <div className="grid grid-cols-2 gap-2">
-            <select
-              value={selectedType}
-              onChange={(e) => setSelectedType(e.target.value as 'all' | 'link' | 'file' | 'folder')}
-              className="px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-              title="Filter by content type"
-            >
-              <option value="all">All Types</option>
-              <option value="link">Links</option>
-              <option value="file">Files</option>
-              <option value="folder">Folders</option>
-            </select>
-
-            <select
-              value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as SortOption)}
-              className="px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-              title="Sort content by"
-            >
-              <option value="name">Name</option>
-              <option value="lastUsed">Recent</option>
-              <option value="dateAdded">Added</option>
-              <option value="type">Type</option>
-              <option value="favorites">Favorites</option>
-            </select>
+      <div
+        className={`space-y-3 ${compact ? "mb-3 px-3 pt-3" : "mb-4"}`}
+      >
+        {!sidebarSearchControlled ? (
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-3 w-3 -translate-y-1/2 transform text-flow-text-muted" />
+            <input
+              type="text"
+              placeholder="Search content..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className={
+                compact
+                  ? "flow-sidebar-search w-full py-2 pl-9 pr-3"
+                  : "w-full rounded-lg border border-flow-border bg-flow-surface py-2 pl-9 pr-3 text-sm text-flow-text-primary placeholder-flow-text-muted transition-all duration-200 focus:border-flow-accent-blue/50 focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50"
+              }
+            />
           </div>
+        ) : null}
 
-          {/* View and Favorites Row */}
-          <div className="flex items-center gap-2">
-            <select
-              value={viewMode}
-              onChange={(e) => setViewMode(e.target.value as ViewMode)}
-              className="flex-1 px-2 py-1.5 bg-flow-surface border border-flow-border rounded text-xs text-flow-text-primary focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50 focus:border-flow-accent-blue/50 transition-all duration-200"
-              title="Change view mode"
-            >
-              <option value="normal">Normal</option>
-              <option value="detailed">Detailed</option>
-              <option value="simplified">Compact</option>
-            </select>
+        {!compact ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-2">
+              <select
+                value={selectedType}
+                onChange={(e) =>
+                  setSelectedType(
+                    e.target.value as "all" | "link" | "file" | "folder",
+                  )
+                }
+                className="rounded border border-flow-border bg-flow-surface px-2 py-1.5 text-xs text-flow-text-primary transition-all duration-200 focus:border-flow-accent-blue/50 focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50"
+                title="Filter by content type"
+              >
+                <option value="all">All Types</option>
+                <option value="link">Links</option>
+                <option value="file">Files</option>
+                <option value="folder">Folders</option>
+              </select>
 
-            <button
-              onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
-              className={`inline-flex items-center gap-1 px-3 py-1.5 text-xs rounded transition-colors ${
-                showFavoritesOnly 
-                  ? 'bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30' 
-                  : 'bg-flow-surface border border-flow-border text-flow-text-secondary hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent'
-              }`}
-              title={showFavoritesOnly ? "Show all content" : "Show favorites only"}
-            >
-              <Heart className={`w-3 h-3 ${showFavoritesOnly ? 'fill-current' : ''}`} />
-              <span className="whitespace-nowrap">{showFavoritesOnly ? 'Favs' : 'All'}</span>
-            </button>
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value as SortOption)}
+                className="rounded border border-flow-border bg-flow-surface px-2 py-1.5 text-xs text-flow-text-primary transition-all duration-200 focus:border-flow-accent-blue/50 focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50"
+                title="Sort content by"
+              >
+                <option value="name">Name</option>
+                <option value="lastUsed">Recent</option>
+                <option value="dateAdded">Added</option>
+                <option value="type">Type</option>
+                <option value="favorites">Favorites</option>
+              </select>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <select
+                value={viewMode}
+                onChange={(e) => setViewMode(e.target.value as ViewMode)}
+                className="flex-1 rounded border border-flow-border bg-flow-surface px-2 py-1.5 text-xs text-flow-text-primary transition-all duration-200 focus:border-flow-accent-blue/50 focus:outline-none focus:ring-1 focus:ring-flow-accent-blue/50"
+                title="Change view mode"
+              >
+                <option value="normal">Normal</option>
+                <option value="detailed">Detailed</option>
+                <option value="simplified">Compact</option>
+              </select>
+
+              <button
+                type="button"
+                onClick={() => setShowFavoritesOnly(!showFavoritesOnly)}
+                className={`inline-flex items-center gap-1 rounded px-3 py-1.5 text-xs transition-colors ${
+                  showFavoritesOnly
+                    ? "border border-flow-accent-blue/30 bg-flow-accent-blue/20 text-flow-accent-blue"
+                    : "border border-flow-border bg-flow-surface text-flow-text-secondary hover:border-flow-border-accent hover:bg-flow-surface-elevated hover:text-flow-text-primary"
+                }`}
+                title={
+                  showFavoritesOnly ? "Show all content" : "Show favorites only"
+                }
+              >
+                <Heart
+                  className={`h-3 w-3 ${showFavoritesOnly ? "fill-current" : ""}`}
+                />
+                <span className="whitespace-nowrap">
+                  {showFavoritesOnly ? "Favs" : "All"}
+                </span>
+              </button>
+            </div>
           </div>
-        </div>
+        ) : null}
       </div>
 
       {/* Breadcrumbs - Moved to appear under filters */}
       {breadcrumbs.length > 1 && selectedType === 'all' && (
-        <div className="flex items-center gap-1 mb-4 p-2 bg-flow-surface border border-flow-border rounded-lg">
+        <div
+          className={`flex items-center gap-1 border border-flow-border bg-flow-surface p-2 rounded-lg ${
+            compact ? "mx-3 mb-3" : "mb-4"
+          }`}
+        >
           <Home className="w-3 h-3 text-flow-text-muted" />
           {breadcrumbs.map((crumb, index) => (
             <div key={crumb.id || 'root'} className="flex items-center gap-1">
@@ -1395,7 +1465,11 @@ export function ContentManager({
 
 
       {/* Content List - Smart scrolling with elegant scrollbar, no horizontal scroll */}
-      <div className={`${viewMode === 'simplified' ? 'space-y-1' : 'space-y-2'} max-h-[60vh] overflow-y-auto overflow-x-hidden scrollbar-elegant`}>
+      <div
+        className={`${viewMode === "simplified" ? "space-y-1" : "space-y-2"} max-h-[60vh] overflow-x-hidden overflow-y-auto scrollbar-elegant ${
+          compact ? "min-h-0 flex-1 px-3 pb-3" : ""
+        }`}
+      >
         {displayFolders.length === 0 && displayContent.length === 0 ? (
           <div className="text-center py-8">
             <FileText className="w-8 h-8 text-flow-text-muted mx-auto mb-2" />
@@ -1407,7 +1481,7 @@ export function ContentManager({
                'No content found'}
             </p>
             <p className="text-xs text-flow-text-muted mt-1">
-              {searchQuery || showFavoritesOnly 
+              {effectiveSearchQuery || showFavoritesOnly 
                 ? 'Try adjusting your search or filters' 
                 : 'Start by adding some content'
               }

--- a/src/renderer/layout/components/CreateProfileModal.tsx
+++ b/src/renderer/layout/components/CreateProfileModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { safeIconSrc } from "../../utils/safeIconSrc";
+import { formatUnit } from "../../utils/pluralize";
 import { X, Search, Plus, Scan, Folder, Monitor, Globe, Settings } from "lucide-react";
 import { useInstalledApps } from "../../hooks/useInstalledApps";
 
@@ -327,7 +328,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
       id: `profile-${Date.now()}`,
       name: profileName,
       icon: profileIcon,
-      description: profileDescription || `Custom profile with ${selectedApps.length} apps`,
+      description: profileDescription || `Custom profile with ${formatUnit(selectedApps.length, "app")}`,
       appCount: selectedApps.length,
       tabCount: 0,
       globalVolume: 70,
@@ -378,7 +379,7 @@ export function CreateProfileModal({ isOpen, onClose, onCreateProfile }: CreateP
       id: `memory-${Date.now()}`,
       name: profileName,
       icon: profileIcon,
-      description: profileDescription || `Captured layout with ${totalCapturedApps} apps`,
+      description: profileDescription || `Captured layout with ${formatUnit(totalCapturedApps, "app")}`,
       appCount: totalCapturedApps,
       tabCount: 0,
       globalVolume: 70,

--- a/src/renderer/layout/components/LaunchControl.tsx
+++ b/src/renderer/layout/components/LaunchControl.tsx
@@ -8,7 +8,16 @@ type LaunchControlProps = {
   onCancel: () => void;
   /** When true, show inline Cancel (requires IPC support from parent). */
   showCancel: boolean;
+  /** Non-zero summary segments only (e.g. "3 apps"); joined with middots under the label. */
+  profileSummaryParts?: readonly string[];
 };
+
+/** Shared chrome so idle and launching states keep the same footprint. */
+const launchShellClass =
+  "inline-flex min-h-[4.25rem] min-w-[14rem] max-w-[22rem] flex-col justify-center gap-2 rounded-xl border border-flow-accent-blue/35 bg-flow-accent-blue px-6 py-[10px] text-flow-text-primary shadow-md shadow-flow-accent-blue/20 box-border transition-[transform,box-shadow,background-color,border-color] duration-200 ease-out focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/45 focus:ring-offset-2 focus:ring-offset-flow-bg-primary";
+
+const launchIdleInteractiveClass =
+  "hover:-translate-y-0.5 hover:border-flow-accent-blue/55 hover:bg-flow-accent-blue-hover hover:shadow-lg hover:shadow-flow-accent-blue/30 active:translate-y-0 active:scale-[0.99] active:shadow-md disabled:pointer-events-none disabled:opacity-50";
 
 export function LaunchControl({
   isEditMode,
@@ -16,6 +25,7 @@ export function LaunchControl({
   onLaunch,
   onCancel,
   showCancel,
+  profileSummaryParts,
 }: LaunchControlProps) {
   const [elapsedSec, setElapsedSec] = useState(0);
   const startedAtRef = useRef<number | null>(null);
@@ -31,14 +41,24 @@ export function LaunchControl({
     }
     const tick = () => {
       if (startedAtRef.current === null) return;
-      setElapsedSec((Date.now() - startedAtRef.current) / 1000);
+      setElapsedSec(
+        Math.floor((Date.now() - startedAtRef.current) / 1000),
+      );
     };
     tick();
-    const id = window.setInterval(tick, 100);
+    const id = window.setInterval(tick, 1000);
     return () => window.clearInterval(id);
   }, [isLaunching]);
 
-  const elapsedLabel = `${elapsedSec.toFixed(1)}s`;
+  const secondaryLine =
+    profileSummaryParts && profileSummaryParts.length > 0
+      ? profileSummaryParts.join(" · ")
+      : null;
+
+  const launchTitle =
+    secondaryLine != null && profileSummaryParts?.length
+      ? `Launch this profile (${profileSummaryParts.join(", ")})`
+      : "Launch this profile";
 
   if (!isLaunching) {
     return (
@@ -46,46 +66,60 @@ export function LaunchControl({
         type="button"
         onClick={onLaunch}
         disabled={isEditMode}
-        className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/90 disabled:opacity-50 shadow-sm"
+        title={launchTitle}
+        className={`group ${launchShellClass} ${launchIdleInteractiveClass}`}
       >
-        <Play className="w-4 h-4 shrink-0" />
-        Launch Profile
+        <div className="flex w-full flex-col justify-center gap-2">
+          <div className="flex items-center justify-center gap-1">
+            <Play
+              className="h-5 w-5 shrink-0 transition-transform duration-200 ease-out group-hover:scale-105"
+              strokeWidth={1.75}
+              aria-hidden
+            />
+            <span className="text-sm font-semibold leading-tight">
+              Launch profile
+            </span>
+          </div>
+          {secondaryLine ? (
+            <span className="max-w-full truncate text-center text-xs font-normal leading-snug text-flow-text-primary/80">
+              {secondaryLine}
+            </span>
+          ) : null}
+        </div>
       </button>
     );
   }
 
   return (
     <div
-      className="inline-flex items-stretch rounded-lg border border-flow-accent-blue/50 bg-flow-accent-blue text-flow-text-primary shadow-sm overflow-hidden"
+      className={`${launchShellClass} border-flow-accent-blue/50`}
       role="group"
       aria-label="Profile launch"
     >
-      <div className="inline-flex items-center gap-2 px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium">
-        <div
-          className="w-4 h-4 shrink-0 border-2 border-flow-text-primary/30 border-t-flow-text-primary rounded-full animate-spin"
-          aria-hidden
-        />
-        <span className="whitespace-nowrap">Launching</span>
-        <span className="tabular-nums text-flow-text-primary/90">
-          ({elapsedLabel})
-        </span>
-      </div>
-      {showCancel ? (
-        <>
+      <div className="flex w-full flex-col justify-center gap-2">
+        <div className="flex items-center justify-center gap-2">
           <div
-            className="w-px shrink-0 bg-flow-text-primary/25 self-stretch my-2"
+            className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-flow-text-primary/30 border-t-flow-text-primary"
             aria-hidden
           />
+          <span className="text-sm font-semibold leading-tight">
+            Launching
+          </span>
+          <span className="tabular-nums text-sm font-normal text-flow-text-primary/80">
+            ({elapsedSec}s)
+          </span>
+        </div>
+        {showCancel ? (
           <button
             type="button"
             onClick={() => void onCancel()}
             disabled={isEditMode}
-            className="px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium text-flow-text-primary hover:bg-flow-text-primary/10 transition-colors disabled:opacity-50"
+            className="w-full rounded-lg border border-flow-text-primary/15 bg-flow-text-primary/5 py-2 text-sm font-medium text-flow-text-primary transition-colors hover:bg-flow-text-primary/10 disabled:opacity-50"
           >
             Cancel
           </button>
-        </>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/renderer/layout/components/LaunchControl.tsx
+++ b/src/renderer/layout/components/LaunchControl.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from "react";
+import { Play } from "lucide-react";
+
+type LaunchControlProps = {
+  isEditMode: boolean;
+  isLaunching: boolean;
+  onLaunch: () => void;
+  onCancel: () => void;
+  /** When true, show inline Cancel (requires IPC support from parent). */
+  showCancel: boolean;
+};
+
+export function LaunchControl({
+  isEditMode,
+  isLaunching,
+  onLaunch,
+  onCancel,
+  showCancel,
+}: LaunchControlProps) {
+  const [elapsedSec, setElapsedSec] = useState(0);
+  const startedAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isLaunching) {
+      startedAtRef.current = null;
+      setElapsedSec(0);
+      return;
+    }
+    if (startedAtRef.current === null) {
+      startedAtRef.current = Date.now();
+    }
+    const tick = () => {
+      if (startedAtRef.current === null) return;
+      setElapsedSec((Date.now() - startedAtRef.current) / 1000);
+    };
+    tick();
+    const id = window.setInterval(tick, 100);
+    return () => window.clearInterval(id);
+  }, [isLaunching]);
+
+  const elapsedLabel = `${elapsedSec.toFixed(1)}s`;
+
+  if (!isLaunching) {
+    return (
+      <button
+        type="button"
+        onClick={onLaunch}
+        disabled={isEditMode}
+        className="inline-flex items-center justify-center gap-2 rounded-lg px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium transition-all duration-150 ease-out focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/40 focus:ring-offset-2 focus:ring-offset-flow-bg-primary bg-flow-accent-blue text-flow-text-primary hover:bg-flow-accent-blue-hover active:bg-flow-accent-blue/90 disabled:opacity-50 shadow-sm"
+      >
+        <Play className="w-4 h-4 shrink-0" />
+        Launch Profile
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="inline-flex items-stretch rounded-lg border border-flow-accent-blue/50 bg-flow-accent-blue text-flow-text-primary shadow-sm overflow-hidden"
+      role="group"
+      aria-label="Profile launch"
+    >
+      <div className="inline-flex items-center gap-2 px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium">
+        <div
+          className="w-4 h-4 shrink-0 border-2 border-flow-text-primary/30 border-t-flow-text-primary rounded-full animate-spin"
+          aria-hidden
+        />
+        <span className="whitespace-nowrap">Launching</span>
+        <span className="tabular-nums text-flow-text-primary/90">
+          ({elapsedLabel})
+        </span>
+      </div>
+      {showCancel ? (
+        <>
+          <div
+            className="w-px shrink-0 bg-flow-text-primary/25 self-stretch my-2"
+            aria-hidden
+          />
+          <button
+            type="button"
+            onClick={() => void onCancel()}
+            disabled={isEditMode}
+            className="px-3 md:px-4 py-2 md:py-2.5 text-xs md:text-sm font-medium text-flow-text-primary hover:bg-flow-text-primary/10 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import { Monitor, Grid3X3, Zap, ChevronDown, GripVertical } from "lucide-react";
+import {
+  Monitor,
+  Grid3X3,
+  Zap,
+  ChevronDown,
+  GripVertical,
+  PenLine,
+  Save,
+} from "lucide-react";
 import { AppFileWindow } from "./AppFileWindow";
 import { MinimizedApps } from "./MinimizedApps";
 import { AppSettings } from "./AppSettings";
@@ -115,6 +123,10 @@ interface MonitorLayoutProps {
   selectedApp?: any;
   onAutoSnapApps?: (monitorId: string, appUpdates: { appIndex: number; position: { x: number; y: number }; size: { width: number; height: number } }[]) => void;
   onUpdateMonitorPositions?: (positions: Array<{ id: string; layoutPosition: { x: number; y: number } }>) => void;
+  /** When set, shows Edit layout / Done in the preview toolbar (layout editing, not profile prefs). */
+  onToggleLayoutEdit?: () => void;
+  /** Visually join the preview toolbar to the profile header above (shared column). */
+  layoutToolbarConnected?: boolean;
 }
 
 // Layout definitions - Horizontal Monitor Layouts
@@ -365,7 +377,9 @@ export function MonitorLayout({
   onFileSelect, // Legacy
   selectedApp,
   onAutoSnapApps,
-  onUpdateMonitorPositions
+  onUpdateMonitorPositions,
+  onToggleLayoutEdit,
+  layoutToolbarConnected = false,
 }: MonitorLayoutProps) {
   // Enhanced drag state with persistence
   const [localDragState, setLocalDragState] = useState<{
@@ -1319,29 +1333,84 @@ export function MonitorLayout({
 
   return (
     <div ref={layoutRootRef} className="h-full flex flex-col relative min-h-0">
-      {/* Header Section */}
-      <div className={`flex items-center justify-between ${densePreviewMode ? 'mb-2' : compactPreviewMode ? 'mb-3' : 'mb-4'} flex-shrink-0`}>
-        <div className="flex items-center gap-3">
-          <Monitor className={`${densePreviewMode ? 'w-4 h-4' : 'w-5 h-5'} text-white/70`} />
-          <h3 className={`text-white ${densePreviewMode ? 'text-base' : 'text-lg'}`}>Monitor Layout Preview</h3>
-          {isEditMode ? (
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-2 px-3 py-1.5 bg-flow-accent-blue/20 border border-flow-accent-blue/30 rounded-lg backdrop-blur-sm">
-                <div className="w-2 h-2 bg-flow-accent-blue rounded-full animate-pulse" />
-                <span className="text-flow-accent-blue text-xs font-medium">Edit Mode</span>
-                {dragState?.isDragging && (
-                  <span className="text-flow-accent-blue text-xs font-medium">
-                    | Dragging: {dragState.dragData?.name || 'Item'}
-                  </span>
-                )}
-              </div>
-              <span className="text-xs text-white/50">Apps only - Files become content</span>
+      {/* Preview toolbar — layout editing lives here (not profile preferences) */}
+      <div
+        className={`flex-shrink-0 ${
+          layoutToolbarConnected
+            ? `-mx-4 bg-flow-bg-secondary/90 px-4 pb-3 pt-2.5 md:-mx-6 md:px-6 xl:-mx-8 xl:px-8 ${
+                densePreviewMode ? "mb-2" : compactPreviewMode ? "mb-3" : "mb-4"
+              }`
+            : `rounded-xl border border-white/[0.06] bg-white/[0.03] px-4 py-3 ${
+                densePreviewMode ? "mb-2" : compactPreviewMode ? "mb-3" : "mb-4"
+              }`
+        }`}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-wrap items-center gap-3">
+            <Monitor
+              className={`shrink-0 text-flow-accent-blue/90 ${densePreviewMode ? "h-4 w-4" : "h-5 w-5"}`}
+              strokeWidth={1.75}
+            />
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <h3
+                className={`font-semibold tracking-tight text-flow-text-primary ${densePreviewMode ? "text-sm" : "text-base md:text-lg"}`}
+              >
+                Monitor layout
+              </h3>
+              <p className="text-[11px] text-flow-text-muted">
+                Drag apps on monitors · use Edit layout to change positions
+              </p>
             </div>
-          ) : (
-            <span className="text-xs text-white/50 bg-white/10 px-2 py-1 rounded-full">
-              View Mode
-            </span>
-          )}
+            {isEditMode ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-2 rounded-lg bg-flow-accent-blue/15 px-2.5 py-1">
+                  <div className="h-2 w-2 animate-pulse rounded-full bg-flow-accent-blue" />
+                  <span className="text-xs font-medium text-flow-accent-blue">
+                    Editing layout
+                  </span>
+                  {dragState?.isDragging && (
+                    <span className="text-xs font-medium text-flow-accent-blue/90">
+                      · {dragState.dragData?.name || "Item"}
+                    </span>
+                  )}
+                </div>
+                <span className="text-[11px] text-flow-text-muted">
+                  Apps only — files become content
+                </span>
+              </div>
+            ) : (
+              <span className="rounded-md bg-white/[0.06] px-2 py-1 text-[11px] font-medium text-flow-text-muted">
+                View mode
+              </span>
+            )}
+          </div>
+          {onToggleLayoutEdit ? (
+            <button
+              type="button"
+              onClick={onToggleLayoutEdit}
+              title={
+                isEditMode
+                  ? "Save layout and exit edit mode"
+                  : "Edit monitor layout (drag apps between monitors)"
+              }
+              aria-label={
+                isEditMode
+                  ? "Save layout and exit edit mode"
+                  : "Edit monitor layout"
+              }
+              className={`inline-flex shrink-0 items-center justify-center rounded-lg p-2.5 transition-colors md:p-3 ${
+                isEditMode
+                  ? "bg-flow-accent-blue text-flow-text-primary shadow-sm hover:bg-flow-accent-blue-hover"
+                  : "text-flow-text-secondary hover:bg-white/[0.06] hover:text-flow-text-primary"
+              }`}
+            >
+              {isEditMode ? (
+                <Save className="h-4 w-4 shrink-0 md:h-[1.125rem] md:w-[1.125rem]" strokeWidth={1.75} />
+              ) : (
+                <PenLine className="h-4 w-4 shrink-0 md:h-[1.125rem] md:w-[1.125rem]" strokeWidth={1.75} />
+              )}
+            </button>
+          ) : null}
         </div>
       </div>
 

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Monitor, Folder, Globe, MoreVertical, Copy, Edit, Trash2, Settings, Download, Zap, ZapOff, Clock, Layers } from "lucide-react";
 import { LucideIcon } from "lucide-react";
+import { ProfileIconGlyph } from "../utils/profileHeaderPresentation";
+import { formatUnit } from "../../utils/pluralize";
 
 interface Profile {
   id: string;
@@ -66,19 +68,6 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
     return <Folder className="w-2 h-2 text-white" />;
   };
   
-  const getProfileIcon = () => {
-    switch (profile.icon) {
-      case 'work':
-        return <Folder className="w-4 h-4" />;
-      case 'gaming':
-        return <Monitor className="w-4 h-4" />;
-      case 'personal':
-        return <Globe className="w-4 h-4" />;
-      default:
-        return <Folder className="w-4 h-4" />;
-    }
-  };
-
   const handleActionClick = (e: React.MouseEvent, action: () => void) => {
     e.stopPropagation();
     action();
@@ -128,7 +117,7 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
           <div className={`p-2 rounded-lg transition-colors duration-150 ${
             profile.isActive ? 'bg-flow-accent-blue/15' : 'bg-flow-bg-tertiary/80 group-hover:bg-flow-surface'
           }`}>
-            {getProfileIcon()}
+            <ProfileIconGlyph icon={profile.icon} className="w-4 h-4" />
           </div>
           
           <div className="flex-1 min-w-0">
@@ -148,15 +137,15 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
             <div className="grid grid-cols-2 gap-2 text-xs">
               <div className="flex items-center gap-1 text-flow-text-muted">
                 <Layers className="w-3 h-3" />
-                <span>{profile.appCount} apps</span>
+                <span>{formatUnit(profile.appCount, "app")}</span>
               </div>
               <div className="flex items-center gap-1 text-flow-text-muted">
                 <Globe className="w-3 h-3" />
-                <span>{profile.tabCount} tabs</span>
+                <span>{formatUnit(profile.tabCount, "tab")}</span>
               </div>
               <div className="flex items-center gap-1 text-flow-text-muted">
                 <Monitor className="w-3 h-3" />
-                <span>{profile.monitors.length} monitors</span>
+                <span>{formatUnit(profile.monitors.length, "monitor")}</span>
               </div>
               <div className="flex items-center gap-1 text-flow-text-muted">
                 <Clock className="w-3 h-3" />

--- a/src/renderer/layout/components/ProfileHeaderOverflowMenu.tsx
+++ b/src/renderer/layout/components/ProfileHeaderOverflowMenu.tsx
@@ -5,18 +5,30 @@ import {
   Copy,
   Trash2,
   Plus,
+  Upload,
+  Download,
 } from "lucide-react";
 
 type ProfileHeaderOverflowMenuProps = {
   disabled: boolean;
+  /** Hidden file input id for import (label uses htmlFor). */
+  importInputId: string;
+  exportDisabled: boolean;
+  onExport: () => void;
   onSettings: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
   onNewProfile: () => void;
 };
 
+const menuPanelClass =
+  "flow-menu-panel absolute right-0 top-full z-[30000] mt-1.5 min-w-[14rem]";
+
 export function ProfileHeaderOverflowMenu({
   disabled,
+  importInputId,
+  exportDisabled,
+  onExport,
   onSettings,
   onDuplicate,
   onDelete,
@@ -55,56 +67,76 @@ export function ProfileHeaderOverflowMenu({
           e.stopPropagation();
           if (!disabled) setOpen((v) => !v);
         }}
-        className={`inline-flex items-center justify-center rounded-lg p-2 md:px-3 md:py-2.5 text-flow-text-secondary border border-flow-border/60 bg-flow-surface/90 hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50 transition-all duration-150 ease-out ${
-          disabled ? "opacity-50 cursor-not-allowed" : ""
+        className={`inline-flex items-center justify-center rounded-lg p-2 text-flow-text-secondary transition-colors duration-150 ease-out hover:bg-white/[0.06] md:px-2.5 md:py-2 ${
+          disabled ? "cursor-not-allowed opacity-50" : ""
         }`}
         title="More actions"
         aria-expanded={open}
         aria-haspopup="menu"
       >
-        <MoreHorizontal className="w-4 h-4" />
+        <MoreHorizontal className="h-5 w-5" strokeWidth={1.75} />
         <span className="sr-only">More profile actions</span>
       </button>
       {open && !disabled ? (
-        <div
-          className="absolute right-0 top-full z-[70] mt-1.5 min-w-[12rem] rounded-xl border border-flow-border/60 bg-flow-surface-elevated py-1 shadow-flow-shadow-lg"
-          role="menu"
-        >
+        <div className={menuPanelClass} role="menu">
           <button
             type="button"
             role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
+            className="flow-menu-item"
+            onClick={() => run(onSettings)}
+          >
+            <Settings className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
+            Profile preferences…
+          </button>
+          <div className="my-1 h-px bg-white/[0.08]" />
+          <button
+            type="button"
+            role="menuitem"
+            className="flow-menu-item"
             onClick={() => run(onNewProfile)}
           >
-            <Plus className="w-4 h-4 shrink-0" />
+            <Plus className="h-4 w-4 shrink-0" strokeWidth={1.75} />
             New profile
           </button>
           <button
             type="button"
             role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
-            onClick={() => run(onSettings)}
-          >
-            <Settings className="w-4 h-4 shrink-0" />
-            Profile settings
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
+            className="flow-menu-item"
             onClick={() => run(onDuplicate)}
           >
-            <Copy className="w-4 h-4 shrink-0" />
+            <Copy className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
             Duplicate
           </button>
-          <div className="my-1 h-px bg-flow-border/60" />
+          <div className="my-1 h-px bg-white/[0.08]" />
+          <label
+            htmlFor={importInputId}
+            role="menuitem"
+            className="flow-menu-item cursor-pointer"
+            onClick={() => setOpen(false)}
+          >
+            <Upload className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
+            Import profile…
+          </label>
           <button
             type="button"
             role="menuitem"
-            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-accent-red hover:bg-flow-accent-red/10"
+            disabled={exportDisabled}
+            className="flow-menu-item disabled:pointer-events-none disabled:opacity-40"
+            onClick={() => {
+              if (!exportDisabled) run(onExport);
+            }}
+          >
+            <Download className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
+            Export profile
+          </button>
+          <div className="my-1 h-px bg-white/[0.08]" />
+          <button
+            type="button"
+            role="menuitem"
+            className="flow-menu-item flow-menu-item-danger"
             onClick={() => run(onDelete)}
           >
-            <Trash2 className="w-4 h-4 shrink-0" />
+            <Trash2 className="h-4 w-4 shrink-0" strokeWidth={1.75} />
             Delete
           </button>
         </div>

--- a/src/renderer/layout/components/ProfileHeaderOverflowMenu.tsx
+++ b/src/renderer/layout/components/ProfileHeaderOverflowMenu.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  MoreHorizontal,
+  Settings,
+  Copy,
+  Trash2,
+  Plus,
+} from "lucide-react";
+
+type ProfileHeaderOverflowMenuProps = {
+  disabled: boolean;
+  onSettings: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onNewProfile: () => void;
+};
+
+export function ProfileHeaderOverflowMenu({
+  disabled,
+  onSettings,
+  onDuplicate,
+  onDelete,
+  onNewProfile,
+}: ProfileHeaderOverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const t = window.setTimeout(() => {
+      document.addEventListener("click", onDoc);
+    }, 0);
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener("click", onDoc);
+    };
+  }, [open]);
+
+  const run = (fn: () => void) => {
+    fn();
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={rootRef}>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (!disabled) setOpen((v) => !v);
+        }}
+        className={`inline-flex items-center justify-center rounded-lg p-2 md:px-3 md:py-2.5 text-flow-text-secondary border border-flow-border/60 bg-flow-surface/90 hover:bg-flow-surface-elevated hover:text-flow-text-primary hover:border-flow-border-accent/50 transition-all duration-150 ease-out ${
+          disabled ? "opacity-50 cursor-not-allowed" : ""
+        }`}
+        title="More actions"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <MoreHorizontal className="w-4 h-4" />
+        <span className="sr-only">More profile actions</span>
+      </button>
+      {open && !disabled ? (
+        <div
+          className="absolute right-0 top-full z-[70] mt-1.5 min-w-[12rem] rounded-xl border border-flow-border/60 bg-flow-surface-elevated py-1 shadow-flow-shadow-lg"
+          role="menu"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
+            onClick={() => run(onNewProfile)}
+          >
+            <Plus className="w-4 h-4 shrink-0" />
+            New profile
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
+            onClick={() => run(onSettings)}
+          >
+            <Settings className="w-4 h-4 shrink-0" />
+            Profile settings
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary"
+            onClick={() => run(onDuplicate)}
+          >
+            <Copy className="w-4 h-4 shrink-0" />
+            Duplicate
+          </button>
+          <div className="my-1 h-px bg-flow-border/60" />
+          <button
+            type="button"
+            role="menuitem"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-flow-accent-red hover:bg-flow-accent-red/10"
+            onClick={() => run(onDelete)}
+          >
+            <Trash2 className="w-4 h-4 shrink-0" />
+            Delete
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/renderer/layout/components/TitleBarAppMenu.tsx
+++ b/src/renderer/layout/components/TitleBarAppMenu.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronDown, Info, Settings } from "lucide-react";
+
+type TitleBarAppMenuProps = {
+  onAppPreferences: () => void;
+  onAbout: () => void;
+};
+
+export function TitleBarAppMenu({
+  onAppPreferences,
+  onAbout,
+}: TitleBarAppMenuProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [menuRect, setMenuRect] = useState<{
+    top: number;
+    left: number;
+    minWidth: number;
+  } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current) {
+      setMenuRect(null);
+      return;
+    }
+    const el = triggerRef.current;
+    const update = () => {
+      const r = el.getBoundingClientRect();
+      setMenuRect({
+        top: r.bottom + 6,
+        left: r.left,
+        minWidth: Math.max(r.width, 13.5 * 16),
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!rootRef.current?.contains(t)) {
+        setOpen(false);
+      }
+    };
+    const t = window.setTimeout(() => {
+      document.addEventListener("click", onDoc);
+    }, 0);
+    return () => {
+      window.clearTimeout(t);
+      document.removeEventListener("click", onDoc);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    window.addEventListener("scroll", close, true);
+    return () => window.removeEventListener("scroll", close, true);
+  }, [open]);
+
+  const run = (fn: () => void) => {
+    fn();
+    setOpen(false);
+  };
+
+  const menu =
+    open && menuRect
+      ? createPortal(
+          <div
+            className="flow-menu-panel fixed z-[30000]"
+            style={{
+              top: menuRect.top,
+              left: menuRect.left,
+              minWidth: menuRect.minWidth,
+            }}
+            role="menu"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              className="flow-menu-item"
+              onClick={() => run(onAppPreferences)}
+            >
+              <Settings className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
+              App preferences…
+            </button>
+            <div className="my-1 h-px bg-white/[0.08]" />
+            <button
+              type="button"
+              role="menuitem"
+              className="flow-menu-item"
+              onClick={() => run(onAbout)}
+            >
+              <Info className="h-4 w-4 shrink-0 opacity-90" strokeWidth={1.75} />
+              About FlowSwitch
+            </button>
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <div className="app-no-drag relative" ref={rootRef}>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        className="inline-flex max-w-full items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-flow-text-primary transition-colors hover:bg-white/[0.08]"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        title="FlowSwitch menu"
+      >
+        <img
+          src="/flowswitch-logo.png"
+          alt=""
+          className="h-7 w-7 shrink-0 rounded-md object-contain"
+          width={28}
+          height={28}
+        />
+        <span className="truncate text-sm font-semibold tracking-tight">
+          FlowSwitch
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-flow-text-muted transition-transform duration-150 ${
+            open ? "rotate-180" : ""
+          }`}
+          strokeWidth={2}
+          aria-hidden
+        />
+      </button>
+      {menu}
+    </div>
+  );
+}

--- a/src/renderer/layout/hooks/useProfileLaunch.ts
+++ b/src/renderer/layout/hooks/useProfileLaunch.ts
@@ -242,10 +242,11 @@ export function useProfileLaunch({
               return;
             }
 
-            setLaunchFeedback({
-              status: "in-progress",
-              message: "Launching profile...",
-            });
+            // Main-process steady state while apps launch; LaunchControl shows progress — no redundant feedback updates.
+            if (st === "in-progress") {
+              return;
+            }
+
           } catch {
             // Keep UI resilient; next poll tick can recover.
           }

--- a/src/renderer/layout/hooks/useProfileLaunch.ts
+++ b/src/renderer/layout/hooks/useProfileLaunch.ts
@@ -16,6 +16,11 @@ type UseProfileLaunchOptions = {
   setIsLaunching: Dispatch<SetStateAction<boolean>>;
   setLaunchFeedback: Dispatch<SetStateAction<LaunchFeedbackState>>;
   launchFeedbackTimeoutRef: MutableRefObject<number | null>;
+  /** Called when a launch finishes successfully, with wall-clock seconds for this run. */
+  onLaunchCompletedDuration?: (
+    profileId: string,
+    durationSeconds: number,
+  ) => void;
 };
 
 export function useProfileLaunch({
@@ -24,10 +29,26 @@ export function useProfileLaunch({
   setIsLaunching,
   setLaunchFeedback,
   launchFeedbackTimeoutRef,
+  onLaunchCompletedDuration,
 }: UseProfileLaunchOptions) {
   const launchStatusPollRef = useRef<number | null>(null);
   const launchStatusPollTokenRef = useRef(0);
   const activeLaunchRunRef = useRef<{ profileId: string; runId: string } | null>(null);
+  const launchWallClockStartMsRef = useRef<number | null>(null);
+
+  const emitLaunchDurationIfSuccess = useCallback(
+    (profileId: string) => {
+      const start = launchWallClockStartMsRef.current;
+      launchWallClockStartMsRef.current = null;
+      if (start == null || !onLaunchCompletedDuration) return;
+      const seconds = Math.max(
+        1,
+        Math.round((Date.now() - start) / 1000),
+      );
+      onLaunchCompletedDuration(profileId, seconds);
+    },
+    [onLaunchCompletedDuration],
+  );
 
   const stopLaunchStatusPolling = useCallback(() => {
     launchStatusPollTokenRef.current += 1;
@@ -69,6 +90,7 @@ export function useProfileLaunch({
         launchFeedbackTimeoutRef.current = null;
       }
 
+      launchWallClockStartMsRef.current = Date.now();
       setIsLaunching(true);
       setLaunchFeedback({
         status: "in-progress",
@@ -98,6 +120,7 @@ export function useProfileLaunch({
             serializableProfiles,
           );
           if (!saveResult?.ok) {
+            launchWallClockStartMsRef.current = null;
             setLaunchFeedback({
               status: "error",
               message: "Could not save profile changes before launch.",
@@ -120,6 +143,7 @@ export function useProfileLaunch({
         );
 
         if (!launchResult?.ok) {
+          launchWallClockStartMsRef.current = null;
           activeLaunchRunRef.current = null;
           const errorMessage = launchResult?.error
             || "Could not launch this profile. Check app executable paths in app details.";
@@ -136,6 +160,7 @@ export function useProfileLaunch({
 
         const launchRunId = String(launchResult?.runId || "").trim();
         if (!launchResult?.started || !launchRunId) {
+          launchWallClockStartMsRef.current = null;
           activeLaunchRunRef.current = null;
           setLaunchFeedback({
             status: "error",
@@ -176,6 +201,7 @@ export function useProfileLaunch({
 
             if (st === "cancelled") {
               stopLaunchStatusPolling();
+              launchWallClockStartMsRef.current = null;
               activeLaunchRunRef.current = null;
               setIsLaunching(false);
               setLaunchFeedback({
@@ -188,6 +214,7 @@ export function useProfileLaunch({
 
             if (st === "failed") {
               stopLaunchStatusPolling();
+              launchWallClockStartMsRef.current = null;
               activeLaunchRunRef.current = null;
               setIsLaunching(false);
               setLaunchFeedback({
@@ -202,6 +229,7 @@ export function useProfileLaunch({
               stopLaunchStatusPolling();
               activeLaunchRunRef.current = null;
               setIsLaunching(false);
+              emitLaunchDurationIfSuccess(launchProfileId);
               setLaunchFeedback({
                 status: "success",
                 message: `Launch complete: ${summaryText}.`,
@@ -234,6 +262,7 @@ export function useProfileLaunch({
               stopLaunchStatusPolling();
               activeLaunchRunRef.current = null;
               setIsLaunching(false);
+              emitLaunchDurationIfSuccess(launchProfileId);
               setLaunchFeedback({
                 status: "success",
                 message: `Launch complete: ${summaryText}.`,
@@ -252,6 +281,7 @@ export function useProfileLaunch({
           }
         }, 1300);
       } catch (error) {
+        launchWallClockStartMsRef.current = null;
         activeLaunchRunRef.current = null;
         console.error("Failed to launch profile:", error);
         const errorMessage =
@@ -288,6 +318,7 @@ export function useProfileLaunch({
     launchFeedbackTimeoutRef,
     stopLaunchStatusPolling,
     isCurrentLaunchContext,
+    emitLaunchDurationIfSuccess,
   ]);
 
   return {

--- a/src/renderer/layout/utils/profileHeaderPresentation.tsx
+++ b/src/renderer/layout/utils/profileHeaderPresentation.tsx
@@ -16,15 +16,3 @@ export function ProfileIconGlyph({
       return <Folder className={className} />;
   }
 }
-
-/** Shorten auto-generated descriptions so the header stays scannable. */
-export function shortenProfileDescriptionForHeader(description: string): string {
-  const d = description.trim();
-  if (/^Custom profile with \d+ apps?$/i.test(d)) {
-    return "Custom profile";
-  }
-  if (/^Captured layout with \d+ apps?$/i.test(d)) {
-    return "Captured layout";
-  }
-  return d;
-}

--- a/src/renderer/layout/utils/profileHeaderPresentation.tsx
+++ b/src/renderer/layout/utils/profileHeaderPresentation.tsx
@@ -1,0 +1,30 @@
+import { Monitor, Folder, Globe } from "lucide-react";
+
+export function ProfileIconGlyph({
+  icon,
+  className = "w-4 h-4",
+}: {
+  icon: string;
+  className?: string;
+}) {
+  switch (icon) {
+    case "gaming":
+      return <Monitor className={className} />;
+    case "personal":
+      return <Globe className={className} />;
+    default:
+      return <Folder className={className} />;
+  }
+}
+
+/** Shorten auto-generated descriptions so the header stays scannable. */
+export function shortenProfileDescriptionForHeader(description: string): string {
+  const d = description.trim();
+  if (/^Custom profile with \d+ apps?$/i.test(d)) {
+    return "Custom profile";
+  }
+  if (/^Captured layout with \d+ apps?$/i.test(d)) {
+    return "Captured layout";
+  }
+  return d;
+}

--- a/src/renderer/layout/utils/profileHeaderPresentation.tsx
+++ b/src/renderer/layout/utils/profileHeaderPresentation.tsx
@@ -16,3 +16,35 @@ export function ProfileIconGlyph({
       return <Folder className={className} />;
   }
 }
+
+const frameStyles: Record<string, string> = {
+  gaming:
+    "border-violet-400/20 bg-violet-500/15 text-violet-200 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)]",
+  personal:
+    "border-emerald-400/20 bg-emerald-500/15 text-emerald-200 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)]",
+  work:
+    "border-sky-400/20 bg-sky-500/15 text-sky-200 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)]",
+};
+
+/** Profile type icon in a soft tinted tile for header identity. */
+export function ProfileIconFrame({
+  icon,
+  className = "",
+}: {
+  icon: string;
+  className?: string;
+}) {
+  const key =
+    icon === "gaming" || icon === "personal" || icon === "work"
+      ? icon
+      : "work";
+  const frame = frameStyles[key] || frameStyles.work;
+  return (
+    <div
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border ${frame} ${className}`}
+      aria-hidden
+    >
+      <ProfileIconGlyph icon={icon} className="h-5 w-5 opacity-95" />
+    </div>
+  );
+}

--- a/src/renderer/utils/pluralize.ts
+++ b/src/renderer/utils/pluralize.ts
@@ -1,0 +1,18 @@
+/** Returns singular when count is 1, otherwise plural (default: singular + "s"). */
+export function pluralize(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  const p = plural ?? `${singular}s`;
+  return Math.abs(count) === 1 ? singular : p;
+}
+
+/** e.g. formatUnit(1, "app") → "1 app"; formatUnit(3, "app") → "3 apps" */
+export function formatUnit(
+  count: number,
+  singular: string,
+  plural?: string,
+): string {
+  return `${count} ${pluralize(count, singular, plural)}`;
+}


### PR DESCRIPTION
## Summary
Refresh of the Electron shell around profiles: title bar, left sidebar, launch control, monitor layout toolbar, and shared menu styling.

## Changes
- **Title bar:** FlowSwitch menu (fixed portal) with App preferences + About modals; solid \low-menu-panel\ styling.
- **Sidebar:** Icon + label nav tabs, shared search for Profiles / Apps / Content; compact Apps/Content headers aligned with Profiles; filter dropdowns removed in compact mode.
- **Launch:** Consistent button shell, typography (primary vs sub-label), whole-second launching timer; **estimated startup time** updated from the last successful launch duration.
- **Profile header / monitor preview:** Edit/save on layout strip, overflow menu order and z-index, connected toolbar styling.
- **Docs:** \AGENTS.md\ note on commit expectations; small braindump tweak.

## QA
- \
npm run lint\ (0 errors)
- \
npm run typecheck\ (baseline)

## Manual
- [ ] Title bar menu, overflow menu, Content Add menu render above sidebar.
- [ ] Launch → success updates \~Xs startup\ in header after run completes.


Made with [Cursor](https://cursor.com)