### PR TITLE
feat: global content library, sidebar pickers, and inspector

### DIFF
--- a/src/main/ipc/trusted-renderer-ipc.js
+++ b/src/main/ipc/trusted-renderer-ipc.js
@@ -3,6 +3,8 @@
 const path = require('path');
 const fs = require('fs');
 const ws = require('windows-shortcuts');
+const { BrowserWindow, dialog } = require('electron');
+
 
 const createHandleTrustedIpc = (ipcMain, isTrustedIpcSender) => (
   (channel, handler) => {
@@ -22,7 +24,7 @@ const registerTrustedRendererIpc = (handleTrustedIpc, deps) => {
     buildSystemMonitorSnapshot,
     unpackProfilesReadResult,
     readProfilesFromDisk,
-    sanitizeProfilesPayload,
+    sanitizeProfileStorePayload,
     writeProfilesToDisk,
     safeLimitedString,
     MAX_PROFILE_ID_LENGTH,
@@ -76,27 +78,77 @@ const registerTrustedRendererIpc = (handleTrustedIpc, deps) => {
 
   handleTrustedIpc('profiles:list', async () => {
   try {
-    const { profiles, storeError } = unpackProfilesReadResult(readProfilesFromDisk());
-    if (storeError) {
-      console.error('[profiles:list] Failed to read profiles from store:', storeError);
+    const disk = readProfilesFromDisk();
+    if (disk.storeError) {
+      console.error('[profiles:list] Failed to read profiles from store:', disk.storeError);
     }
-    return profiles;
+    return {
+      profiles: disk.profiles,
+      contentLibrary: disk.contentLibrary,
+      contentLibraryExclusions: disk.contentLibraryExclusions,
+      storeError: disk.storeError,
+    };
   } catch (error) {
     console.error('[profiles:list] Failed to list profiles:', error);
-    return [];
+    return {
+      profiles: [],
+      contentLibrary: { items: [], folders: [] },
+      contentLibraryExclusions: {},
+      storeError: null,
+    };
   }
 });
 
-  handleTrustedIpc('profiles:save-all', async (_event, profiles) => {
+  handleTrustedIpc('profiles:save-all', async (_event, payload) => {
   try {
-    const sanitizedProfiles = sanitizeProfilesPayload(profiles);
-    const savedProfiles = writeProfilesToDisk(sanitizedProfiles);
+    const safe = sanitizeProfileStorePayload(payload);
+    const savedProfiles = writeProfilesToDisk(safe);
     return { ok: true, count: savedProfiles.length };
   } catch (error) {
     console.error('[profiles:save-all] Failed to save profiles:', error);
     return { ok: false, error: 'Failed to save profiles' };
   }
 });
+
+  handleTrustedIpc('content-library:pick-paths', async (event, opts = {}) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const options = opts && typeof opts === 'object' ? opts : {};
+    const mode = typeof options.mode === 'string' ? options.mode : 'files';
+
+    const buildEntries = (paths) => {
+      if (!paths?.length) return [];
+      return paths.map((p) => {
+        let kind = 'file';
+        try {
+          const st = fs.statSync(p);
+          if (st.isDirectory()) kind = 'directory';
+        } catch {
+          kind = 'file';
+        }
+        return { path: p, kind };
+      });
+    };
+
+    const pack = (result) => {
+      if (result.canceled || !result.filePaths?.length) {
+        return { canceled: true, entries: [] };
+      }
+      return { canceled: false, entries: buildEntries(result.filePaths) };
+    };
+
+    if (mode === 'directory') {
+      const r = await dialog.showOpenDialog(win || undefined, {
+        properties: ['openDirectory'],
+      });
+      return pack(r);
+    }
+
+    // mode === 'files' (default) or unknown → file picker only
+    const r = await dialog.showOpenDialog(win || undefined, {
+      properties: ['openFile', 'multiSelections'],
+    });
+    return pack(r);
+  });
 
   handleTrustedIpc('launch-profile', async (_event, profileId, request = {}) => {
   try {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -43,7 +43,7 @@ const {
   scoreReuseCandidate,
   shouldTriggerAmbiguityFallback,
 } = require('./utils/launch-target-mode');
-const { sanitizeProfilesPayload } = require('./utils/sanitize-profiles-payload');
+const { sanitizeProfileStorePayload } = require('./utils/sanitize-profile-store-payload');
 const {
   buildSystemMonitorSnapshot,
   physicalBoundsFromDip,
@@ -838,7 +838,7 @@ if (shouldBootstrapElectronMain) {
     buildSystemMonitorSnapshot,
     unpackProfilesReadResult,
     readProfilesFromDisk,
-    sanitizeProfilesPayload,
+    sanitizeProfileStorePayload,
     writeProfilesToDisk,
     safeLimitedString,
     MAX_PROFILE_ID_LENGTH,

--- a/src/main/services/icon-path-and-app-helpers.js
+++ b/src/main/services/icon-path-and-app-helpers.js
@@ -47,6 +47,8 @@ const createIconPathAndAppHelpers = ({
     if (value && typeof value === 'object') {
       return {
         profiles: Array.isArray(value.profiles) ? value.profiles : [],
+        contentLibrary: value.contentLibrary ?? null,
+        contentLibraryExclusions: value.contentLibraryExclusions ?? null,
         storeError: value.storeError || null,
       };
     }

--- a/src/main/services/profile-store.js
+++ b/src/main/services/profile-store.js
@@ -27,15 +27,108 @@ const mapSanitizedProfiles = (profiles) => (
   profiles.map((p) => sanitizeProfileLaunchFieldsDeep(sanitizeProfileIconPathsDeep(p)))
 );
 
+const emptyLibrary = () => ({ items: [], folders: [] });
+
 /**
- * Read profiles from disk. Never silently drops encrypted data: if the OS cannot
- * decrypt, `storeError` is set and `profiles` is empty.
- * @returns {{ profiles: unknown[], storeError: ProfileStoreReadError | null }}
+ * One-time migration: library lived on each profile. Merge by id into a global
+ * library and clear embedded arrays so future saves stay normalized.
+ * @param {unknown[]} profiles
+ * @returns {{ items: unknown[], folders: unknown[] }}
+ */
+const migrateEmbeddedContentToLibrary = (profiles) => {
+  const seenItem = new Map();
+  const seenFolder = new Map();
+  let found = false;
+  for (const p of profiles) {
+    if (!p || typeof p !== 'object') continue;
+    for (const it of p.contentItems || []) {
+      if (it && typeof it === 'object' && it.id && !seenItem.has(String(it.id))) {
+        seenItem.set(String(it.id), it);
+        found = true;
+      }
+    }
+    for (const f of p.contentFolders || []) {
+      if (f && typeof f === 'object' && f.id && !seenFolder.has(String(f.id))) {
+        seenFolder.set(String(f.id), f);
+        found = true;
+      }
+    }
+  }
+  if (!found) return emptyLibrary();
+  for (const p of profiles) {
+    if (!p || typeof p !== 'object') continue;
+    p.contentItems = [];
+    p.contentFolders = [];
+  }
+  return { items: [...seenItem.values()], folders: [...seenFolder.values()] };
+};
+
+const parseRootContentLibrary = (parsed, profiles, hadRootLibraryKey) => {
+  if (
+    hadRootLibraryKey
+    && parsed.contentLibrary
+    && typeof parsed.contentLibrary === 'object'
+  ) {
+    const items = Array.isArray(parsed.contentLibrary.items) ? parsed.contentLibrary.items : [];
+    const folders = Array.isArray(parsed.contentLibrary.folders) ? parsed.contentLibrary.folders : [];
+    return { items, folders };
+  }
+  return migrateEmbeddedContentToLibrary(profiles);
+};
+
+const parseExclusions = (parsed) => {
+  const ex = parsed?.contentLibraryExclusions;
+  if (!ex || typeof ex !== 'object' || Array.isArray(ex)) return {};
+  const out = {};
+  for (const [pid, arr] of Object.entries(ex)) {
+    if (typeof pid !== 'string' || !Array.isArray(arr)) continue;
+    out[pid] = arr.filter((x) => typeof x === 'string');
+  }
+  return out;
+};
+
+const buildReadSuccess = (parsed) => {
+  const rawProfiles = parseProfilesPayload(parsed);
+  const profiles = mapSanitizedProfiles(rawProfiles);
+  const hadRootLibraryKey = Boolean(
+    parsed && Object.prototype.hasOwnProperty.call(parsed, 'contentLibrary'),
+  );
+  const contentLibrary = parseRootContentLibrary(parsed, profiles, hadRootLibraryKey);
+  const contentLibraryExclusions = parseExclusions(parsed);
+  if (hadRootLibraryKey) {
+    for (const p of profiles) {
+      if (p && typeof p === 'object') {
+        p.contentItems = [];
+        p.contentFolders = [];
+      }
+    }
+  }
+  return {
+    profiles,
+    contentLibrary,
+    contentLibraryExclusions,
+    storeError: null,
+  };
+};
+
+/**
+ * Read profiles + global content library from disk.
+ * @returns {{
+ *   profiles: unknown[],
+ *   contentLibrary: { items: unknown[], folders: unknown[] },
+ *   contentLibraryExclusions: Record<string, string[]>,
+ *   storeError: ProfileStoreReadError | null
+ * }}
  */
 const readProfilesFromDisk = () => {
   const storePath = getProfileStorePath();
   if (!fs.existsSync(storePath)) {
-    return { profiles: [], storeError: null };
+    return {
+      profiles: [],
+      contentLibrary: emptyLibrary(),
+      contentLibraryExclusions: {},
+      storeError: null,
+    };
   }
 
   try {
@@ -51,6 +144,8 @@ const readProfilesFromDisk = () => {
         console.error('[profile-store] Encrypted store present but OS encryption is unavailable');
         return {
           profiles: [],
+          contentLibrary: emptyLibrary(),
+          contentLibraryExclusions: {},
           storeError: { code: 'ENCRYPTION_UNAVAILABLE', message },
         };
       }
@@ -62,6 +157,8 @@ const readProfilesFromDisk = () => {
         console.error('[profile-store] Decrypt failed:', err);
         return {
           profiles: [],
+          contentLibrary: emptyLibrary(),
+          contentLibraryExclusions: {},
           storeError: {
             code: 'DECRYPT_FAILED',
             message: (
@@ -78,17 +175,15 @@ const readProfilesFromDisk = () => {
         console.error('[profile-store] JSON parse failed (encrypted payload):', err);
         return {
           profiles: [],
+          contentLibrary: emptyLibrary(),
+          contentLibraryExclusions: {},
           storeError: {
             code: 'PARSE_FAILED',
             message: 'Decrypted profile data could not be read. The file may be damaged.',
           },
         };
       }
-      const profiles = parseProfilesPayload(parsed);
-      return {
-        profiles: mapSanitizedProfiles(profiles),
-        storeError: null,
-      };
+      return buildReadSuccess(parsed);
     }
 
     let parsed;
@@ -98,6 +193,8 @@ const readProfilesFromDisk = () => {
       console.error('[profile-store] JSON parse failed (plain JSON):', err);
       return {
         profiles: [],
+        contentLibrary: emptyLibrary(),
+        contentLibraryExclusions: {},
         storeError: {
           code: 'PARSE_FAILED',
           message: (
@@ -106,15 +203,13 @@ const readProfilesFromDisk = () => {
         },
       };
     }
-    const profiles = parseProfilesPayload(parsed);
-    return {
-      profiles: mapSanitizedProfiles(profiles),
-      storeError: null,
-    };
+    return buildReadSuccess(parsed);
   } catch (error) {
     console.error('[profile-store] Failed to read profiles:', error);
     return {
       profiles: [],
+      contentLibrary: emptyLibrary(),
+      contentLibraryExclusions: {},
       storeError: {
         code: 'READ_FAILED',
         message: (
@@ -125,29 +220,64 @@ const readProfilesFromDisk = () => {
   }
 };
 
-const writeProfilesToDisk = (profiles) => {
-  const safeProfiles = normalizeProfiles(profiles).map((p) => sanitizeProfileLaunchFieldsDeep(sanitizeProfileIconPathsDeep(p)));
+/**
+ * Persist profiles and global content library.
+ * @param {{
+ *   profiles: unknown[],
+ *   contentLibrary: { items: unknown[], folders: unknown[] },
+ *   contentLibraryExclusions?: Record<string, string[]>
+ * } | unknown[]} payload
+ * @returns {unknown[]} sanitized profiles (for callers that still expect an array)
+ */
+const writeProfilesToDisk = (payload) => {
+  let profiles;
+  let contentLibrary;
+  let contentLibraryExclusions;
+
+  if (Array.isArray(payload)) {
+    const disk = readProfilesFromDisk();
+    profiles = normalizeProfiles(payload);
+    contentLibrary = disk.contentLibrary && typeof disk.contentLibrary === 'object'
+      ? disk.contentLibrary
+      : emptyLibrary();
+    contentLibraryExclusions = disk.contentLibraryExclusions && typeof disk.contentLibraryExclusions === 'object'
+      ? disk.contentLibraryExclusions
+      : {};
+  } else if (payload && typeof payload === 'object') {
+    profiles = normalizeProfiles(payload.profiles);
+    contentLibrary = payload.contentLibrary && typeof payload.contentLibrary === 'object'
+      ? {
+        items: Array.isArray(payload.contentLibrary.items) ? payload.contentLibrary.items : [],
+        folders: Array.isArray(payload.contentLibrary.folders) ? payload.contentLibrary.folders : [],
+      }
+      : emptyLibrary();
+    contentLibraryExclusions = payload.contentLibraryExclusions && typeof payload.contentLibraryExclusions === 'object'
+      ? payload.contentLibraryExclusions
+      : {};
+  } else {
+    throw new Error('Invalid profile store write payload');
+  }
+
+  const safeProfiles = profiles.map((p) => sanitizeProfileLaunchFieldsDeep(sanitizeProfileIconPathsDeep(p)));
   const storePath = getProfileStorePath();
   const dirPath = path.dirname(storePath);
   const tempPath = `${storePath}.tmp`;
 
   fs.mkdirSync(dirPath, { recursive: true });
 
-  const payload = {
+  const storeBody = {
     version: 1,
     updatedAt: Date.now(),
     profiles: safeProfiles,
+    contentLibrary,
+    contentLibraryExclusions,
   };
 
-  const json = JSON.stringify(payload, null, 2);
+  const json = JSON.stringify(storeBody, null, 2);
 
   if (safeStorage.isEncryptionAvailable()) {
     try {
-      const encrypted = safeStorage.encryptString(JSON.stringify({
-        version: payload.version,
-        updatedAt: payload.updatedAt,
-        profiles: safeProfiles,
-      }));
+      const encrypted = safeStorage.encryptString(JSON.stringify(storeBody));
       const out = Buffer.concat([MAGIC, Buffer.from([FORMAT_VERSION]), encrypted]);
       fs.writeFileSync(tempPath, out);
       fs.renameSync(tempPath, storePath);

--- a/src/main/utils/sanitize-profile-store-payload.js
+++ b/src/main/utils/sanitize-profile-store-payload.js
@@ -1,0 +1,160 @@
+/**
+ * Validates and lightly normalizes the full profile store document (profiles +
+ * global content library) before writing to disk.
+ */
+const {
+  MAX_PROFILE_COUNT,
+  MAX_PROFILE_ID_LENGTH,
+  MAX_PROFILE_NAME_LENGTH,
+  MAX_PROFILE_PAYLOAD_SIZE_BYTES,
+} = require('./limits');
+const { safeLimitedString, normalizeSafeUrl } = require('./url-safety');
+const { sanitizeProfileIconPathsDeep } = require('./profile-icon-paths');
+const { sanitizeProfileLaunchFieldsDeep } = require('./profile-launch-fields');
+
+const MAX_CONTENT_ITEMS = 8000;
+const MAX_CONTENT_FOLDERS = 2000;
+const MAX_CONTENT_STRING = 4096;
+const MAX_EXCLUSIONS_PER_PROFILE = 4000;
+
+const clampStr = (v, max) => safeLimitedString(String(v ?? ''), max);
+
+const sanitizeProfilesArray = (profiles) => {
+  if (!Array.isArray(profiles)) {
+    throw new Error('Profiles payload must be an array');
+  }
+  if (profiles.length > MAX_PROFILE_COUNT) {
+    throw new Error('Profiles payload exceeds maximum profile count');
+  }
+
+  return profiles
+    .filter((profile) => profile && typeof profile === 'object' && !Array.isArray(profile))
+    .map((profile) => {
+      const normalized = { ...profile };
+      normalized.id = safeLimitedString(profile.id, MAX_PROFILE_ID_LENGTH);
+      normalized.name = safeLimitedString(profile.name, MAX_PROFILE_NAME_LENGTH);
+      if (Array.isArray(profile.browserTabs)) {
+        normalized.browserTabs = profile.browserTabs
+          .map((tab) => {
+            const url = normalizeSafeUrl(tab?.url);
+            if (!url) return null;
+            return { ...tab, url };
+          })
+          .filter(Boolean);
+      }
+      if (Array.isArray(profile.actions)) {
+        normalized.actions = profile.actions
+          .map((action) => {
+            if (action?.type !== 'browserTab') return action;
+            const url = normalizeSafeUrl(action?.url);
+            if (!url) return null;
+            return { ...action, url };
+          })
+          .filter(Boolean);
+      }
+      return sanitizeProfileLaunchFieldsDeep(sanitizeProfileIconPathsDeep(normalized));
+    });
+};
+
+const sanitizeContentItems = (items) => {
+  if (!Array.isArray(items)) return [];
+  return items.slice(0, MAX_CONTENT_ITEMS).map((row) => {
+    if (!row || typeof row !== 'object') return null;
+    const id = clampStr(row.id, 128);
+    if (!id) return null;
+    const type = row.type === 'link' ? 'link' : 'file';
+    const out = {
+      ...row,
+      id,
+      type,
+      name: clampStr(row.name, MAX_CONTENT_STRING),
+      defaultApp: clampStr(row.defaultApp, 256),
+      parentId: row.parentId ? clampStr(row.parentId, 128) : undefined,
+      url: type === 'link' ? normalizeSafeUrl(row.url) || '' : row.url,
+      path: row.path ? clampStr(row.path, MAX_CONTENT_STRING) : undefined,
+      fileType: row.fileType ? clampStr(row.fileType, 64) : undefined,
+      description: row.description ? clampStr(row.description, MAX_CONTENT_STRING) : undefined,
+    };
+    if (type === 'link' && !out.url) return null;
+    return out;
+  }).filter(Boolean);
+};
+
+const sanitizeContentFolders = (folders) => {
+  if (!Array.isArray(folders)) return [];
+  return folders.slice(0, MAX_CONTENT_FOLDERS).map((row) => {
+    if (!row || typeof row !== 'object') return null;
+    const id = clampStr(row.id, 128);
+    if (!id) return null;
+    const children = Array.isArray(row.children)
+      ? row.children.map((c) => clampStr(c, 128)).filter(Boolean)
+      : [];
+    return {
+      ...row,
+      id,
+      name: clampStr(row.name, MAX_CONTENT_STRING),
+      type: 'folder',
+      defaultApp: clampStr(row.defaultApp, 256),
+      parentId: row.parentId ? clampStr(row.parentId, 128) : undefined,
+      diskPath: row.diskPath ? clampStr(row.diskPath, MAX_CONTENT_STRING) : undefined,
+      contentType: row.contentType === 'link' || row.contentType === 'file' || row.contentType === 'mixed'
+        ? row.contentType
+        : 'mixed',
+      children: children.slice(0, MAX_CONTENT_ITEMS),
+    };
+  }).filter(Boolean);
+};
+
+const sanitizeExclusions = (raw) => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out = {};
+  for (const [pid, arr] of Object.entries(raw)) {
+    const profileId = clampStr(pid, MAX_PROFILE_ID_LENGTH);
+    if (!profileId || !Array.isArray(arr)) continue;
+    out[profileId] = arr
+      .map((x) => clampStr(x, 128))
+      .filter(Boolean)
+      .slice(0, MAX_EXCLUSIONS_PER_PROFILE);
+  }
+  return out;
+};
+
+/**
+ * @param {unknown} payload
+ * @returns {{ profiles: unknown[], contentLibrary: { items: unknown[], folders: unknown[] }, contentLibraryExclusions: Record<string, string[]> }}
+ */
+const sanitizeProfileStorePayload = (payload) => {
+  let profilesInput;
+  let libraryInput;
+  let exclusionsInput;
+
+  if (Array.isArray(payload)) {
+    profilesInput = payload;
+    libraryInput = { items: [], folders: [] };
+    exclusionsInput = {};
+  } else if (payload && typeof payload === 'object') {
+    profilesInput = payload.profiles;
+    libraryInput = payload.contentLibrary;
+    exclusionsInput = payload.contentLibraryExclusions;
+  } else {
+    throw new Error('Invalid profile store payload');
+  }
+
+  const profiles = sanitizeProfilesArray(profilesInput);
+  const contentLibrary = {
+    items: sanitizeContentItems(libraryInput?.items),
+    folders: sanitizeContentFolders(libraryInput?.folders),
+  };
+  const contentLibraryExclusions = sanitizeExclusions(exclusionsInput);
+
+  const blob = JSON.stringify({ profiles, contentLibrary, contentLibraryExclusions });
+  if (Buffer.byteLength(blob, 'utf8') > MAX_PROFILE_PAYLOAD_SIZE_BYTES) {
+    throw new Error('Profile store payload exceeds size limit');
+  }
+
+  return { profiles, contentLibrary, contentLibraryExclusions };
+};
+
+module.exports = {
+  sanitizeProfileStorePayload,
+};

--- a/src/preload.js
+++ b/src/preload.js
@@ -19,7 +19,8 @@ contextBridge.exposeInMainWorld('electron', {
 
   // Profile persistence API
   listProfiles: () => ipcRenderer.invoke('profiles:list'),
-  saveProfiles: (profiles) => ipcRenderer.invoke('profiles:save-all', profiles),
+  saveProfiles: (payload) => ipcRenderer.invoke('profiles:save-all', payload),
+  pickContentLibraryPaths: (opts) => ipcRenderer.invoke('content-library:pick-paths', opts ?? {}),
 
   // Zone placement history (main-process stats)
   getZoneHistoryStats: () => ipcRenderer.invoke('zone-history:stats'),

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -14,7 +14,21 @@ import { MonitorLayout } from "./components/MonitorLayout";
 import { ProfileSettings } from "./components/ProfileSettings";
 import { CreateProfileModal } from "./components/CreateProfileModal";
 import { AppManager } from "./components/AppManager";
-import { ContentManager } from "./components/ContentManager";
+import {
+  ContentManager,
+  type ContentFolder,
+  type ContentItem,
+} from "./components/ContentManager";
+import {
+  placeSidebarContentOnMinimized,
+  placeSidebarContentOnMonitor,
+  placeSidebarLibraryFolderOnMinimized,
+  placeSidebarLibraryFolderOnMonitor,
+} from "./utils/sidebarExplicitPlacement";
+import {
+  SelectedContentDetails,
+  type LibrarySelection,
+} from "./components/SelectedContentDetails";
 import { SelectedAppDetails } from "./components/SelectedAppDetails";
 import {
   Play,
@@ -37,7 +51,12 @@ import {
 } from "lucide-react";
 import { DragState } from "./types/dragTypes";
 import { safeIconSrc } from "../utils/safeIconSrc";
-import type { FlowProfile } from "../../types/flow-profile";
+import type { FlowProfile, ProfileSavePayload } from "../../types/flow-profile";
+import { toSerializableProfiles } from "../../types/flow-profile";
+import {
+  deleteLibraryFolder,
+  deleteLibraryItem,
+} from "./utils/contentLibraryMutations";
 import { useProfilesPersistence } from "./hooks/useProfilesPersistence";
 import { useLaunchFeedback } from "./hooks/useLaunchFeedback";
 import { useProfileLaunch } from "./hooks/useProfileLaunch";
@@ -69,6 +88,10 @@ export default function App() {
   const {
     profiles,
     setProfiles,
+    contentLibrary,
+    setContentLibrary,
+    contentLibraryExclusions,
+    setContentLibraryExclusions,
     profilesLoaded,
     profileStoreError,
     skipNextAutosaveRef,
@@ -96,6 +119,11 @@ export default function App() {
 
   const [rightSidebarOpen, setRightSidebarOpen] =
     useState(false);
+  const [librarySelection, setLibrarySelection] =
+    useState<LibrarySelection | null>(null);
+  const [openLibraryFolderId, setOpenLibraryFolderId] = useState<
+    string | null
+  >(null);
 
   // CUSTOM DRAG SYSTEM STATE
   const [dragState, setDragState] = useState<DragState>({
@@ -121,6 +149,44 @@ export default function App() {
   const currentProfile = profiles.find(
     (p) => p.id === selectedProfile,
   ) || null;
+
+  const excludedContentIdSet = useMemo(() => {
+    if (!selectedProfile) return new Set<string>();
+    return new Set(contentLibraryExclusions[selectedProfile] || []);
+  }, [
+    selectedProfile,
+    selectedProfile
+      ? (contentLibraryExclusions[selectedProfile] || []).join("|")
+      : "",
+  ]);
+
+  const resolvedLibrarySelection = useMemo((): LibrarySelection | null => {
+    if (!librarySelection) return null;
+    const items = contentLibrary.items as ContentItem[];
+    const fds = contentLibrary.folders as ContentFolder[];
+    if (librarySelection.kind === "item") {
+      const it = items.find((i) => i.id === librarySelection.item.id);
+      return it ? { kind: "item" as const, item: it } : null;
+    }
+    const fd = fds.find((f) => f.id === librarySelection.folder.id);
+    return fd ? { kind: "folder" as const, folder: fd } : null;
+  }, [librarySelection, contentLibrary.items, contentLibrary.folders]);
+
+  /** Avoid empty inspector while library arrays briefly disagree with selection (persist/sync races). */
+  const contentInspectorSelection = useMemo((): LibrarySelection | null => {
+    if (!librarySelection) return null;
+    if (resolvedLibrarySelection) return resolvedLibrarySelection;
+    return librarySelection;
+  }, [librarySelection, resolvedLibrarySelection]);
+
+  const resolvedLibraryEntryExcluded = useMemo(() => {
+    if (!selectedProfile || !contentInspectorSelection) return false;
+    return (contentLibraryExclusions[selectedProfile] || []).includes(
+      contentInspectorSelection.kind === "item"
+        ? contentInspectorSelection.item.id
+        : contentInspectorSelection.folder.id,
+    );
+  }, [selectedProfile, contentInspectorSelection, contentLibraryExclusions]);
 
   useEffect(() => {
     setSidebarSearchQuery("");
@@ -212,8 +278,66 @@ export default function App() {
     profileDragActionsRef,
   });
 
+  const buildSavePayload = useCallback((): ProfileSavePayload => ({
+    profiles: toSerializableProfiles(profiles),
+    contentLibrary,
+    contentLibraryExclusions,
+  }), [profiles, contentLibrary, contentLibraryExclusions]);
+
+  const handlePersistContentLibrary = useCallback(
+    (next: { items: ContentItem[]; folders: ContentFolder[] }) => {
+      setContentLibrary({ items: next.items, folders: next.folders });
+    },
+    [setContentLibrary],
+  );
+
+  const handleDeleteLibraryEntry = useCallback(
+    (scope: "item" | "folder", id: string) => {
+      if (
+        librarySelection
+        && ((librarySelection.kind === "item" && librarySelection.item.id === id)
+          || (librarySelection.kind === "folder" && librarySelection.folder.id === id))
+      ) {
+        setRightSidebarOpen(false);
+        setLibrarySelection(null);
+      }
+      setContentLibrary((prev) => {
+        const items = prev.items as ContentItem[];
+        const folders = prev.folders as ContentFolder[];
+        const out =
+          scope === "folder"
+            ? deleteLibraryFolder(folders, items, id)
+            : deleteLibraryItem(items, folders, id);
+        return { ...prev, items: out.items, folders: out.folders };
+      });
+      setContentLibraryExclusions((ex) => {
+        const next: Record<string, string[]> = {};
+        for (const [pid, arr] of Object.entries(ex)) {
+          next[pid] = (arr || []).filter((x) => x !== id);
+        }
+        return next;
+      });
+    },
+    [librarySelection],
+  );
+
+  const handleToggleContentExclusionForEntry = useCallback(
+    (entryId: string) => {
+      if (!selectedProfile) return;
+      setContentLibraryExclusions((prev) => {
+        const cur = [...(prev[selectedProfile] || [])];
+        const ix = cur.indexOf(entryId);
+        if (ix >= 0) cur.splice(ix, 1);
+        else cur.push(entryId);
+        return { ...prev, [selectedProfile]: cur };
+      });
+    },
+    [selectedProfile],
+  );
+
   const { handleLaunch, handleCancelLaunch } = useProfileLaunch({
     profiles,
+    buildSavePayload,
     selectedProfileId: selectedProfile,
     setIsLaunching,
     setLaunchFeedback,
@@ -228,8 +352,142 @@ export default function App() {
   // SELECTED APP HANDLERS
   const handleClearAppSelection = useCallback(() => {
     setSelectedApp(null);
+    setLibrarySelection(null);
+    setOpenLibraryFolderId(null);
     setRightSidebarOpen(false);
   }, []);
+
+  const handlePlaceContentOnMonitor = useCallback(
+    (monitorId: string, item: ContentItem) => {
+      if (!currentProfile) return;
+      placeSidebarContentOnMonitor({
+        profile: currentProfile,
+        monitorId,
+        item,
+        addApp,
+        addBrowserTab,
+      });
+    },
+    [currentProfile, addApp, addBrowserTab],
+  );
+
+  const handlePlaceContentOnMinimized = useCallback(
+    (item: ContentItem) => {
+      if (!currentProfile) return;
+      placeSidebarContentOnMinimized({
+        profile: currentProfile,
+        item,
+        addAppToMinimized,
+        addBrowserTab,
+      });
+    },
+    [currentProfile, addAppToMinimized, addBrowserTab],
+  );
+
+  const handleConsumedOpenLibraryFolder = useCallback(() => {
+    setOpenLibraryFolderId(null);
+  }, []);
+
+  const handleInspectLibrarySelection = useCallback(
+    (payload: LibrarySelection) => {
+      setLibrarySelection(payload);
+      setSelectedApp(null);
+      setRightSidebarOpen(true);
+    },
+    [],
+  );
+
+  const handleLibraryChangeDefaultApp = useCallback(
+    (id: string, nextApp: string, scope: "item" | "folder") => {
+      setContentLibrary((prev) => {
+        if (scope === "item") {
+          return {
+            ...prev,
+            items: (prev.items as ContentItem[]).map((it) =>
+              it.id === id ? { ...it, defaultApp: nextApp } : it,
+            ),
+          };
+        }
+        return {
+          ...prev,
+          folders: (prev.folders as ContentFolder[]).map((f) =>
+            f.id === id ? { ...f, defaultApp: nextApp } : f,
+          ),
+        };
+      });
+    },
+    [setContentLibrary],
+  );
+
+  const clearInspectorSelection = useCallback(() => {
+    setRightSidebarOpen(false);
+    setSelectedApp(null);
+    setLibrarySelection(null);
+    setOpenLibraryFolderId(null);
+  }, []);
+
+  const handleLibraryPlaceOnMonitor = useCallback(
+    (monitorId: string) => {
+      if (!currentProfile || !contentInspectorSelection) return;
+      if (contentInspectorSelection.kind === "item") {
+        placeSidebarContentOnMonitor({
+          profile: currentProfile,
+          monitorId,
+          item: contentInspectorSelection.item,
+          addApp,
+          addBrowserTab,
+        });
+      } else {
+        placeSidebarLibraryFolderOnMonitor({
+          profile: currentProfile,
+          monitorId,
+          folder: contentInspectorSelection.folder,
+          folders: contentLibrary.folders as ContentFolder[],
+          libraryItems: contentLibrary.items as ContentItem[],
+          addApp,
+        });
+      }
+      clearInspectorSelection();
+    },
+    [
+      currentProfile,
+      contentInspectorSelection,
+      contentLibrary.folders,
+      contentLibrary.items,
+      addApp,
+      addBrowserTab,
+      clearInspectorSelection,
+    ],
+  );
+
+  const handleLibraryPlaceOnMinimized = useCallback(() => {
+    if (!currentProfile || !contentInspectorSelection) return;
+    if (contentInspectorSelection.kind === "item") {
+      placeSidebarContentOnMinimized({
+        profile: currentProfile,
+        item: contentInspectorSelection.item,
+        addAppToMinimized,
+        addBrowserTab,
+      });
+    } else {
+      placeSidebarLibraryFolderOnMinimized({
+        profile: currentProfile,
+        folder: contentInspectorSelection.folder,
+        folders: contentLibrary.folders as ContentFolder[],
+        libraryItems: contentLibrary.items as ContentItem[],
+        addAppToMinimized,
+      });
+    }
+    clearInspectorSelection();
+  }, [
+    currentProfile,
+    contentInspectorSelection,
+    contentLibrary.folders,
+    contentLibrary.items,
+    addAppToMinimized,
+    addBrowserTab,
+    clearInspectorSelection,
+  ]);
 
   const handleAppSelect = useCallback(
     (
@@ -249,6 +507,9 @@ export default function App() {
       });
 
       if (!currentProfile) return;
+
+      setLibrarySelection(null);
+      setOpenLibraryFolderId(null);
 
       // Determine if this is a browser app
       const isBrowser =
@@ -615,9 +876,8 @@ export default function App() {
   }, [selectedApp, currentProfile]);
 
   const handleCloseSidebar = useCallback(() => {
-    setRightSidebarOpen(false);
-    setSelectedApp(null);
-  }, []);
+    clearInspectorSelection();
+  }, [clearInspectorSelection]);
 
   // FIXED: Simplified profile switching
   const handleProfileSwitch = useCallback(
@@ -647,6 +907,8 @@ export default function App() {
 
       // Clear any selected app when switching profiles
       setSelectedApp(null);
+      setLibrarySelection(null);
+      setOpenLibraryFolderId(null);
       setRightSidebarOpen(false);
 
       console.log("🎉 PROFILE SWITCH COMPLETED:", profileId);
@@ -903,6 +1165,36 @@ export default function App() {
                   onUpdateProfile={updateProfile}
                   onDragStart={handleDragStart}
                   onCustomDragStart={handleCustomDragStart}
+                  onPlaceContentOnMonitor={handlePlaceContentOnMonitor}
+                  onPlaceContentOnMinimized={handlePlaceContentOnMinimized}
+                  onPlaceLibraryFolderOnMonitor={(monitorId, folder) => {
+                    if (!currentProfile) return;
+                    placeSidebarLibraryFolderOnMonitor({
+                      profile: currentProfile,
+                      monitorId,
+                      folder,
+                      folders: contentLibrary.folders as ContentFolder[],
+                      libraryItems: contentLibrary.items as ContentItem[],
+                      addApp,
+                    });
+                  }}
+                  onPlaceLibraryFolderOnMinimized={(folder) => {
+                    if (!currentProfile) return;
+                    placeSidebarLibraryFolderOnMinimized({
+                      profile: currentProfile,
+                      folder,
+                      folders: contentLibrary.folders as ContentFolder[],
+                      libraryItems: contentLibrary.items as ContentItem[],
+                      addAppToMinimized,
+                    });
+                  }}
+                  onInspectLibrarySelection={handleInspectLibrarySelection}
+                  openLibraryFolderId={openLibraryFolderId}
+                  onConsumedOpenLibraryFolder={handleConsumedOpenLibraryFolder}
+                  externalContentItems={contentLibrary.items as ContentItem[]}
+                  externalContentFolders={contentLibrary.folders as ContentFolder[]}
+                  excludedContentIds={Array.from(excludedContentIdSet)}
+                  onPersistContentLibrary={handlePersistContentLibrary}
                   compact={true}
                   sidebarSearchQuery={sidebarSearchQuery}
                   onSidebarSearchQueryChange={setSidebarSearchQuery}
@@ -1260,36 +1552,68 @@ export default function App() {
 
             {/* Sidebar Content - Now contains app header */}
             <div className="flex-1 overflow-hidden">
-              <SelectedAppDetails
-                selectedApp={selectedApp}
-                onClose={handleCloseSidebar}
-                onUpdateApp={handleSelectedAppUpdate}
-                onUpdateAssociatedFiles={
-                  handleSelectedAppAssociatedFiles
-                }
-                onDeleteApp={handleSelectedAppDelete}
-                onMoveToMonitor={handleSelectedAppMoveToMonitor}
-                onMoveToMinimized={
-                  handleSelectedAppMoveToMinimized
-                }
-                monitors={currentProfile?.monitors || []}
-                browserTabs={currentProfile?.browserTabs || []}
-                onUpdateBrowserTabs={(tabs) =>
-                  updateBrowserTabs(
-                    currentProfile?.id || "",
-                    tabs,
-                  )
-                }
-                onAddBrowserTab={(tab) =>
-                  addBrowserTab(currentProfile?.id || "", tab)
-                }
-              />
+              {librarySelection
+              && contentInspectorSelection
+              && currentProfile ? (
+                <SelectedContentDetails
+                  selection={contentInspectorSelection}
+                  onChangeDefaultApp={handleLibraryChangeDefaultApp}
+                  excludedFromActiveProfile={resolvedLibraryEntryExcluded}
+                  onToggleExcludeFromActiveProfile={() => {
+                    if (!contentInspectorSelection) return;
+                    handleToggleContentExclusionForEntry(
+                      contentInspectorSelection.kind === "item"
+                        ? contentInspectorSelection.item.id
+                        : contentInspectorSelection.folder.id,
+                    );
+                  }}
+                  onDeleteFromLibrary={() => {
+                    if (!contentInspectorSelection) return;
+                    handleDeleteLibraryEntry(
+                      contentInspectorSelection.kind === "item"
+                        ? "item"
+                        : "folder",
+                      contentInspectorSelection.kind === "item"
+                        ? contentInspectorSelection.item.id
+                        : contentInspectorSelection.folder.id,
+                    );
+                  }}
+                  onPlaceOnMonitor={handleLibraryPlaceOnMonitor}
+                  onPlaceOnMinimized={handleLibraryPlaceOnMinimized}
+                  monitors={currentProfile.monitors || []}
+                />
+              ) : selectedApp ? (
+                <SelectedAppDetails
+                  selectedApp={selectedApp}
+                  onClose={handleCloseSidebar}
+                  onUpdateApp={handleSelectedAppUpdate}
+                  onUpdateAssociatedFiles={
+                    handleSelectedAppAssociatedFiles
+                  }
+                  onDeleteApp={handleSelectedAppDelete}
+                  onMoveToMonitor={handleSelectedAppMoveToMonitor}
+                  onMoveToMinimized={
+                    handleSelectedAppMoveToMinimized
+                  }
+                  monitors={currentProfile?.monitors || []}
+                  browserTabs={currentProfile?.browserTabs || []}
+                  onUpdateBrowserTabs={(tabs) =>
+                    updateBrowserTabs(
+                      currentProfile?.id || "",
+                      tabs,
+                    )
+                  }
+                  onAddBrowserTab={(tab) =>
+                    addBrowserTab(currentProfile?.id || "", tab)
+                  }
+                />
+              ) : null}
             </div>
           </div>
         )}
 
         {/* Right Sidebar Toggle Button (when closed) */}
-        {!rightSidebarOpen && selectedApp && (
+        {!rightSidebarOpen && (selectedApp || librarySelection) ? (
           <button
             type="button"
             onClick={() => setRightSidebarOpen(true)}
@@ -1298,11 +1622,15 @@ export default function App() {
               top: "calc(2.25rem + (100vh - 2.25rem) / 2)",
               transform: "translateY(-50%)",
             }}
-            title="Open App Details"
+            title={
+              librarySelection
+                ? "Open library item details"
+                : "Open app details"
+            }
           >
             <ChevronLeft className="w-4 h-4" />
           </button>
-        )}
+        ) : null}
 
         {/* Drag Overlay — pointer-events-none so hit-testing uses the cursor, not the preview */}
         {dragState.isDragging && dragState.dragData && (

--- a/src/renderer/layout/components/AddContentModal.tsx
+++ b/src/renderer/layout/components/AddContentModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from "react";
-import { X, ExternalLink, Upload, Folder, File, Globe, Link as LinkIcon } from "lucide-react";
+import { X, ExternalLink, Upload, Folder, File, Globe } from "lucide-react";
 
 interface AddContentModalProps {
   isOpen: boolean;
@@ -9,10 +9,20 @@ interface AddContentModalProps {
   onAddContent: (contentData: any) => void;
 }
 
+type NativePickedEntry = { path: string; kind: 'file' | 'directory' };
+
+type LibraryPickMode = 'files' | 'directory';
+
 // Function to detect file type from file name
 const getFileType = (fileName: string): string => {
   const extension = fileName.split('.').pop()?.toLowerCase();
   return extension || 'unknown';
+};
+
+const baseName = (p: string) => {
+  const s = p.replace(/[/\\]+$/, "");
+  const parts = s.split(/[/\\]/);
+  return parts[parts.length - 1] || s;
 };
 
 // Function to get default app for content
@@ -24,7 +34,7 @@ const getDefaultApp = (type: 'link' | 'file', fileName?: string, url?: string): 
     return 'Chrome';
   } else {
     if (!fileName) return 'File Explorer';
-    
+
     const extension = fileName.split('.').pop()?.toLowerCase();
     const appMap: { [key: string]: string } = {
       'pdf': 'Adobe Acrobat',
@@ -58,7 +68,7 @@ const getDefaultApp = (type: 'link' | 'file', fileName?: string, url?: string): 
       'rar': 'WinRAR',
       '7z': '7-Zip'
     };
-    
+
     return appMap[extension || ''] || 'File Explorer';
   }
 };
@@ -68,7 +78,7 @@ const extractTitleFromUrl = (url: string): string => {
   try {
     const urlObj = new URL(url);
     const hostname = urlObj.hostname.replace('www.', '');
-    
+
     // Common site mappings
     const siteNames: { [key: string]: string } = {
       'github.com': 'GitHub',
@@ -88,7 +98,7 @@ const extractTitleFromUrl = (url: string): string => {
       'slack.com': 'Slack',
       'discord.com': 'Discord'
     };
-    
+
     return siteNames[hostname] || hostname.split('.')[0];
   } catch {
     return url;
@@ -100,12 +110,18 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
   const [name, setName] = useState('');
 
   const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
+  const [nativeEntries, setNativeEntries] = useState<NativePickedEntry[] | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const hasDesktopPicker = Boolean(
+    typeof window !== 'undefined'
+    && window.electron?.pickContentLibraryPaths,
+  );
+
   const handleUrlChange = (newUrl: string) => {
     setUrl(newUrl);
-    
+
     // Auto-generate name from URL if name is empty
     if (!name && newUrl) {
       const extractedTitle = extractTitleFromUrl(newUrl);
@@ -116,7 +132,8 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     setSelectedFiles(files);
-    
+    setNativeEntries(null);
+
     // Auto-generate name from first file if name is empty
     if (files && files.length > 0 && !name) {
       if (files.length === 1) {
@@ -127,56 +144,126 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
     }
   };
 
+  const handleChooseFromComputer = async (pickMode: LibraryPickMode) => {
+    const pick = window.electron?.pickContentLibraryPaths;
+    if (!pick) {
+      window.alert('Desktop file picker is not available in this environment.');
+      return;
+    }
+    try {
+      const res = await pick({ mode: pickMode });
+      if (res.canceled || !res.entries?.length) return;
+      setSelectedFiles(null);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      setNativeEntries(res.entries);
+      if (!name) {
+        if (res.entries.length === 1) {
+          setName(baseName(res.entries[0].path));
+        } else {
+          const dirs = res.entries.filter((e) => e.kind === 'directory');
+          const files = res.entries.filter((e) => e.kind === 'file');
+          if (dirs.length === 1 && files.length === 0) {
+            setName(baseName(dirs[0].path));
+          } else {
+            setName(`${res.entries.length} paths`);
+          }
+        }
+      }
+    } catch {
+      window.alert('Could not open the file picker.');
+    }
+  };
+
   const handleSubmit = async () => {
     if (isSubmitting) return;
-    
+
     setIsSubmitting(true);
-    
+
     try {
       if (type === 'link') {
         if (!url || !name) {
           alert('Please provide both URL and name');
           return;
         }
-        
+
         const contentData = {
           type: 'link',
           name: name.trim(),
           url: url.trim(),
           defaultApp: getDefaultApp('link', undefined, url)
         };
-        
+
         onAddContent(contentData);
-        console.log('🔗 Adding link:', contentData);
       } else {
-        if (!selectedFiles || selectedFiles.length === 0) {
+        if (nativeEntries?.length) {
+          const dirs = nativeEntries.filter((e) => e.kind === 'directory');
+          const files = nativeEntries.filter((e) => e.kind === 'file');
+          if (dirs.length && files.length) {
+            alert('Choose only files or only folders in the same pick — not both.');
+            return;
+          }
+          if (dirs.length >= 1) {
+            for (let di = 0; di < dirs.length; di++) {
+              const dpath = dirs[di].path;
+              const base = baseName(dpath);
+              onAddContent({
+                libraryDiskFolder: true,
+                diskPath: dpath,
+                name:
+                  dirs.length === 1 && name.trim()
+                    ? name.trim()
+                    : base,
+                defaultApp: 'File Explorer',
+              });
+            }
+          }
+          if (files.length) {
+            for (let i = 0; i < files.length; i++) {
+              const fp = files[i].path;
+              const bn = baseName(fp);
+              onAddContent({
+                type: 'file',
+                name: files.length === 1 && name ? name.trim() : bn,
+                path: fp,
+                fileType: getFileType(bn),
+                isFolder: false,
+                defaultApp: getDefaultApp('file', bn),
+              });
+            }
+          }
+        } else if (selectedFiles && selectedFiles.length > 0) {
+          for (let i = 0; i < selectedFiles.length; i++) {
+            const file = selectedFiles[i];
+            const isFolder = Boolean(
+              file.webkitRelativePath && file.webkitRelativePath.includes("/"),
+            );
+            const absolutePath =
+              (file as File & { path?: string }).path
+              || file.webkitRelativePath
+              || file.name;
+
+            const contentData = {
+              type: 'file',
+              name: selectedFiles.length === 1 && name ? name.trim() : file.name,
+              path: absolutePath,
+              fileType: isFolder ? 'folder' : getFileType(file.name),
+              isFolder: isFolder,
+              defaultApp: getDefaultApp('file', file.name)
+            };
+
+            onAddContent(contentData);
+          }
+        } else {
           alert('Please select at least one file or folder');
           return;
         }
-        
-        // Process each selected file
-        for (let i = 0; i < selectedFiles.length; i++) {
-          const file = selectedFiles[i];
-          const isFolder = file.webkitRelativePath && file.webkitRelativePath.includes('/');
-          
-          const contentData = {
-            type: 'file',
-            name: selectedFiles.length === 1 && name ? name.trim() : file.name,
-            path: file.webkitRelativePath || file.name,
-            fileType: isFolder ? 'folder' : getFileType(file.name),
-            isFolder: isFolder,
-            defaultApp: getDefaultApp('file', file.name)
-          };
-          
-          onAddContent(contentData);
-          console.log('📁 Adding file:', contentData);
-        }
       }
-      
+
       // Reset form and close
       setUrl('');
       setName('');
       setSelectedFiles(null);
+      setNativeEntries(null);
       if (fileInputRef.current) {
         fileInputRef.current.value = '';
       }
@@ -193,11 +280,53 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
     setUrl('');
     setName('');
     setSelectedFiles(null);
+    setNativeEntries(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
     onClose();
   };
+
+  const fileHasSelection = Boolean(
+    (nativeEntries && nativeEntries.length > 0)
+    || (selectedFiles && selectedFiles.length > 0),
+  );
+
+  const previewFileLabel = (() => {
+    if (!fileHasSelection) return '';
+    if (nativeEntries?.length) {
+      const dirs = nativeEntries.filter((e) => e.kind === 'directory');
+      if (dirs.length === 1 && nativeEntries.every((e) => e.kind === 'directory')) {
+        return name.trim() || baseName(dirs[0].path);
+      }
+      if (nativeEntries.length === 1 && nativeEntries[0].kind === 'file') {
+        return name.trim() || baseName(nativeEntries[0].path);
+      }
+      return `${nativeEntries.length} paths`;
+    }
+    if (selectedFiles?.length === 1) {
+      return name.trim() || selectedFiles[0].name;
+    }
+    return `${selectedFiles?.length ?? 0} files`;
+  })();
+
+  const previewDefaultApp = (() => {
+    if (type === 'link') return getDefaultApp('link', undefined, url);
+    if (nativeEntries?.length) {
+      const dirs = nativeEntries.filter((e) => e.kind === 'directory');
+      if (dirs.length === 1 && nativeEntries.every((e) => e.kind === 'directory')) {
+        return 'File Explorer';
+      }
+      if (nativeEntries.length === 1 && nativeEntries[0].kind === 'file') {
+        return getDefaultApp('file', baseName(nativeEntries[0].path));
+      }
+      return 'Various';
+    }
+    if (selectedFiles && selectedFiles.length === 1) {
+      return getDefaultApp('file', selectedFiles[0].name);
+    }
+    return 'Various';
+  })();
 
   if (!isOpen) return null;
 
@@ -213,7 +342,7 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
               <Upload className="w-4 h-4 text-green-400" />
             )}
             <h3 className="text-lg font-semibold text-flow-text-primary">
-              {type === 'link' ? 'Add Link' : 'Add File/Folder'}
+              {type === 'link' ? 'Add Link' : 'Add files or folder'}
             </h3>
           </div>
           <button
@@ -270,36 +399,90 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
             </>
           ) : (
             <>
-              {/* File Input */}
               <div>
                 <label className="block text-sm font-medium text-flow-text-secondary mb-2">
-                  Select Files/Folders *
+                  From your computer *
                 </label>
-                <div className="relative">
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    onChange={handleFileSelect}
-                    className="hidden"
-                    webkitdirectory=""
-                  />
-                  <div
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  onChange={handleFileSelect}
+                  className="hidden"
+                />
+                {hasDesktopPicker ? (
+                  <div className="space-y-2">
+                    <button
+                      type="button"
+                      onClick={() => void handleChooseFromComputer('files')}
+                      className="w-full rounded-lg border-2 border-dashed border-flow-border bg-flow-surface p-4 text-center transition-colors hover:border-flow-border-accent hover:bg-flow-surface-elevated"
+                    >
+                      <Upload className="mx-auto mb-2 h-8 w-8 text-flow-text-muted" />
+                      <p className="text-sm font-medium text-flow-text-primary">
+                        Choose files
+                      </p>
+                      <p className="mt-1 text-xs text-flow-text-muted">
+                        One or more files; each becomes its own library entry.
+                      </p>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void handleChooseFromComputer('directory')}
+                      className="w-full rounded-lg border-2 border-dashed border-flow-border bg-flow-surface p-4 text-center transition-colors hover:border-flow-border-accent hover:bg-flow-surface-elevated"
+                    >
+                      <Folder
+                        className="mx-auto mb-2 h-8 w-8 text-amber-400/90"
+                        aria-hidden
+                      />
+                      <p className="text-sm font-medium text-flow-text-primary">
+                        Choose folder
+                      </p>
+                      <p className="mt-1 text-xs text-flow-text-muted">
+                        One folder path as a single entry (contents are not scanned).
+                      </p>
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    className="w-full p-4 border-2 border-dashed border-flow-border hover:border-flow-border-accent rounded-lg cursor-pointer transition-colors bg-flow-surface hover:bg-flow-surface-elevated"
+                    className="w-full rounded-lg border-2 border-dashed border-flow-border bg-flow-surface p-4 text-center transition-colors hover:border-flow-border-accent hover:bg-flow-surface-elevated"
                   >
-                    <div className="flex flex-col items-center text-center">
-                      <Upload className="w-8 h-8 text-flow-text-muted mb-2" />
-                      <p className="text-sm text-flow-text-primary font-medium">
-                        Click to select files or folders
-                      </p>
-                      <p className="text-xs text-flow-text-muted mt-1">
-                        Multiple files and folders supported
-                      </p>
+                    <Upload className="mx-auto mb-2 h-8 w-8 text-flow-text-muted" />
+                    <p className="text-sm font-medium text-flow-text-primary">
+                      Choose files
+                    </p>
+                    <p className="mt-1 text-xs text-flow-text-muted">
+                      Adding a folder path from disk requires the FlowSwitch desktop app.
+                    </p>
+                  </button>
+                )}
+
+                {nativeEntries && nativeEntries.length > 0 && (
+                  <div className="mt-2 p-3 bg-flow-bg-tertiary rounded-lg">
+                    <div className="text-xs text-flow-text-secondary font-medium mb-2">
+                      Selected ({nativeEntries.length}):
+                    </div>
+                    <div className="space-y-1 max-h-24 overflow-y-auto">
+                      {nativeEntries.slice(0, 6).map((e, index) => (
+                        <div key={`${e.path}:${index}`} className="flex items-center gap-2 text-xs text-flow-text-muted">
+                          {e.kind === 'directory' ? (
+                            <Folder className="w-3 h-3 flex-shrink-0 text-amber-400/90" />
+                          ) : (
+                            <File className="w-3 h-3 flex-shrink-0" />
+                          )}
+                          <span className="truncate">{baseName(e.path)}</span>
+                        </div>
+                      ))}
+                      {nativeEntries.length > 6 && (
+                        <div className="text-xs text-flow-text-muted italic">
+                          ... and {nativeEntries.length - 6} more
+                        </div>
+                      )}
                     </div>
                   </div>
-                </div>
-                
+                )}
+
                 {selectedFiles && selectedFiles.length > 0 && (
                   <div className="mt-2 p-3 bg-flow-bg-tertiary rounded-lg">
                     <div className="text-xs text-flow-text-secondary font-medium mb-2">
@@ -322,8 +505,10 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
                 )}
               </div>
 
-              {/* Custom Name Input (for single file) */}
-              {selectedFiles && selectedFiles.length === 1 && (
+              {(
+                (selectedFiles && selectedFiles.length === 1)
+                || (nativeEntries?.length === 1 && nativeEntries[0].kind === 'file')
+              ) && (
                 <div>
                   <label className="block text-sm font-medium text-flow-text-secondary mb-2">
                     Custom Name (optional)
@@ -343,7 +528,7 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
 
 
           {/* Preview Info */}
-          {((type === 'link' && url && name) || (type === 'file' && selectedFiles && selectedFiles.length > 0)) && (
+          {((type === 'link' && url && name) || (type === 'file' && fileHasSelection)) && (
             <div className="p-3 bg-flow-bg-tertiary rounded-lg border border-flow-border">
               <div className="text-xs text-flow-text-secondary font-medium mb-2">Preview:</div>
               <div className="flex items-center gap-2 text-sm">
@@ -353,16 +538,11 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
                   <File className="w-4 h-4 text-green-400" />
                 )}
                 <span className="text-flow-text-primary font-medium">
-                  {type === 'link' ? name : (selectedFiles?.length === 1 ? (name || selectedFiles[0].name) : `${selectedFiles?.length} files`)}
+                  {type === 'link' ? name : previewFileLabel}
                 </span>
               </div>
               <div className="text-xs text-flow-text-muted mt-1">
-                Default app: {type === 'link' 
-                  ? getDefaultApp('link', undefined, url)
-                  : selectedFiles && selectedFiles.length === 1 
-                    ? getDefaultApp('file', selectedFiles[0].name)
-                    : 'Various'
-                }
+                Default app: {previewDefaultApp}
               </div>
             </div>
           )}
@@ -378,10 +558,13 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
           </button>
           <button
             onClick={handleSubmit}
-            disabled={isSubmitting || (type === 'link' ? !url || !name : !selectedFiles || selectedFiles.length === 0)}
+            disabled={
+              isSubmitting
+              || (type === 'link' ? !url || !name : !fileHasSelection)
+            }
             className="px-4 py-2 text-sm font-medium bg-flow-accent-blue hover:bg-flow-accent-blue-hover text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? 'Adding...' : `Add ${type === 'link' ? 'Link' : 'File(s)'}`}
+            {isSubmitting ? 'Adding...' : `Add ${type === 'link' ? 'Link' : 'content'}`}
           </button>
         </div>
       </div>

--- a/src/renderer/layout/components/AppFileWindow.tsx
+++ b/src/renderer/layout/components/AppFileWindow.tsx
@@ -187,7 +187,6 @@ export function AppFileWindow({
   onAppSelect,
   onFileSelect
 }: AppFileWindowProps) {
-  const [isHovered, setIsHovered] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [localDragging, setLocalDragging] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -499,7 +498,13 @@ export function AppFileWindow({
             
             {/* Admin indicator if applicable */}
             {file.associatedApp === 'Terminal' && (
-              <Shield className="w-3 h-3 text-yellow-400 mt-1" title="May require Admin" />
+              <span
+                className="mt-1 inline-flex"
+                title="May require admin"
+                aria-label="May require admin"
+              >
+                <Shield className="h-3 w-3 text-yellow-400" aria-hidden />
+              </span>
             )}
           </div>
         </>
@@ -525,7 +530,13 @@ export function AppFileWindow({
             
             {/* Admin indicator */}
             {app.runAsAdmin && (
-              <Shield className="w-3 h-3 text-yellow-400 mt-1" title="Run as Admin" />
+              <span
+                className="mt-1 inline-flex"
+                title="Run as admin"
+                aria-label="Run as admin"
+              >
+                <Shield className="h-3 w-3 text-yellow-400" aria-hidden />
+              </span>
             )}
           </div>
         </>
@@ -998,8 +1009,6 @@ export function AppFileWindow({
           width: `${item.size.width}%`,
           height: `${item.size.height}%`,
         }}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
         draggable={isEditable}
         onDragStart={handleDragStartEvent}
         onDragEnd={handleDragEndEvent}
@@ -1053,30 +1062,38 @@ export function AppFileWindow({
             </div>
           )}
 
-          {/* Settings and Actions */}
-          {(isHovered || showSettings) && isEditable && !isCurrentlyDragging && (
-            <div className="absolute -top-2 -right-2 flex items-center gap-1 z-20">
+          {/* Settings and actions: visible in edit mode (drag remains a power shortcut) */}
+          {isEditable && !isCurrentlyDragging && (
+            <div className="pointer-events-auto absolute -top-2 -right-2 z-20 flex items-center gap-1">
               <button
+                type="button"
                 onClick={handleSettingsClick}
-                className="w-6 h-6 bg-white/20 backdrop-blur-sm border border-white/30 rounded-full flex items-center justify-center text-white/70 hover:bg-white/30 hover:text-white transition-all duration-200"
+                className={`flex h-6 w-6 items-center justify-center rounded-full border border-white/30 bg-white/20 text-white/80 backdrop-blur-sm transition-all duration-200 hover:bg-white/30 hover:text-white ${
+                  showSettings ? "ring-1 ring-white/50" : ""
+                }`}
                 title="Settings"
+                aria-label="Window settings"
               >
-                <Settings className="w-3 h-3" />
+                <Settings className="h-3 w-3" />
               </button>
               <button
+                type="button"
                 onClick={handleDeleteClick}
-                className="w-6 h-6 bg-red-500/20 backdrop-blur-sm border border-red-500/30 rounded-full flex items-center justify-center text-red-300 hover:bg-red-500/30 hover:text-red-100 transition-all duration-200"
+                className="flex h-6 w-6 items-center justify-center rounded-full border border-red-500/30 bg-red-500/20 text-red-200 backdrop-blur-sm transition-all duration-200 hover:bg-red-500/30 hover:text-red-50"
                 title="Delete"
+                aria-label="Remove from layout"
               >
-                <Trash2 className="w-3 h-3" />
+                <Trash2 className="h-3 w-3" />
               </button>
               {onMoveToMinimized && (
                 <button
+                  type="button"
                   onClick={handleMinimizeClick}
-                  className="w-6 h-6 bg-white/20 backdrop-blur-sm border border-white/30 rounded-full flex items-center justify-center text-white/70 hover:bg-white/30 hover:text-white transition-all duration-200"
+                  className="flex h-6 w-6 items-center justify-center rounded-full border border-white/30 bg-white/20 text-white/80 backdrop-blur-sm transition-all duration-200 hover:bg-white/30 hover:text-white"
                   title="Minimize"
+                  aria-label="Move to minimized row"
                 >
-                  <Minimize2 className="w-3 h-3" />
+                  <Minimize2 className="h-3 w-3" />
                 </button>
               )}
             </div>

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -1,13 +1,27 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { safeIconSrc } from "../../utils/safeIconSrc";
-import { Search, Settings, Trash2, Power, Save, Move, LayoutGrid } from "lucide-react";
+import {
+  Search,
+  Settings,
+  Trash2,
+  Power,
+  Save,
+  Move,
+  LayoutGrid,
+  Plus,
+} from "lucide-react";
 import { useInstalledApps } from "../../hooks/useInstalledApps";
+import {
+  placeInstalledSidebarAppOnMinimized,
+  placeInstalledSidebarAppOnMonitor,
+} from "../utils/sidebarExplicitPlacement";
 
 interface AppManagerProps {
   profiles: any[];
   onUpdateProfile: (profileId: string, updates: any) => void;
-  onAddApp?: (profileId: string, monitorId: string, newApp: any) => void;
-  onAddAppToMinimized?: (profileId: string, newApp: any) => void;
+  /** Adds to the active profile; parent closes over `profileId`. */
+  onAddApp?: (monitorId: string, newApp: any) => void;
+  onAddAppToMinimized?: (newApp: any) => void;
   onDragStart?: () => void;
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
   currentProfile?: any;
@@ -72,6 +86,7 @@ export function AppManager({
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [showAppSettings, setShowAppSettings] = useState(false);
   const [expandedApp, setExpandedApp] = useState<string | null>(null);
+  const [addMenuApp, setAddMenuApp] = useState<string | null>(null);
   const [sortOption, setSortOption] = useState<'name' | 'lastAccessed' | 'size'>('name');
   const installedApps = useInstalledApps();
   const allApps = useMemo<AppType[]>(() => (
@@ -118,6 +133,23 @@ export function AppManager({
     }
     return 0;
   });
+
+  const monitorsSortedForMenu = useMemo(() => {
+    const list = [...(currentProfile?.monitors ?? [])] as {
+      id: string;
+      name?: string;
+      primary?: boolean;
+    }[];
+    list.sort((a, b) => {
+      if (a.primary === b.primary) return 0;
+      return a.primary ? -1 : 1;
+    });
+    return list;
+  }, [currentProfile?.monitors]);
+
+  useEffect(() => {
+    setAddMenuApp(null);
+  }, [currentProfile?.id]);
 
   const getAppUsage = (appName: string) => {
     const usage = {
@@ -235,6 +267,46 @@ export function AppManager({
     }
   };
 
+  const stopRowPointerForDrag = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleAddInstalledToMonitor = (app: AppType, monitorId: string) => {
+    if (!currentProfile || !onAddApp) return;
+    placeInstalledSidebarAppOnMonitor({
+      profile: currentProfile,
+      monitorId,
+      app: {
+        name: app.name,
+        color: app.color,
+        iconPath: app.iconPath,
+        executablePath: app.executablePath ?? undefined,
+      },
+      addApp: (_profileId, mid, newApp) => {
+        onAddApp(mid, newApp);
+      },
+    });
+    setAddMenuApp(null);
+  };
+
+  const handleAddInstalledToMinimized = (app: AppType) => {
+    if (!currentProfile || !onAddAppToMinimized) return;
+    placeInstalledSidebarAppOnMinimized({
+      profile: currentProfile,
+      app: {
+        name: app.name,
+        color: app.color,
+        iconPath: app.iconPath,
+        executablePath: app.executablePath ?? undefined,
+      },
+      addAppToMinimized: (_profileId, newApp) => {
+        onAddAppToMinimized(newApp);
+      },
+    });
+    setAddMenuApp(null);
+  };
+
   if (compact) {
     return (
       <div className="flex min-h-0 flex-1 flex-col">
@@ -267,7 +339,10 @@ export function AppManager({
           <div className="mb-3 rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3">
             <div className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
               <Move className="h-3.5 w-3.5 shrink-0 text-flow-accent-blue" strokeWidth={1.75} />
-              <span>Drag apps onto a monitor or into the minimized row.</span>
+              <span>
+                Use <span className="font-medium text-flow-text-primary">+</span> to add to a
+                monitor or minimized row. Drag the app icon to place precisely on the canvas.
+              </span>
             </div>
           </div>
 
@@ -322,7 +397,34 @@ export function AppManager({
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-0.5">
-                      <h4 className="text-flow-text-primary text-sm font-medium truncate">{app.name}</h4>
+                      <h4
+                        className="text-flow-text-primary cursor-pointer text-sm font-medium truncate hover:text-flow-accent-blue"
+                        title={
+                          usage.profiles.length
+                            ? "Show where this app is used in profiles"
+                            : undefined
+                        }
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setAddMenuApp(null);
+                          setExpandedApp(
+                            isExpanded ? null : app.name,
+                          );
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            setAddMenuApp(null);
+                            setExpandedApp(
+                              isExpanded ? null : app.name,
+                            );
+                          }
+                        }}
+                        role={usage.profiles.length ? "button" : undefined}
+                        tabIndex={usage.profiles.length ? 0 : undefined}
+                      >
+                        {app.name}
+                      </h4>
                       <div className="flex items-center gap-1">
                         {usage.runAsAdmin && (
                           <span className="text-yellow-400 text-xs" title="Run as Admin">⚡</span>
@@ -336,22 +438,91 @@ export function AppManager({
                       </div>
                     </div>
                     <div className="flex items-center gap-2 text-xs text-flow-text-muted">
-                      <span className="px-1.5 py-0.5 bg-flow-bg-tertiary rounded text-xs">{app.category}</span>
-                      {usage.totalInstances > 0 && (
-                        <>
-                          <span>{usage.profiles.length} profiles</span>
-                          <span>{usage.totalInstances} instances</span>
-                        </>
-                      )}
+                      <span className="rounded bg-flow-bg-tertiary px-1.5 py-0.5 text-xs">
+                        {app.category}
+                      </span>
                     </div>
                   </div>
-                  <button
-                    onClick={() => setExpandedApp(isExpanded ? null : app.name)}
-                    className="p-1 text-flow-text-muted hover:text-flow-text-primary transition-colors"
-                    title="Toggle details"
+                  <div
+                    className="flex shrink-0 items-center gap-0.5 self-center"
+                    onMouseDown={stopRowPointerForDrag}
                   >
-                    <Settings className="w-3 h-3" />
-                  </button>
+                    <div className="relative">
+                      <button
+                        type="button"
+                        disabled={!currentProfile || !onAddApp}
+                        title={
+                          !currentProfile
+                            ? "Select a profile first"
+                            : "Add to a monitor or minimized row"
+                        }
+                        aria-label={`Add ${app.name} to layout`}
+                        aria-expanded={addMenuApp === app.name}
+                        aria-haspopup="menu"
+                        onClick={(e) => {
+                          stopRowPointerForDrag(e);
+                          setAddMenuApp(
+                            addMenuApp === app.name ? null : app.name,
+                          );
+                        }}
+                        className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
+                      </button>
+                      {addMenuApp === app.name ? (
+                        <div
+                          className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
+                          role="menu"
+                        >
+                          {monitorsSortedForMenu.length ? (
+                            monitorsSortedForMenu.map((m) => (
+                              <button
+                                key={m.id}
+                                type="button"
+                                role="menuitem"
+                                className="flow-menu-item text-left text-xs"
+                                onClick={(e) => {
+                                  stopRowPointerForDrag(e);
+                                  handleAddInstalledToMonitor(app, m.id);
+                                }}
+                              >
+                                {(m.name || m.id) +
+                                  (m.primary ? " (primary)" : "")}
+                              </button>
+                            ))
+                          ) : (
+                            <div className="px-3 py-2 text-[11px] text-flow-text-muted">
+                              No monitors in this profile.
+                            </div>
+                          )}
+                          <div
+                            className="my-0.5 h-px bg-flow-border/50"
+                            role="none"
+                          />
+                          <button
+                            type="button"
+                            role="menuitem"
+                            disabled={!currentProfile || !onAddAppToMinimized}
+                            title={
+                              !currentProfile
+                                ? "Select a profile first"
+                                : undefined
+                            }
+                            className="flow-menu-item text-left text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                            onClick={(e) => {
+                              stopRowPointerForDrag(e);
+                              handleAddInstalledToMinimized(app);
+                            }}
+                          >
+                            Minimized row
+                          </button>
+                          <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
+                            Drag the app icon to drop on a specific tile.
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
                 </div>
                 {/* Expanded Details - CLEAN: More compact */}
                 {isExpanded && usage.profiles.length > 0 && (

--- a/src/renderer/layout/components/ContentManager.tsx
+++ b/src/renderer/layout/components/ContentManager.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useEffect } from "react";
-import { Link, FileText, Plus, Settings, Search, Star, ExternalLink, Play, ChevronRight, ChevronDown, Folder, FolderPlus, Home, Heart, Clock, Filter, HelpCircle, Info, Upload, LayoutGrid, List, Grid3X3 } from "lucide-react";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { Link, FileText, Plus, Settings, Search, Star, ExternalLink, ChevronRight, ChevronDown, Folder, Home, Heart, Clock, Filter, HelpCircle, Info, Upload, LayoutGrid, List, Grid3X3 } from "lucide-react";
 import { FileIcon, getFileTypeColor } from "./FileIcon";
 import { AddContentModal } from "./AddContentModal";
 import {
@@ -8,20 +8,22 @@ import {
 } from "../utils/documentTextSelection";
 
 // Enhanced content types for the unified system
-interface ContentFolder {
+export interface ContentFolder {
   id: string;
   name: string;
   type: 'folder';
   parentId?: string;
   contentType: 'link' | 'file' | 'mixed';
   children: string[]; // IDs of child items and folders
+  /** When set, this folder represents a single on-disk directory (children may be empty). */
+  diskPath?: string;
   isExpanded?: boolean;
   isFavorite?: boolean;
   lastUsed?: string;
   defaultApp: string; // App to open folder with
 }
 
-interface ContentItem {
+export interface ContentItem {
   id: string;
   type: 'link' | 'file';
   name: string;
@@ -47,14 +49,40 @@ interface ContentManagerProps {
   onUpdateProfile?: (profileId: string, updates: any) => void;
   onCustomDragStart: (data: any, sourceType: 'sidebar' | 'monitor' | 'minimized', sourceId: string, startPos: { x: number; y: number }, preview?: React.ReactNode) => void;
   onDragStart?: () => void;
+  /** Places a content item on a monitor (parent supplies profile-scoped mutations). */
+  onPlaceContentOnMonitor?: (monitorId: string, item: ContentItem) => void;
+  onPlaceContentOnMinimized?: (item: ContentItem) => void;
+  onPlaceLibraryFolderOnMonitor?: (
+    monitorId: string,
+    folder: ContentFolder,
+  ) => void;
+  onPlaceLibraryFolderOnMinimized?: (folder: ContentFolder) => void;
+  /** Compact sidebar: open right inspector instead of cramming metadata in the list. */
+  onInspectLibrarySelection?: (
+    payload:
+      | { kind: "item"; item: ContentItem }
+      | { kind: "folder"; folder: ContentFolder },
+  ) => void;
+  /** When set, navigates into this folder then clears (e.g. from inspector “Open folder”). */
+  openLibraryFolderId?: string | null;
+  onConsumedOpenLibraryFolder?: () => void;
+  /** Global library rows visible for the active profile (parent filters exclusions). */
+  externalContentItems?: ContentItem[];
+  externalContentFolders?: ContentFolder[];
+  onPersistContentLibrary?: (next: {
+    items: ContentItem[];
+    folders: ContentFolder[];
+  }) => void;
+  /** IDs hidden for the active profile only (global library still contains them). */
+  excludedContentIds?: string[];
   compact?: boolean;
   /** When both set with `compact`, hides the local search field and uses this query. */
   sidebarSearchQuery?: string;
   onSidebarSearchQueryChange?: (query: string) => void;
 }
 
-// Available apps for users to choose from
-const AVAILABLE_APPS = [
+// Available apps for users to choose from (exported for library inspector)
+export const AVAILABLE_APPS = [
   // Browsers
   'Chrome',
   'Firefox', 
@@ -154,7 +182,18 @@ export function ContentManager({
   currentProfile, 
   onUpdateProfile, 
   onCustomDragStart, 
-  onDragStart, 
+  onDragStart,
+  onPlaceContentOnMonitor,
+  onPlaceContentOnMinimized,
+  onPlaceLibraryFolderOnMonitor,
+  onPlaceLibraryFolderOnMinimized,
+  onInspectLibrarySelection,
+  openLibraryFolderId,
+  onConsumedOpenLibraryFolder,
+  externalContentItems,
+  externalContentFolders,
+  onPersistContentLibrary,
+  excludedContentIds,
   compact = false,
   sidebarSearchQuery,
   onSidebarSearchQueryChange,
@@ -181,15 +220,75 @@ export function ContentManager({
   const [showAddModal, setShowAddModal] = useState(false);
   const [addModalType, setAddModalType] = useState<'link' | 'file'>('link');
   const [appDropdownOpen, setAppDropdownOpen] = useState<string | null>(null);
+  const [compactAddMenuKey, setCompactAddMenuKey] = useState<string | null>(
+    null,
+  );
+  const libraryHydratedRef = useRef(false);
+  const lastExternalLibrarySigRef = useRef("");
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const compactItemMenuKey = (id: string) => `item:${id}`;
+  const compactFolderMenuKey = (id: string) => `folder:${id}`;
+
+  const monitorsSortedForMenu = useMemo(() => {
+    const list = [...(currentProfile?.monitors ?? [])] as {
+      id: string;
+      name?: string;
+      primary?: boolean;
+    }[];
+    list.sort((a, b) => {
+      if (a.primary === b.primary) return 0;
+      return a.primary ? -1 : 1;
+    });
+    return list;
+  }, [currentProfile?.monitors]);
 
   useEffect(() => {
+    if (externalContentItems == null || externalContentFolders == null) {
+      libraryHydratedRef.current = false;
+    }
+
     if (!currentProfile) {
       setContent([]);
       setFolders([]);
       setCurrentFolderId(null);
+      lastExternalLibrarySigRef.current = "";
       return;
     }
 
+    if (
+      externalContentItems != null
+      && externalContentFolders != null
+    ) {
+      const sig = [
+        externalContentItems.length,
+        externalContentFolders.length,
+        externalContentItems
+          .map(
+            (i) =>
+              `${i.id}:${i.defaultApp}:${i.type}:${i.path ?? ""}:${i.url ?? ""}:${i.name}`,
+          )
+          .join("|"),
+        externalContentFolders
+          .map(
+            (f) =>
+              `${f.id}:${f.defaultApp}:${f.name}:${f.diskPath ?? ""}:${(f.children || []).join(",")}`,
+          )
+          .join("|"),
+      ].join("::");
+      if (lastExternalLibrarySigRef.current !== sig) {
+        lastExternalLibrarySigRef.current = sig;
+        setContent(externalContentItems);
+        setFolders(externalContentFolders);
+      }
+      libraryHydratedRef.current = true;
+      setCurrentFolderId((prev) => {
+        if (!prev) return null;
+        return externalContentFolders.some((f) => f.id === prev) ? prev : null;
+      });
+      return;
+    }
+
+    lastExternalLibrarySigRef.current = "";
     const profileContent = Array.isArray(currentProfile.contentItems)
       ? currentProfile.contentItems
       : [];
@@ -200,15 +299,39 @@ export function ContentManager({
     setContent(profileContent);
     setFolders(profileFolders);
     setCurrentFolderId(null);
+  }, [currentProfile?.id, externalContentItems, externalContentFolders]);
+
+  useEffect(() => {
+    setCompactAddMenuKey(null);
   }, [currentProfile?.id]);
 
   useEffect(() => {
-    if (!currentProfile?.id || !onUpdateProfile) return;
+    if (!openLibraryFolderId) return;
+    setCurrentFolderId(openLibraryFolderId);
+    onConsumedOpenLibraryFolder?.();
+  }, [openLibraryFolderId, onConsumedOpenLibraryFolder]);
+
+  useEffect(() => {
+    if (!currentProfile?.id) return;
+
+    if (onPersistContentLibrary) {
+      if (!libraryHydratedRef.current) return;
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = setTimeout(() => {
+        persistTimerRef.current = null;
+        onPersistContentLibrary({ items: content, folders: folders });
+      }, 350);
+      return () => {
+        if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+      };
+    }
+
+    if (!onUpdateProfile) return;
     onUpdateProfile(currentProfile.id, {
       contentItems: content,
       contentFolders: folders,
     });
-  }, [content, folders, currentProfile?.id, onUpdateProfile]);
+  }, [content, folders, currentProfile?.id, onUpdateProfile, onPersistContentLibrary]);
 
   // Timer and state for click vs drag detection
   const dragTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -294,6 +417,10 @@ export function ContentManager({
         return shouldShow;
       });
     }
+
+    const excluded = new Set(excludedContentIds || []);
+    displayFolders = displayFolders.filter((f) => !excluded.has(f.id));
+    displayContent = displayContent.filter((i) => !excluded.has(i.id));
 
     console.log(`📊 Display results: ${displayFolders.length} folders, ${displayContent.length} items`);
 
@@ -501,38 +628,28 @@ export function ContentManager({
     console.log('🎯 CONTENT CLICKED:', item.name, 'type:', item.type);
     
     if (item.type === 'folder') {
-      // Navigate into folder (only if not filtering by specific type)
+      if (compact && onInspectLibrarySelection) {
+        onInspectLibrarySelection({
+          kind: "folder",
+          folder: item as ContentFolder,
+        });
+        return;
+      }
       if (selectedType === 'all' || selectedType === 'folder') {
         console.log('📁 NAVIGATING INTO FOLDER:', item.id);
         setCurrentFolderId(item.id);
       }
     } else {
       const contentItem = item as ContentItem;
+      if (compact && onInspectLibrarySelection) {
+        onInspectLibrarySelection({ kind: "item", item: contentItem });
+        return;
+      }
       if (contentItem.type === 'link' && contentItem.url) {
         console.log('🔗 Opening link:', contentItem.url);
-        // In a real app, this would open the link
       } else if (contentItem.type === 'file' && contentItem.path) {
         console.log('📁 Opening file:', contentItem.path);
-        // In a real app, this would open the file
       }
-    }
-  };
-
-  const handleDirectOpen = (e: React.MouseEvent, item: ContentItem) => {
-    e.stopPropagation();
-    
-    if (item.type === 'link' && item.url) {
-      console.log('🚀 Direct open link:', item.url);
-      // Update last used
-      setContent(prev => prev.map(c => 
-        c.id === item.id ? { ...c, lastUsed: new Date().toISOString().split('T')[0] } : c
-      ));
-    } else if (item.type === 'file' && item.path) {
-      console.log('🚀 Direct open file:', item.path);
-      // Update last used
-      setContent(prev => prev.map(c => 
-        c.id === item.id ? { ...c, lastUsed: new Date().toISOString().split('T')[0] } : c
-      ));
     }
   };
 
@@ -556,8 +673,25 @@ export function ContentManager({
   };
 
   const handleAddContent = (contentData: any) => {
+    if (contentData.libraryDiskFolder && contentData.diskPath) {
+      const folderId = `folder-${Date.now()}`;
+      const newFolder: ContentFolder = {
+        id: folderId,
+        name: String(contentData.name || "Folder").trim() || "Folder",
+        type: "folder",
+        contentType: "mixed",
+        children: [],
+        defaultApp: contentData.defaultApp || "File Explorer",
+        diskPath: String(contentData.diskPath).trim(),
+        parentId: currentFolderId ?? undefined,
+        isFavorite: false,
+      };
+      setFolders((prev) => [...prev, newFolder]);
+      return;
+    }
+
     const newItem: ContentItem = {
-      id: `${contentData.type}-${Date.now()}`,
+      id: `${contentData.type}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
       type: contentData.type,
       name: contentData.name,
       url: contentData.url,
@@ -588,6 +722,192 @@ export function ContentManager({
       console.log('✅ Changed default app for content', itemId, 'to', newDefaultApp);
     }
     setAppDropdownOpen(null);
+  };
+
+  const stopContentRowPointer = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  const handleAddContentToMonitor = (item: ContentItem, monitorId: string) => {
+    if (!onPlaceContentOnMonitor) return;
+    onPlaceContentOnMonitor(monitorId, item);
+    setCompactAddMenuKey(null);
+  };
+
+  const handleAddContentToMinimized = (item: ContentItem) => {
+    if (!onPlaceContentOnMinimized) return;
+    onPlaceContentOnMinimized(item);
+    setCompactAddMenuKey(null);
+  };
+
+  const handleAddLibraryFolderToMonitor = (
+    folder: ContentFolder,
+    monitorId: string,
+  ) => {
+    if (!onPlaceLibraryFolderOnMonitor) return;
+    onPlaceLibraryFolderOnMonitor(monitorId, folder);
+    setCompactAddMenuKey(null);
+  };
+
+  const handleAddLibraryFolderToMinimized = (folder: ContentFolder) => {
+    if (!onPlaceLibraryFolderOnMinimized) return;
+    onPlaceLibraryFolderOnMinimized(folder);
+    setCompactAddMenuKey(null);
+  };
+
+  /** Compact sidebar: + menu for a content item */
+  const renderCompactAddToolbar = (item: ContentItem) => {
+    if (!compact || !onPlaceContentOnMonitor) return null;
+    const k = compactItemMenuKey(item.id);
+    return (
+      <div
+        className="flex shrink-0 items-center gap-0.5 self-center"
+        onMouseDown={stopContentRowPointer}
+      >
+        <div className="relative">
+          <button
+            type="button"
+            disabled={!currentProfile}
+            title={
+              !currentProfile
+                ? "Select a profile first"
+                : "Add to a monitor or minimized row"
+            }
+            aria-label={`Add ${item.name} to layout`}
+            aria-expanded={compactAddMenuKey === k}
+            aria-haspopup="menu"
+            onClick={(e) => {
+              stopContentRowPointer(e);
+              setAppDropdownOpen(null);
+              setCompactAddMenuKey(compactAddMenuKey === k ? null : k);
+            }}
+            className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
+          </button>
+          {compactAddMenuKey === k ? (
+            <div
+              className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
+              role="menu"
+            >
+              {monitorsSortedForMenu.length ? (
+                monitorsSortedForMenu.map((m) => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    role="menuitem"
+                    className="flow-menu-item text-left text-xs"
+                    onClick={(e) => {
+                      stopContentRowPointer(e);
+                      handleAddContentToMonitor(item, m.id);
+                    }}
+                  >
+                    {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-[11px] text-flow-text-muted">
+                  No monitors in this profile.
+                </div>
+              )}
+              <div className="my-0.5 h-px bg-flow-border/50" role="none" />
+              <button
+                type="button"
+                role="menuitem"
+                disabled={!currentProfile || !onPlaceContentOnMinimized}
+                title={!currentProfile ? "Select a profile first" : undefined}
+                className="flow-menu-item text-left text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                onClick={(e) => {
+                  stopContentRowPointer(e);
+                  handleAddContentToMinimized(item);
+                }}
+              >
+                Minimized row
+              </button>
+              <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
+                Drag the row to place on a specific tile. Click the row to see
+                full path and change “Opens with” in the panel.
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const renderCompactFolderAddToolbar = (folder: ContentFolder) => {
+    if (!compact || !onPlaceLibraryFolderOnMonitor) return null;
+    const k = compactFolderMenuKey(folder.id);
+    return (
+      <div
+        className="flex shrink-0 items-center gap-0.5 self-center"
+        onMouseDown={stopContentRowPointer}
+      >
+        <div className="relative">
+          <button
+            type="button"
+            disabled={!currentProfile}
+            title="Add folder contents as one layout tile"
+            aria-label={`Add folder ${folder.name} to layout`}
+            aria-expanded={compactAddMenuKey === k}
+            aria-haspopup="menu"
+            onClick={(e) => {
+              stopContentRowPointer(e);
+              setAppDropdownOpen(null);
+              setCompactAddMenuKey(compactAddMenuKey === k ? null : k);
+            }}
+            className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
+          </button>
+          {compactAddMenuKey === k ? (
+            <div
+              className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
+              role="menu"
+            >
+              {monitorsSortedForMenu.length ? (
+                monitorsSortedForMenu.map((m) => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    role="menuitem"
+                    className="flow-menu-item text-left text-xs"
+                    onClick={(e) => {
+                      stopContentRowPointer(e);
+                      handleAddLibraryFolderToMonitor(folder, m.id);
+                    }}
+                  >
+                    {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-[11px] text-flow-text-muted">
+                  No monitors in this profile.
+                </div>
+              )}
+              <div className="my-0.5 h-px bg-flow-border/50" role="none" />
+              <button
+                type="button"
+                role="menuitem"
+                disabled={!currentProfile || !onPlaceLibraryFolderOnMinimized}
+                className="flow-menu-item text-left text-xs disabled:cursor-not-allowed disabled:opacity-40"
+                onClick={(e) => {
+                  stopContentRowPointer(e);
+                  handleAddLibraryFolderToMinimized(folder);
+                }}
+              >
+                Minimized row
+              </button>
+              <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
+                Adds one tile with all files in this folder (including nested
+                folders). Links are skipped.
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
   };
 
   // Get icon for content item
@@ -633,6 +953,29 @@ export function ContentManager({
   // Render folder based on view mode
   const renderFolder = (folder: ContentFolder) => {
     const baseClasses = "group relative cursor-pointer";
+
+    if (compact) {
+      return (
+        <div key={folder.id} className={baseClasses}>
+          <div className="flow-card-quiet rounded-lg">
+            <div
+              className="flex cursor-pointer items-center gap-3 p-3"
+              onClick={() => handleContentClick(folder)}
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-flow-bg-tertiary/50">
+                <Folder className="h-4 w-4 text-amber-400" aria-hidden />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate text-sm font-medium text-flow-text-primary">
+                  {folder.name}
+                </h3>
+              </div>
+              {renderCompactFolderAddToolbar(folder)}
+            </div>
+          </div>
+        </div>
+      );
+    }
     
     if (viewMode === 'simplified') {
       return (
@@ -887,6 +1230,31 @@ export function ContentManager({
   // Render content item based on view mode
   const renderContentItem = (item: ContentItem) => {
     const baseClasses = "group relative cursor-grab active:cursor-grabbing";
+
+    if (compact) {
+      return (
+        <div key={item.id} className={baseClasses}>
+          <div className="flow-card-quiet rounded-lg">
+            <div
+              className="flex cursor-grab items-center gap-3 p-3 active:cursor-grabbing"
+              onMouseDown={(e) => handleMouseDown(e, item)}
+              onMouseEnter={() => setHoveredItem(item.id)}
+              onMouseLeave={() => setHoveredItem(null)}
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-flow-bg-tertiary/50">
+                {getContentIcon(item)}
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate text-sm font-medium text-flow-text-primary">
+                  {item.name}
+                </h3>
+              </div>
+              {renderCompactAddToolbar(item)}
+            </div>
+          </div>
+        </div>
+      );
+    }
     
     if (viewMode === 'simplified') {
       return (
@@ -941,18 +1309,6 @@ export function ContentManager({
                   )}
                 </div>
               </div>
-            </div>
-            <div className="flex-shrink-0 flex items-center gap-1">
-              <button
-                onClick={(e) => handleToggleFavorite(e, item.id)}
-                className={`p-1 rounded transition-colors ${
-                  item.isFavorite 
-                    ? 'text-red-400 hover:text-red-300' 
-                    : 'text-flow-text-muted hover:text-red-400'
-                }`}
-              >
-                <Heart className={`w-3 h-3 ${item.isFavorite ? 'fill-current' : ''}`} />
-              </button>
             </div>
           </div>
         </div>
@@ -1049,25 +1405,6 @@ export function ContentManager({
                 )}
               </div>
             </div>
-
-            <div className="flex-shrink-0 flex items-center gap-1">
-              <button
-                onClick={(e) => handleToggleFavorite(e, item.id)}
-                className={`p-1.5 rounded transition-colors ${
-                  item.isFavorite 
-                    ? 'text-red-400 hover:text-red-300' 
-                    : 'text-flow-text-muted hover:text-red-400'
-                }`}
-              >
-                <Heart className={`w-4 h-4 ${item.isFavorite ? 'fill-current' : ''}`} />
-              </button>
-              <button
-                onClick={(e) => handleDirectOpen(e, item)}
-                className="p-1.5 text-flow-text-muted hover:text-flow-accent-blue rounded transition-colors"
-              >
-                <Play className="w-4 h-4" />
-              </button>
-            </div>
           </div>
           
           {hoveredItem === item.id && (
@@ -1154,25 +1491,6 @@ export function ContentManager({
                 </span>
               )}
             </div>
-          </div>
-
-          <div className="flex-shrink-0 flex items-center gap-1">
-            <button
-              onClick={(e) => handleToggleFavorite(e, item.id)}
-              className={`p-1 rounded transition-colors ${
-                item.isFavorite 
-                  ? 'text-red-400 hover:text-red-300' 
-                  : 'text-flow-text-muted hover:text-red-400'
-              }`}
-            >
-              <Heart className={`w-3 h-3 ${item.isFavorite ? 'fill-current' : ''}`} />
-            </button>
-            <button
-              onClick={(e) => handleDirectOpen(e, item)}
-              className="p-1 text-flow-text-muted hover:text-flow-accent-blue rounded transition-colors"
-            >
-              <Play className="w-3 h-3" />
-            </button>
           </div>
         </div>
 
@@ -1339,7 +1657,7 @@ export function ContentManager({
                   className="flow-menu-item text-xs"
                 >
                   <Upload className="h-3.5 w-3.5 shrink-0 text-emerald-400" />
-                  Add File/Folder
+                  Add files…
                 </button>
               </div>
             )}
@@ -1364,6 +1682,23 @@ export function ContentManager({
                   : "w-full rounded-lg border border-flow-border bg-flow-surface py-2 pl-9 pr-3 text-sm text-flow-text-primary placeholder-flow-text-muted transition-all duration-200 focus:border-flow-accent-blue/50 focus:outline-none focus:ring-2 focus:ring-flow-accent-blue/50"
               }
             />
+          </div>
+        ) : null}
+
+        {compact && onPlaceContentOnMonitor ? (
+          <div className="rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3">
+            <div className="flex items-start gap-2 text-[11px] text-flow-text-secondary">
+              <ExternalLink
+                className="mt-0.5 h-3.5 w-3.5 shrink-0 text-flow-accent-blue"
+                strokeWidth={1.75}
+                aria-hidden
+              />
+              <span>
+                Click a row for full path and to change <span className="font-medium text-flow-text-primary">Opens with</span>
+                . Use <span className="font-medium text-flow-text-primary">+</span> for a monitor
+                or minimized row. Drag to place precisely.
+              </span>
+            </div>
           </div>
         ) : null}
 

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Monitor, Folder, Globe, MoreVertical, Copy, Edit, Trash2, Settings, Download, Zap, ZapOff, Clock, Layers } from "lucide-react";
+import { Monitor, Folder, Globe, MoreVertical, Copy, Edit, Trash2, Download, Zap, ZapOff, Clock, Layers } from "lucide-react";
 import { LucideIcon } from "lucide-react";
 import { ProfileIconGlyph } from "../utils/profileHeaderPresentation";
 import { formatUnit } from "../../utils/pluralize";
@@ -155,33 +155,41 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
           </div>
         </div>
 
-        {/* Profile Actions Menu */}
+        {/* Profile actions: always visible for discoverability and keyboard paths */}
         {!disabled && (
-          <div className="absolute top-3 right-3">
+          <div className="absolute top-3 right-3 flex items-center gap-0.5">
+            {onSettings ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSettings();
+                }}
+                className="rounded p-1 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary"
+                aria-label={`Edit ${profile.name}`}
+                title="Edit profile"
+              >
+                <Edit className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
             <div className="relative">
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   setShowActions(!showActions);
                 }}
-                className={`p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-flow-surface transition-all ${
-                  profile.isActive ? 'opacity-100' : ''
-                }`}
+                className="rounded p-1 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary"
+                aria-expanded={showActions}
+                aria-haspopup="menu"
+                aria-label={`More actions for ${profile.name}`}
+                title="More"
               >
-                <MoreVertical className="w-3 h-3 text-flow-text-muted" />
+                <MoreVertical className="h-3 w-3" />
               </button>
             
               {showActions && (
                 <div className="absolute top-6 right-0 w-48 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-10 py-1">
-                  {onSettings && (
-                    <button
-                      onClick={(e) => handleActionClick(e, onSettings)}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-flow-text-secondary hover:bg-flow-surface hover:text-flow-text-primary text-sm transition-colors"
-                    >
-                      <Settings className="w-3 h-3" />
-                      Settings
-                    </button>
-                  )}
                   {onSetOnStartup && (
                     <button
                       onClick={(e) => handleActionClick(e, onSetOnStartup)}

--- a/src/renderer/layout/components/SelectedContentDetails.tsx
+++ b/src/renderer/layout/components/SelectedContentDetails.tsx
@@ -1,0 +1,202 @@
+import { useMemo } from "react";
+import { ExternalLink, FileText, Folder, Trash2 } from "lucide-react";
+import type { ContentItem, ContentFolder } from "./ContentManager";
+import { getCompatibleOpensWithApps } from "../utils/contentOpensWithOptions";
+
+export type LibrarySelection =
+  | { kind: "item"; item: ContentItem }
+  | { kind: "folder"; folder: ContentFolder };
+
+type Props = {
+  selection: LibrarySelection;
+  onChangeDefaultApp: (
+    id: string,
+    nextApp: string,
+    scope: "item" | "folder",
+  ) => void;
+  onPlaceOnMonitor: (monitorId: string) => void;
+  onPlaceOnMinimized: () => void;
+  monitors: { id: string; name?: string; primary?: boolean }[];
+  /** Hidden from the compact list for the active profile only (library entry remains). */
+  excludedFromActiveProfile?: boolean;
+  onToggleExcludeFromActiveProfile?: () => void;
+  /** Permanently removes this entry from the global library. */
+  onDeleteFromLibrary?: () => void;
+};
+
+export function SelectedContentDetails({
+  selection,
+  onChangeDefaultApp,
+  onPlaceOnMonitor,
+  onPlaceOnMinimized,
+  monitors,
+  excludedFromActiveProfile,
+  onToggleExcludeFromActiveProfile,
+  onDeleteFromLibrary,
+}: Props) {
+  const isFolder = selection.kind === "folder";
+  const title = isFolder ? selection.folder.name : selection.item.name;
+  const defaultApp = isFolder
+    ? selection.folder.defaultApp
+    : selection.item.defaultApp;
+  const id = isFolder ? selection.folder.id : selection.item.id;
+  const diskPath = isFolder ? selection.folder.diskPath : undefined;
+  const subtitle = isFolder
+    ? diskPath
+      ? diskPath
+      : `${selection.folder.children.length} item(s) in this folder`
+    : selection.item.type === "link"
+      ? selection.item.url || ""
+      : selection.item.path || "";
+
+  const appOptions = useMemo(() => {
+    const base = getCompatibleOpensWithApps(selection);
+    const seen = new Set<string>();
+    const out: string[] = [];
+    const push = (a: string) => {
+      const t = a.trim();
+      if (!t || seen.has(t)) return;
+      seen.add(t);
+      out.push(t);
+    };
+    push(defaultApp);
+    for (const a of base) push(a);
+    return out;
+  }, [
+    id,
+    defaultApp,
+    isFolder,
+    isFolder ? selection.folder.children?.length : selection.item.type,
+    isFolder ? diskPath : selection.item.path,
+    isFolder ? undefined : selection.item.url,
+    isFolder ? undefined : selection.item.isFolder,
+  ]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col pt-12">
+      <div className="border-b border-flow-border/50 px-4 pb-3">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 shrink-0 text-flow-text-muted">
+            {isFolder ? (
+              <Folder className="h-6 w-6 text-amber-400" aria-hidden />
+            ) : selection.item.type === "link" ? (
+              <ExternalLink className="h-6 w-6 text-blue-400" aria-hidden />
+            ) : (
+              <FileText className="h-6 w-6 text-flow-text-muted" aria-hidden />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="break-words text-base font-semibold leading-snug text-flow-text-primary">
+              {title}
+            </h2>
+          </div>
+        </div>
+      </div>
+
+      <div className="scrollbar-elegant flex-1 space-y-4 overflow-y-auto px-4 py-4">
+        {((isFolder && diskPath) || (!isFolder && subtitle)) ? (
+          <div>
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-flow-text-muted">
+              {isFolder ? "Folder path" : selection.item.type === "link" ? "URL" : "Path"}
+            </div>
+            <div className="break-all rounded-lg border border-flow-border/50 bg-flow-bg-tertiary/40 px-3 py-2 font-mono text-xs leading-relaxed text-flow-text-secondary">
+              {subtitle}
+            </div>
+          </div>
+        ) : null}
+
+        {onToggleExcludeFromActiveProfile ? (
+          <label className="flex cursor-pointer items-start gap-2 rounded-lg border border-flow-border/50 bg-flow-surface/40 px-3 py-2.5">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-3.5 w-3.5 rounded border-flow-border"
+              checked={Boolean(excludedFromActiveProfile)}
+              onChange={() => onToggleExcludeFromActiveProfile()}
+            />
+            <span className="text-xs leading-snug text-flow-text-secondary">
+              <span className="font-medium text-flow-text-primary">
+                Hide from this profile
+              </span>
+              {" "}
+              — the entry stays in your library for other profiles.
+            </span>
+          </label>
+        ) : null}
+
+        {onDeleteFromLibrary ? (
+          <div>
+            <button
+              type="button"
+              onClick={() => onDeleteFromLibrary()}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-flow-accent-red/35 bg-flow-accent-red/10 px-3 py-2 text-xs font-medium text-flow-accent-red transition-colors hover:bg-flow-accent-red/20"
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden />
+              Delete from library
+            </button>
+            <p className="mt-1.5 text-[11px] leading-snug text-flow-text-muted">
+              Removes this {isFolder ? "folder and its library items" : "entry"}{" "}
+              everywhere. This cannot be undone.
+            </p>
+          </div>
+        ) : null}
+
+        <div>
+          <label
+            className="mb-1 block text-[11px] font-medium uppercase tracking-wide text-flow-text-muted"
+            htmlFor="library-default-app"
+          >
+            Opens with
+          </label>
+          <select
+            key={`library-opens-with-${id}`}
+            id="library-default-app"
+            value={defaultApp}
+            onChange={(e) =>
+              onChangeDefaultApp(id, e.target.value, isFolder ? "folder" : "item")
+            }
+            className="flow-sidebar-search w-full rounded-lg border border-flow-border bg-flow-surface py-2 pl-3 pr-3 text-sm text-flow-text-primary"
+          >
+            {appOptions.map((app) => (
+              <option key={app} value={app}>
+                {app}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1.5 text-[11px] leading-snug text-flow-text-muted">
+            Choose which application should open this{" "}
+            {isFolder ? "folder" : selection.item.type === "link" ? "link" : "file"}.
+          </p>
+        </div>
+
+        <div>
+          <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-flow-text-muted">
+            Add to layout
+          </div>
+          <div className="flex flex-col gap-1">
+            {monitors.length ? (
+              monitors.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => onPlaceOnMonitor(m.id)}
+                  className="rounded-lg border border-flow-border/60 bg-flow-surface px-3 py-2 text-left text-xs text-flow-text-secondary transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-primary"
+                >
+                  {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                </button>
+              ))
+            ) : (
+              <p className="text-xs text-flow-text-muted">No monitors in profile.</p>
+            )}
+            <button
+              type="button"
+              onClick={onPlaceOnMinimized}
+              className="rounded-lg border border-flow-border/60 bg-flow-surface px-3 py-2 text-left text-xs text-flow-text-secondary transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-primary"
+            >
+              Minimized row
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/layout/hooks/useProfileLaunch.ts
+++ b/src/renderer/layout/hooks/useProfileLaunch.ts
@@ -6,12 +6,13 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from "react";
-import type { FlowProfile } from "../../../types/flow-profile";
-import { toSerializableProfiles } from "../../../types/flow-profile";
+import type { FlowProfile, ProfileSavePayload } from "../../../types/flow-profile";
 import type { LaunchFeedbackState } from "./useLaunchFeedback";
 
 type UseProfileLaunchOptions = {
   profiles: FlowProfile[];
+  /** Full store document (profiles + global content library) for pre-launch persist. */
+  buildSavePayload: () => ProfileSavePayload;
   selectedProfileId: string;
   setIsLaunching: Dispatch<SetStateAction<boolean>>;
   setLaunchFeedback: Dispatch<SetStateAction<LaunchFeedbackState>>;
@@ -25,6 +26,7 @@ type UseProfileLaunchOptions = {
 
 export function useProfileLaunch({
   profiles,
+  buildSavePayload,
   selectedProfileId,
   setIsLaunching,
   setLaunchFeedback,
@@ -113,11 +115,8 @@ export function useProfileLaunch({
       };
       try {
         if (window.electron?.saveProfiles) {
-          const serializableProfiles = toSerializableProfiles(
-            profiles,
-          );
           const saveResult = await window.electron.saveProfiles(
-            serializableProfiles,
+            buildSavePayload(),
           );
           if (!saveResult?.ok) {
             launchWallClockStartMsRef.current = null;
@@ -312,6 +311,7 @@ export function useProfileLaunch({
     })();
   }, [
     profiles,
+    buildSavePayload,
     selectedProfileId,
     setIsLaunching,
     setLaunchFeedback,

--- a/src/renderer/layout/hooks/useProfilesPersistence.ts
+++ b/src/renderer/layout/hooks/useProfilesPersistence.ts
@@ -7,9 +7,12 @@ import {
 } from "react";
 import {
   normalizeFlowProfile,
+  toSerializableProfiles,
+  type ContentLibrarySnapshot,
   type FlowProfile,
   type ProfileStoreError,
   type ProfileListResult,
+  type ProfileSavePayload,
 } from "../../../types/flow-profile";
 
 type UseProfilesPersistenceOptions = {
@@ -17,10 +20,18 @@ type UseProfilesPersistenceOptions = {
   setSelectedProfileId: Dispatch<SetStateAction<string>>;
 };
 
+const emptyLibrary = (): ContentLibrarySnapshot => ({ items: [], folders: [] });
+
 export function useProfilesPersistence({
   setSelectedProfileId,
 }: UseProfilesPersistenceOptions) {
   const [profiles, setProfiles] = useState<FlowProfile[]>([]);
+  const [contentLibrary, setContentLibrary] = useState<ContentLibrarySnapshot>(
+    emptyLibrary,
+  );
+  const [contentLibraryExclusions, setContentLibraryExclusions] = useState<
+    Record<string, string[]>
+  >({});
   const [profilesLoaded, setProfilesLoaded] = useState(false);
   const [profileStoreError, setProfileStoreError] =
     useState<ProfileStoreError | null>(null);
@@ -60,6 +71,27 @@ export function useProfilesPersistence({
           : [];
         setProfiles(normalizedProfiles);
         setSelectedProfileId((prev) => prev || normalizedProfiles[0]?.id || "");
+
+        if (Array.isArray(listResult)) {
+          setContentLibrary(emptyLibrary());
+          setContentLibraryExclusions({});
+        } else {
+          const lib = listResult.contentLibrary;
+          setContentLibrary(
+            lib && typeof lib === "object"
+              ? {
+                items: Array.isArray(lib.items) ? lib.items : [],
+                folders: Array.isArray(lib.folders) ? lib.folders : [],
+              }
+              : emptyLibrary(),
+          );
+          const ex = listResult.contentLibraryExclusions;
+          setContentLibraryExclusions(
+            ex && typeof ex === "object" && !Array.isArray(ex)
+              ? (ex as Record<string, string[]>)
+              : {},
+          );
+        }
       } catch (error) {
         console.error("Failed to load persisted profiles:", error);
         if (!cancelled) {
@@ -71,6 +103,8 @@ export function useProfilesPersistence({
           });
           blockProfileAutosaveAfterStoreErrorRef.current = true;
           setProfiles([]);
+          setContentLibrary(emptyLibrary());
+          setContentLibraryExclusions({});
           setSelectedProfileId("");
         }
       } finally {
@@ -94,8 +128,14 @@ export function useProfilesPersistence({
       return;
     }
 
+    const payload: ProfileSavePayload = {
+      profiles: toSerializableProfiles(profiles),
+      contentLibrary,
+      contentLibraryExclusions,
+    };
+
     const timer = window.setTimeout(() => {
-      void window.electron.saveProfiles(profiles).catch((error) => {
+      void window.electron.saveProfiles(payload).catch((error) => {
         console.error("Failed to save persisted profiles:", error);
       });
     }, 200);
@@ -103,7 +143,7 @@ export function useProfilesPersistence({
     return () => {
       window.clearTimeout(timer);
     };
-  }, [profiles, profilesLoaded]);
+  }, [profiles, contentLibrary, contentLibraryExclusions, profilesLoaded]);
 
   useEffect(() => {
     if (!profilesLoaded) return;
@@ -117,6 +157,10 @@ export function useProfilesPersistence({
   return {
     profiles,
     setProfiles,
+    contentLibrary,
+    setContentLibrary,
+    contentLibraryExclusions,
+    setContentLibraryExclusions,
     profilesLoaded,
     profileStoreError,
     skipNextAutosaveRef,

--- a/src/renderer/layout/utils/contentLibraryMutations.ts
+++ b/src/renderer/layout/utils/contentLibraryMutations.ts
@@ -1,0 +1,62 @@
+import type { ContentFolder, ContentItem } from "../components/ContentManager";
+
+function collectCascadeDelete(
+  folders: ContentFolder[],
+  _items: ContentItem[],
+  rootFolderId: string,
+): { folderIds: Set<string>; itemIds: Set<string> } {
+  const folderIds = new Set<string>();
+  const itemIds = new Set<string>();
+  const queue = [rootFolderId];
+  while (queue.length) {
+    const fid = queue.shift()!;
+    if (folderIds.has(fid)) continue;
+    folderIds.add(fid);
+    const folder = folders.find((f) => f.id === fid);
+    for (const cid of folder?.children || []) {
+      const sub = folders.find((f) => f.id === cid);
+      if (sub) queue.push(sub.id);
+      else itemIds.add(cid);
+    }
+  }
+  return { folderIds, itemIds };
+}
+
+function stripDeletedFromChildren(
+  folders: ContentFolder[],
+  folderIds: Set<string>,
+  itemIds: Set<string>,
+): ContentFolder[] {
+  return folders
+    .filter((f) => !folderIds.has(f.id))
+    .map((f) => ({
+      ...f,
+      children: (f.children || []).filter(
+        (c) => !folderIds.has(c) && !itemIds.has(c),
+      ),
+    }));
+}
+
+export function deleteLibraryFolder(
+  folders: ContentFolder[],
+  items: ContentItem[],
+  rootFolderId: string,
+): { items: ContentItem[]; folders: ContentFolder[] } {
+  const { folderIds, itemIds } = collectCascadeDelete(folders, items, rootFolderId);
+  const nextItems = items.filter((i) => !itemIds.has(i.id));
+  const nextFolders = stripDeletedFromChildren(folders, folderIds, itemIds);
+  return { items: nextItems, folders: nextFolders };
+}
+
+export function deleteLibraryItem(
+  items: ContentItem[],
+  folders: ContentFolder[],
+  itemId: string,
+): { items: ContentItem[]; folders: ContentFolder[] } {
+  const nextItems = items.filter((i) => i.id !== itemId);
+  const nextFolders = folders.map((f) => ({
+    ...f,
+    children: (f.children || []).filter((c) => c !== itemId),
+  }));
+  return { items: nextItems, folders: nextFolders };
+}

--- a/src/renderer/layout/utils/contentOpensWithOptions.ts
+++ b/src/renderer/layout/utils/contentOpensWithOptions.ts
@@ -1,0 +1,182 @@
+import type { ContentFolder, ContentItem } from "../components/ContentManager";
+import { AVAILABLE_APPS } from "../components/ContentManager";
+
+type LibrarySelectionInput =
+  | { kind: "item"; item: ContentItem }
+  | { kind: "folder"; folder: ContentFolder };
+
+const BROWSER_NAMES = new Set(
+  [
+    "Chrome",
+    "Firefox",
+    "Safari",
+    "Edge",
+    "Brave",
+    "Opera",
+    "Vivaldi",
+  ].map((s) => s.toLowerCase()),
+);
+
+const FOLDER_OPENERS = new Set(
+  [
+    "File Explorer",
+    "Visual Studio Code",
+    "Windows Terminal",
+    "Command Prompt",
+    "PowerShell",
+    "Sublime Text",
+    "Atom",
+    "IntelliJ IDEA",
+  ].map((s) => s.toLowerCase()),
+);
+
+const OFFICE_APPS = new Set(
+  [
+    "Microsoft Word",
+    "Microsoft Excel",
+    "Microsoft PowerPoint",
+    "Microsoft Outlook",
+    "Adobe Acrobat",
+  ].map((s) => s.toLowerCase()),
+);
+
+const MEDIA_APPS = new Set(
+  [
+    "Photos",
+    "VLC Media Player",
+    "Windows Media Player",
+    "Adobe Photoshop",
+    "Adobe Illustrator",
+  ].map((s) => s.toLowerCase()),
+);
+
+const CODE_APPS = new Set(
+  [
+    "Visual Studio Code",
+    "Visual Studio",
+    "Sublime Text",
+    "Atom",
+    "IntelliJ IDEA",
+  ].map((s) => s.toLowerCase()),
+);
+
+const TEXT_APPS = new Set(
+  ["Notepad", "Notepad++", "Visual Studio Code"].map((s) => s.toLowerCase()),
+);
+
+const ARCHIVE_APPS = new Set(["WinRAR", "7-Zip"].map((s) => s.toLowerCase()));
+
+function catalogFilter(pred: (name: string) => boolean): string[] {
+  return AVAILABLE_APPS.filter((a) => pred(a));
+}
+
+function extOfFileItem(item: ContentItem): string {
+  const fromName = item.name?.split(".").pop()?.toLowerCase() || "";
+  const fromPath = item.path?.split(".").pop()?.toLowerCase() || "";
+  return fromName.length <= 8 ? fromName : fromPath;
+}
+
+/**
+ * Apps shown in “Opens with” for the library inspector — subset of {@link AVAILABLE_APPS}.
+ */
+export function getCompatibleOpensWithApps(
+  selection: LibrarySelectionInput,
+): string[] {
+  if (selection.kind === "folder" || isFolderLikeItem(selection)) {
+    return catalogFilter((a) => FOLDER_OPENERS.has(a.toLowerCase()));
+  }
+  const item = selection.item;
+  if (item.type === "link") {
+    return catalogFilter((a) => BROWSER_NAMES.has(a.toLowerCase()));
+  }
+
+  const ext = extOfFileItem(item);
+  const groups: Array<Set<string>> = [];
+
+  if (
+    ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico"].includes(ext)
+  ) {
+    groups.push(MEDIA_APPS);
+  }
+  if (["mp4", "avi", "mov", "mkv", "webm"].includes(ext)) {
+    groups.push(MEDIA_APPS);
+  }
+  if (["mp3", "wav", "flac", "aac", "ogg", "m4a"].includes(ext)) {
+    groups.push(MEDIA_APPS);
+  }
+  if (
+    ["pdf"].includes(ext)
+    || ["doc", "docx", "xls", "xlsx", "ppt", "pptx"].includes(ext)
+  ) {
+    groups.push(OFFICE_APPS);
+  }
+  if (
+    [
+      "zip",
+      "rar",
+      "7z",
+      "tar",
+      "gz",
+    ].includes(ext)
+  ) {
+    groups.push(ARCHIVE_APPS);
+  }
+  if (
+    [
+      "txt",
+      "md",
+      "json",
+      "xml",
+      "csv",
+      "log",
+    ].includes(ext)
+  ) {
+    groups.push(TEXT_APPS);
+  }
+  if (
+    [
+      "js",
+      "ts",
+      "tsx",
+      "jsx",
+      "html",
+      "css",
+      "py",
+      "java",
+      "cs",
+      "go",
+      "rs",
+      "cpp",
+      "c",
+      "h",
+    ].includes(ext)
+  ) {
+    groups.push(CODE_APPS);
+  }
+
+  if (groups.length === 0) {
+    return catalogFilter(
+      (a) =>
+        FOLDER_OPENERS.has(a.toLowerCase())
+        || CODE_APPS.has(a.toLowerCase())
+        || TEXT_APPS.has(a.toLowerCase())
+        || OFFICE_APPS.has(a.toLowerCase())
+        || MEDIA_APPS.has(a.toLowerCase())
+        || ARCHIVE_APPS.has(a.toLowerCase()),
+    );
+  }
+
+  const allow = new Set<string>();
+  for (const g of groups) {
+    for (const n of g) allow.add(n);
+  }
+  return AVAILABLE_APPS.filter((a) => allow.has(a.toLowerCase()));
+}
+
+function isFolderLikeItem(selection: LibrarySelectionInput): boolean {
+  return (
+    selection.kind === "item"
+    && selection.item.type === "file"
+    && Boolean(selection.item.isFolder)
+  );
+}

--- a/src/renderer/layout/utils/sidebarExplicitPlacement.ts
+++ b/src/renderer/layout/utils/sidebarExplicitPlacement.ts
@@ -1,0 +1,409 @@
+import type { FlowProfile } from "../../../types/flow-profile";
+import {
+  computeDropZonesForAppCount,
+  getAppColor,
+  getAppIcon,
+  getBrowserColor,
+  getBrowserIcon,
+} from "./layoutDropPresentation";
+
+export type SidebarContentItemInput = {
+  id: string;
+  type: "link" | "file";
+  name: string;
+  url?: string;
+  path?: string;
+  fileType?: string;
+  defaultApp: string;
+};
+
+export type InstalledSidebarAppInput = {
+  name: string;
+  color?: string;
+  iconPath?: string | null;
+  executablePath?: string | null;
+};
+
+function pickZoneNearCenter(isPortrait: boolean, prospectiveAppCount: number) {
+  const rawPosition = { x: 50, y: 50 };
+  const zones = computeDropZonesForAppCount(isPortrait, prospectiveAppCount);
+  let activeZone = zones[0];
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const zone of zones) {
+    const distance = Math.sqrt(
+      (rawPosition.x - zone.position.x) ** 2
+      + (rawPosition.y - zone.position.y) ** 2,
+    );
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      activeZone = zone;
+    }
+  }
+  return {
+    position: activeZone.position,
+    size: { width: activeZone.size.width, height: activeZone.size.height },
+  };
+}
+
+function newInstanceId(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Places a library content item onto a monitor using the same shapes as
+ * `useLayoutCustomDrag` empty-monitor drops (center-picked snap zone).
+ */
+export function placeSidebarContentOnMonitor(args: {
+  profile: FlowProfile;
+  monitorId: string;
+  item: SidebarContentItemInput;
+  addApp: (profileId: string, monitorId: string, newApp: unknown) => void;
+  addBrowserTab: (profileId: string, tab: unknown) => void;
+}): void {
+  const { profile, monitorId, item, addApp, addBrowserTab } = args;
+  const targetMonitor = profile.monitors?.find((m) => m.id === monitorId);
+  if (!targetMonitor) return;
+
+  const isPortrait = targetMonitor.orientation === "portrait";
+  const prospectiveAppCount = (targetMonitor.apps?.length || 0) + 1;
+  const snapped = pickZoneNearCenter(isPortrait, prospectiveAppCount);
+
+  const isLink = item.type === "link" && Boolean(item.url);
+
+  if (isLink) {
+    const instanceId = newInstanceId(item.defaultApp);
+    const newApp: Record<string, unknown> = {
+      instanceId,
+      name: item.defaultApp,
+      icon: getBrowserIcon(item.defaultApp),
+      color: getBrowserColor(item.defaultApp),
+      position: snapped.position,
+      size: { width: 60, height: 60 },
+      volume: 50,
+      launchBehavior: "new",
+      runAsAdmin: false,
+      forceCloseOnExit: false,
+      smartSave: false,
+      monitorId,
+      associatedFiles: [],
+    };
+    addApp(profile.id, monitorId, newApp);
+
+    addBrowserTab(profile.id, {
+      name: item.name,
+      url: item.url,
+      browser: item.defaultApp,
+      newWindow: false,
+      monitorId,
+      isActive: true,
+      appInstanceId: instanceId,
+      id: `content-tab-${Date.now()}`,
+    });
+    return;
+  }
+
+  const appLabel = item.defaultApp || "File Viewer";
+  const instanceId = newInstanceId(appLabel);
+  const newApp: Record<string, unknown> = {
+    instanceId,
+    name: appLabel,
+    icon: getAppIcon(appLabel),
+    color: getAppColor(appLabel),
+    position: snapped.position,
+    size: snapped.size,
+    volume: 50,
+    launchBehavior: "new",
+    runAsAdmin: false,
+    forceCloseOnExit: false,
+    smartSave: false,
+    monitorId,
+    associatedFiles: [
+      {
+        id: `content-file-${Date.now()}`,
+        name: item.name,
+        path: item.path,
+        type: item.fileType || item.type,
+        associatedApp: item.defaultApp,
+        useDefaultApp: true,
+      },
+    ],
+  };
+  addApp(profile.id, monitorId, newApp);
+}
+
+export function placeSidebarContentOnMinimized(args: {
+  profile: FlowProfile;
+  item: SidebarContentItemInput;
+  addAppToMinimized: (profileId: string, newApp: unknown) => void;
+  addBrowserTab: (profileId: string, tab: unknown) => void;
+}): void {
+  const { profile, item, addAppToMinimized, addBrowserTab } = args;
+  const primary =
+    profile.monitors.find((m) => m.primary) || profile.monitors[0];
+  const targetMonitorId = primary?.id || "monitor-1";
+
+  const isLink = item.type === "link" && Boolean(item.url);
+
+  if (isLink) {
+    const appLabel = item.defaultApp || "File Viewer";
+    const instanceId = newInstanceId(appLabel);
+    const newApp: Record<string, unknown> = {
+      instanceId,
+      name: appLabel,
+      icon: getAppIcon(appLabel),
+      color: getAppColor(appLabel),
+      volume: 50,
+      launchBehavior: "minimize",
+      targetMonitor: targetMonitorId,
+      associatedFiles: [],
+    };
+    // Matches `useLayoutCustomDrag` minimized drop for sidebar links.
+    addAppToMinimized(profile.id, newApp);
+
+    addBrowserTab(profile.id, {
+      name: item.name,
+      url: item.url,
+      browser: item.defaultApp,
+      newWindow: false,
+      monitorId: targetMonitorId,
+      isActive: true,
+      appInstanceId: instanceId,
+      id: `content-tab-${Date.now()}`,
+    });
+    return;
+  }
+
+  const appLabel = item.defaultApp || "File Viewer";
+  const instanceId = newInstanceId(appLabel);
+  const newApp: Record<string, unknown> = {
+    instanceId,
+    name: appLabel,
+    icon: getAppIcon(appLabel),
+    color: getAppColor(appLabel),
+    volume: 50,
+    launchBehavior: "minimize",
+    targetMonitor: targetMonitorId,
+    associatedFiles: [
+      {
+        id: `content-file-${Date.now()}`,
+        name: item.name,
+        path: item.path,
+        type: item.fileType || item.type,
+        associatedApp: item.defaultApp,
+        useDefaultApp: true,
+      },
+    ],
+  };
+  addAppToMinimized(profile.id, newApp);
+}
+
+export function placeInstalledSidebarAppOnMonitor(args: {
+  profile: FlowProfile;
+  monitorId: string;
+  app: InstalledSidebarAppInput;
+  addApp: (profileId: string, monitorId: string, newApp: unknown) => void;
+}): void {
+  const { profile, monitorId, app, addApp } = args;
+  const targetMonitor = profile.monitors?.find((m) => m.id === monitorId);
+  if (!targetMonitor) return;
+
+  const isPortrait = targetMonitor.orientation === "portrait";
+  const prospectiveAppCount = (targetMonitor.apps?.length || 0) + 1;
+  const { position, size } = pickZoneNearCenter(isPortrait, prospectiveAppCount);
+
+  const instanceId = newInstanceId(app.name);
+  addApp(profile.id, monitorId, {
+    instanceId,
+    name: app.name,
+    icon: getAppIcon(app.name),
+    iconPath: app.iconPath ?? null,
+    executablePath: app.executablePath ?? null,
+    color: app.color,
+    position,
+    size,
+    volume: 50,
+    launchBehavior: "new",
+    runAsAdmin: false,
+    forceCloseOnExit: false,
+    smartSave: false,
+    associatedFiles: [],
+  });
+}
+
+export function placeInstalledSidebarAppOnMinimized(args: {
+  profile: FlowProfile;
+  app: InstalledSidebarAppInput;
+  addAppToMinimized: (profileId: string, newApp: unknown) => void;
+}): void {
+  const { profile, app, addAppToMinimized } = args;
+  const primary =
+    profile.monitors.find((m) => m.primary) || profile.monitors[0];
+  const instanceId = newInstanceId(app.name);
+  addAppToMinimized(profile.id, {
+    instanceId,
+    name: app.name,
+    icon: getAppIcon(app.name),
+    iconPath: app.iconPath ?? null,
+    executablePath: app.executablePath ?? null,
+    color: app.color,
+    volume: 50,
+    launchBehavior: "minimize",
+    targetMonitor: primary?.id || "monitor-1",
+  });
+}
+
+export type SidebarLibraryFolderInput = {
+  id: string;
+  name: string;
+  defaultApp: string;
+  children: string[];
+  /** When set and `children` is empty, placement uses this folder path as a single target. */
+  diskPath?: string;
+};
+
+type LibraryContentRow = {
+  id: string;
+  type: string;
+  name: string;
+  path?: string;
+  fileType?: string;
+  defaultApp?: string;
+};
+
+function collectAssociatedFilesFromLibraryFolder(
+  folder: SidebarLibraryFolderInput,
+  folders: SidebarLibraryFolderInput[],
+  items: LibraryContentRow[],
+  visited: Set<string> = new Set<string>(),
+): {
+  id: string;
+  name: string;
+  path: string;
+  type: string;
+  associatedApp: string;
+  useDefaultApp: boolean;
+}[] {
+  if (visited.has(folder.id)) return [];
+  visited.add(folder.id);
+  const diskPath = String((folder as { diskPath?: string }).diskPath || "").trim();
+  if (diskPath && !(folder.children || []).length) {
+    return [
+      {
+        id: `content-folder-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        name: folder.name,
+        path: diskPath,
+        type: "folder",
+        associatedApp: folder.defaultApp || "File Explorer",
+        useDefaultApp: true,
+      },
+    ];
+  }
+  const out: {
+    id: string;
+    name: string;
+    path: string;
+    type: string;
+    associatedApp: string;
+    useDefaultApp: boolean;
+  }[] = [];
+  for (const childId of folder.children || []) {
+    const item = items.find((i) => i.id === childId);
+    if (item?.type === "file" && item.path) {
+      out.push({
+        id: `content-file-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        name: item.name,
+        path: item.path,
+        type: item.fileType || "file",
+        associatedApp: item.defaultApp || folder.defaultApp,
+        useDefaultApp: true,
+      });
+    }
+    const sub = folders.find((f) => f.id === childId);
+    if (sub) {
+      out.push(
+        ...collectAssociatedFilesFromLibraryFolder(sub, folders, items, visited),
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Adds a single layout app hosting all file paths from a content library folder
+ * (including nested folders), instead of placing each file as its own tile.
+ */
+export function placeSidebarLibraryFolderOnMonitor(args: {
+  profile: FlowProfile;
+  monitorId: string;
+  folder: SidebarLibraryFolderInput;
+  folders: SidebarLibraryFolderInput[];
+  /** When the library lives outside the profile document, pass its file rows here. */
+  libraryItems?: LibraryContentRow[];
+  addApp: (profileId: string, monitorId: string, newApp: unknown) => void;
+}): void {
+  const { profile, monitorId, folder, folders, libraryItems, addApp } = args;
+  const items = (libraryItems ?? profile.contentItems ?? []) as LibraryContentRow[];
+  const associatedFiles = collectAssociatedFilesFromLibraryFolder(
+    folder,
+    folders,
+    items,
+  );
+  if (associatedFiles.length === 0) return;
+
+  const targetMonitor = profile.monitors?.find((m) => m.id === monitorId);
+  if (!targetMonitor) return;
+  const isPortrait = targetMonitor.orientation === "portrait";
+  const prospectiveAppCount = (targetMonitor.apps?.length || 0) + 1;
+  const snapped = pickZoneNearCenter(isPortrait, prospectiveAppCount);
+
+  const appLabel = folder.defaultApp || "File Viewer";
+  const instanceId = newInstanceId(appLabel);
+  addApp(profile.id, monitorId, {
+    instanceId,
+    name: appLabel,
+    icon: getAppIcon(appLabel),
+    color: getAppColor(appLabel),
+    position: snapped.position,
+    size: snapped.size,
+    volume: 50,
+    launchBehavior: "new",
+    runAsAdmin: false,
+    forceCloseOnExit: false,
+    smartSave: false,
+    monitorId,
+    associatedFiles,
+  });
+}
+
+export function placeSidebarLibraryFolderOnMinimized(args: {
+  profile: FlowProfile;
+  folder: SidebarLibraryFolderInput;
+  folders: SidebarLibraryFolderInput[];
+  libraryItems?: LibraryContentRow[];
+  addAppToMinimized: (profileId: string, newApp: unknown) => void;
+}): void {
+  const { profile, folder, folders, libraryItems, addAppToMinimized } = args;
+  const items = (libraryItems ?? profile.contentItems ?? []) as LibraryContentRow[];
+  const associatedFiles = collectAssociatedFilesFromLibraryFolder(
+    folder,
+    folders,
+    items,
+  );
+  if (associatedFiles.length === 0) return;
+
+  const primary =
+    profile.monitors.find((m) => m.primary) || profile.monitors[0];
+  const targetMonitorId = primary?.id || "monitor-1";
+  const appLabel = folder.defaultApp || "File Viewer";
+  const instanceId = newInstanceId(appLabel);
+  addAppToMinimized(profile.id, {
+    instanceId,
+    name: appLabel,
+    icon: getAppIcon(appLabel),
+    color: getAppColor(appLabel),
+    volume: 50,
+    launchBehavior: "minimize",
+    targetMonitor: targetMonitorId,
+    associatedFiles,
+  });
+}

--- a/src/types/flow-profile.ts
+++ b/src/types/flow-profile.ts
@@ -38,11 +38,26 @@ export type ProfileStoreError = {
   message: string;
 };
 
+/** Global content library (shared across all profiles). */
+export type ContentLibrarySnapshot = {
+  items: unknown[];
+  folders: unknown[];
+};
+
+/** Full document written by `profiles:save-all`. */
+export type ProfileSavePayload = {
+  profiles: FlowProfile[];
+  contentLibrary: ContentLibrarySnapshot;
+  contentLibraryExclusions: Record<string, string[]>;
+};
+
 export type ProfileListResult =
   | FlowProfile[]
   | {
       profiles: FlowProfile[];
       storeError: ProfileStoreError | null;
+      contentLibrary?: ContentLibrarySnapshot;
+      contentLibraryExclusions?: Record<string, string[]>;
     };
 
 export function normalizeFlowProfile(rawProfile: unknown): FlowProfile {

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -1,5 +1,9 @@
 import type { Profile } from './profile';
-import type { FlowProfile, ProfileListResult } from './flow-profile';
+import type {
+  FlowProfile,
+  ProfileListResult,
+  ProfileSavePayload,
+} from './flow-profile';
 
 export {};
 
@@ -126,7 +130,15 @@ declare global {
         apps: Array<unknown>;
       }>>;
       listProfiles: () => Promise<ProfileListResult>;
-      saveProfiles: (profiles: FlowProfile[]) => Promise<{ ok: boolean; count?: number; error?: string }>;
+      saveProfiles: (
+        payload: ProfileSavePayload,
+      ) => Promise<{ ok: boolean; count?: number; error?: string }>;
+      pickContentLibraryPaths: (opts?: {
+        mode?: 'files' | 'directory';
+      }) => Promise<{
+        canceled: boolean;
+        entries?: Array<{ path: string; kind: 'file' | 'directory' }>;
+      }>;
       getZoneHistoryStats: () => Promise<{
         ok: boolean;
         stats?: {


### PR DESCRIPTION
## Summary
Adds a **global content library** persisted with profiles on disk (sanitized payload), profile-scoped **hide** exclusions, and renderer wiring for **compact sidebar** flows.

## Commits (grouped)
1. **feat: persist global content library in profile store** — profile-store, sanitize-profile-store-payload, low-profile / persistence hooks, contentLibraryMutations.
2. **feat: content library sidebar, disk pickers, and inspector UX** — IPC content-library:pick-paths, preload, MainLayout / ContentManager / AddContentModal / SelectedContentDetails, compatible **Opens with** options, explicit **sidebar placement** helpers, related AppFileWindow / AppManager / ProfileCard / icon helper tweaks.

## Checks
- \
pm run lint\ (0 errors)
- \
pm run typecheck\ (baseline pass)

## Not included
- Local edits to \docs/superpowers/feature-braindump.md\ were left **uncommitted** (unrelated brainstorm bullets).

## Manual QA (suggested)
- Add files + folder from desktop pickers; confirm library rows and \diskPath\ folders.
- Inspector: Opens with, hide from profile, delete from library, place on monitor/minimized.
- Smoke: profile launch and layout unchanged for non-library flows.


Made with [Cursor](https://cursor.com)