### PR TITLE
feat: sidebar scrollbar UX, flex shell, portal compact menus

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -83,7 +83,7 @@ if (shouldBootstrapElectronMain) {
   app.commandLine.appendSwitch('disable-d3d11');
   app.commandLine.appendSwitch(
     'disable-features',
-    'UseSkiaRenderer,Vulkan,CanvasOopRasterization,VizDisplayCompositor,Accelerated2dCanvas',
+    'UseSkiaRenderer,Vulkan,CanvasOopRasterization,VizDisplayCompositor,Accelerated2dCanvas,FluentScrollbar',
   );
 }
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -135,6 +135,18 @@
     @apply border-border outline-ring/50;
   }
 
+  /* Electron/frameless: kill document scroll so only inset panes scroll (avoids full-height OS scrollbar). */
+  html {
+    height: 100%;
+    overflow: hidden;
+  }
+
+  #root {
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
   .app-drag-region {
     -webkit-app-region: drag;
   }
@@ -144,7 +156,7 @@
   }
   
   body {
-    @apply bg-flow-bg-primary text-flow-text-primary;
+    @apply h-full overflow-hidden bg-flow-bg-primary text-flow-text-primary;
     color-scheme: dark;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
     font-feature-settings: 'cv11', 'ss01';
@@ -252,6 +264,20 @@
     box-shadow:
       0 18px 50px -14px rgb(0 0 0 / 0.65),
       0 0 0 1px color-mix(in oklch, white 4%, transparent);
+  }
+
+  /** Compact sidebar “+” popovers (match width to app row menu, avoid max-content blowout) */
+  .flow-menu-panel.flow-menu-panel--compact {
+    min-width: 11rem;
+    max-width: 11rem;
+    width: 11rem;
+  }
+
+  .flow-menu-panel.flow-menu-panel--compact .flow-menu-item {
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
   }
 
   .flow-menu-item {
@@ -1097,85 +1123,20 @@
     background: linear-gradient(135deg, #10B981 0%, #059669 100%);
   }
   
-  /* ELEGANT SCROLLBARS - Minimalistic and Professional */
-  
-  /* Main scrollbar class for FlowSwitch components */
-  .scrollbar-elegant {
-    /* Firefox */
-    scrollbar-width: thin;
-    scrollbar-color: var(--flow-border-accent) transparent;
+  /**
+   * `.scrollbar-elegant` / `.scrollbar-enhanced`: app-wide standard look.
+   * Chromium: `::-webkit-*` rules live OUTSIDE @layer (end of file) so they beat OS Fluent scrollbars.
+   * Firefox: never set `scrollbar-*` on the base rule for Chromium — only inside @supports below.
+   */
+  @supports (-moz-appearance: none) {
+    .scrollbar-elegant,
+    .scrollbar-enhanced {
+      scrollbar-width: thin;
+      scrollbar-color: color-mix(in oklch, var(--flow-border-accent) 58%, var(--flow-surface))
+        color-mix(in oklch, var(--flow-border) 14%, transparent);
+    }
   }
-  
-  /* Webkit browsers (Chrome, Safari, Edge) */
-  .scrollbar-elegant::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  
-  .scrollbar-elegant::-webkit-scrollbar-track {
-    background: transparent;
-    border-radius: 3px;
-  }
-  
-  .scrollbar-elegant::-webkit-scrollbar-thumb {
-    background: var(--flow-border);
-    border-radius: 3px;
-    transition: all 0.2s ease-in-out;
-  }
-  
-  .scrollbar-elegant::-webkit-scrollbar-thumb:hover {
-    background: var(--flow-border-accent);
-  }
-  
-  .scrollbar-elegant::-webkit-scrollbar-thumb:active {
-    background: var(--flow-accent-blue);
-  }
-  
-  .scrollbar-elegant::-webkit-scrollbar-corner {
-    background: transparent;
-  }
-  
-  /* Enhanced scrollbar for content areas that need more visibility */
-  .scrollbar-enhanced {
-    /* Firefox */
-    scrollbar-width: thin;
-    scrollbar-color: var(--flow-accent-blue) var(--flow-surface);
-  }
-  
-  /* Webkit browsers (Chrome, Safari, Edge) */
-  .scrollbar-enhanced::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-  
-  .scrollbar-enhanced::-webkit-scrollbar-track {
-    background: var(--flow-surface);
-    border-radius: 4px;
-    border: 1px solid var(--flow-border);
-  }
-  
-  .scrollbar-enhanced::-webkit-scrollbar-thumb {
-    background: linear-gradient(135deg, var(--flow-accent-blue) 0%, var(--flow-accent-blue-hover) 100%);
-    border-radius: 4px;
-    border: 1px solid var(--flow-border);
-    transition: all 0.2s ease-in-out;
-  }
-  
-  .scrollbar-enhanced::-webkit-scrollbar-thumb:hover {
-    background: linear-gradient(135deg, var(--flow-accent-blue-hover) 0%, var(--flow-accent-blue) 100%);
-    box-shadow: 0 2px 8px var(--flow-accent-blue)/30;
-  }
-  
-  .scrollbar-enhanced::-webkit-scrollbar-thumb:active {
-    background: var(--flow-accent-blue);
-    transform: scale(0.95);
-  }
-  
-  .scrollbar-enhanced::-webkit-scrollbar-corner {
-    background: var(--flow-surface);
-    border: 1px solid var(--flow-border);
-  }
-  
+
   /* Invisible scrollbar for special cases */
   .scrollbar-hidden {
     /* Firefox */
@@ -1187,37 +1148,11 @@
     display: none;
   }
   
-  /* Auto-hiding scrollbar that only appears on hover */
+  /* Auto-hiding scrollbar (Chromium webkit rules: end of file) */
   .scrollbar-auto-hide {
-    /* Firefox */
     scrollbar-width: none;
   }
-  
-  .scrollbar-auto-hide::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-    opacity: 0;
-    transition: opacity 0.3s ease-in-out;
-  }
-  
-  .scrollbar-auto-hide:hover::-webkit-scrollbar {
-    opacity: 1;
-  }
-  
-  .scrollbar-auto-hide::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  
-  .scrollbar-auto-hide::-webkit-scrollbar-thumb {
-    background: var(--flow-border-accent);
-    border-radius: 3px;
-    transition: all 0.2s ease-in-out;
-  }
-  
-  .scrollbar-auto-hide::-webkit-scrollbar-thumb:hover {
-    background: var(--flow-accent-blue);
-  }
-  
+
   /* DEBUGGING: Highlight monitor boundaries (remove in production) */
   .debug-monitor-bounds .monitor-container {
     outline: 2px dashed red;
@@ -1233,4 +1168,110 @@
     outline: 2px dashed green;
     outline-offset: 2px;
   }
+}
+
+/**
+ * App-wide scrollbars (OUTSIDE @layer): Chromium/Electron honors these instead of OS Fluent scrollbars.
+ * Use `scrollbar-elegant` (+ overflow) on scroll containers. `scrollbar-enhanced` is an alias.
+ */
+.scrollbar-elegant::-webkit-scrollbar,
+.scrollbar-enhanced::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.scrollbar-elegant::-webkit-scrollbar-button,
+.scrollbar-enhanced::-webkit-scrollbar-button {
+  height: 0;
+  width: 0;
+  display: none;
+}
+
+.scrollbar-elegant::-webkit-scrollbar-track,
+.scrollbar-enhanced::-webkit-scrollbar-track {
+  margin-block: 10px;
+  margin-inline: 0;
+  background: color-mix(in oklch, var(--flow-border) 14%, transparent);
+  border-radius: 100px;
+}
+
+.scrollbar-elegant::-webkit-scrollbar-thumb,
+.scrollbar-enhanced::-webkit-scrollbar-thumb {
+  border-radius: 100px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--flow-border-accent) 32%, var(--flow-surface)) 0%,
+    color-mix(in oklch, var(--flow-border-accent) 52%, var(--flow-bg-tertiary)) 100%
+  );
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, white 6%, transparent),
+    0 1px 6px oklch(0.04 0.02 260 / 0.35);
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+}
+
+.scrollbar-elegant::-webkit-scrollbar-thumb:hover,
+.scrollbar-enhanced::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--flow-border-accent) 52%, var(--flow-surface)) 0%,
+    color-mix(in oklch, var(--flow-accent-blue) 22%, var(--flow-border-accent)) 100%
+  );
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, white 9%, transparent),
+    0 2px 10px oklch(0.06 0.04 260 / 0.4);
+}
+
+.scrollbar-elegant::-webkit-scrollbar-thumb:active,
+.scrollbar-enhanced::-webkit-scrollbar-thumb:active {
+  background: color-mix(in oklch, var(--flow-accent-blue) 38%, var(--flow-border-accent));
+  box-shadow: 0 0 0 1px color-mix(in oklch, white 5%, transparent);
+}
+
+.scrollbar-elegant::-webkit-scrollbar-corner,
+.scrollbar-enhanced::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.scrollbar-auto-hide::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.scrollbar-auto-hide:hover::-webkit-scrollbar {
+  opacity: 1;
+}
+
+.scrollbar-auto-hide::-webkit-scrollbar-button {
+  height: 0;
+  width: 0;
+  display: none;
+}
+
+.scrollbar-auto-hide::-webkit-scrollbar-track {
+  margin-block: 10px;
+  margin-inline: 0;
+  background: color-mix(in oklch, var(--flow-border) 14%, transparent);
+  border-radius: 100px;
+}
+
+.scrollbar-auto-hide::-webkit-scrollbar-thumb {
+  border-radius: 100px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--flow-border-accent) 32%, var(--flow-surface)) 0%,
+    color-mix(in oklch, var(--flow-border-accent) 52%, var(--flow-bg-tertiary)) 100%
+  );
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, white 6%, transparent),
+    0 1px 6px oklch(0.04 0.02 260 / 0.35);
+}
+
+.scrollbar-auto-hide::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--flow-border-accent) 52%, var(--flow-surface)) 0%,
+    color-mix(in oklch, var(--flow-accent-blue) 22%, var(--flow-border-accent)) 100%
+  );
 }

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -923,7 +923,7 @@ export default function App() {
   };
 
   return (
-    <div className="h-screen overflow-hidden flow-shell-canvas">
+    <div className="flow-shell-canvas flex h-screen min-h-0 flex-col overflow-hidden">
       {profileStoreError ? (
         <div
           className="shrink-0 px-4 py-2 bg-amber-950/80 border-b border-amber-700/60 text-amber-100 text-xs"
@@ -951,9 +951,9 @@ export default function App() {
         id="flowswitch-import-profile"
         aria-hidden
       />
-      <div className="flex h-[calc(100vh-2.25rem)]">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left Sidebar - FIXED: Better height management */}
-        <div className="w-[clamp(16rem,24vw,24rem)] min-w-[16rem] flow-shell-nav flex flex-col">
+        <div className="flow-shell-nav flex h-full max-h-full min-h-0 w-[clamp(16rem,24vw,24rem)] min-w-[16rem] shrink-0 flex-col overflow-hidden">
           <div className="flex shrink-0 flex-col gap-2 border-b border-white/[0.06] px-3 py-2.5 md:px-4">
             <div className="flow-nav-tab-strip" role="tablist" aria-label="Sidebar view">
               <button
@@ -1028,8 +1028,8 @@ export default function App() {
             </div>
           </div>
 
-          {/* Sidebar Content - FIXED: Proper flex and overflow handling */}
-          <div className="flex-1 min-h-0 flex flex-col">
+          {/* List region below tabs + search: scrollbars live only inside child views */}
+          <div className="flex min-h-0 flex-1 flex-col border-t border-flow-border/30 bg-flow-bg-primary/15 pt-1">
             {currentView === "profiles" && (
               <div className="flex-1 flex flex-col min-h-0">
                 <div className="flex-shrink-0 border-b border-flow-border/50 p-3">
@@ -1076,8 +1076,8 @@ export default function App() {
                   )}
                 </div>
 
-                <div className="flex-1 overflow-y-auto scrollbar-elegant p-3">
-                  <div className="space-y-2.5">
+                <div className="scrollbar-elegant min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain py-3 pl-3 pr-0">
+                  <div className="space-y-2.5 pr-2.5">
                     {filteredProfiles.length === 0 ? (
                       <p className="py-6 text-center text-xs text-flow-text-muted">
                         {profiles.length === 0
@@ -1135,7 +1135,7 @@ export default function App() {
             )}
 
             {currentView === "apps" && (
-              <div className="flex-1 min-h-0">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <AppManager
                   profiles={profiles}
                   onUpdateProfile={updateProfile}
@@ -1158,7 +1158,7 @@ export default function App() {
             )}
 
             {currentView === "content" && (
-              <div className="flex-1 min-h-0">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <ContentManager
                   profiles={profiles}
                   currentProfile={currentProfile}
@@ -1206,7 +1206,7 @@ export default function App() {
 
         {/* Main Content Area with Header and Right Sidebar */}
         <div
-          className={`flex-1 flex flex-col transition-[margin] duration-200 ease-out ${
+          className={`flex min-h-0 flex-1 flex-col transition-[margin] duration-200 ease-out ${
             rightSidebarOpen ? "mr-[clamp(18rem,24vw,24rem)]" : "mr-0"
           }`}
         >

--- a/src/renderer/layout/components/AddAppModal.tsx
+++ b/src/renderer/layout/components/AddAppModal.tsx
@@ -197,7 +197,7 @@ export function AddAppModal({
         </div>
 
         {/* App List */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="scrollbar-elegant flex-1 overflow-y-auto p-6">
           {filteredApps.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
               {filteredApps.map((app) => {

--- a/src/renderer/layout/components/AddContentModal.tsx
+++ b/src/renderer/layout/components/AddContentModal.tsx
@@ -463,7 +463,7 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
                     <div className="text-xs text-flow-text-secondary font-medium mb-2">
                       Selected ({nativeEntries.length}):
                     </div>
-                    <div className="space-y-1 max-h-24 overflow-y-auto">
+                    <div className="scrollbar-elegant max-h-24 space-y-1 overflow-y-auto">
                       {nativeEntries.slice(0, 6).map((e, index) => (
                         <div key={`${e.path}:${index}`} className="flex items-center gap-2 text-xs text-flow-text-muted">
                           {e.kind === 'directory' ? (
@@ -488,7 +488,7 @@ export function AddContentModal({ isOpen, onClose, type, currentFolder, onAddCon
                     <div className="text-xs text-flow-text-secondary font-medium mb-2">
                       Selected ({selectedFiles.length}):
                     </div>
-                    <div className="space-y-1 max-h-20 overflow-y-auto">
+                    <div className="scrollbar-elegant max-h-20 space-y-1 overflow-y-auto">
                       {Array.from(selectedFiles).slice(0, 5).map((file, index) => (
                         <div key={index} className="flex items-center gap-2 text-xs text-flow-text-muted">
                           <File className="w-3 h-3 flex-shrink-0" />

--- a/src/renderer/layout/components/AddFileModal.tsx
+++ b/src/renderer/layout/components/AddFileModal.tsx
@@ -143,7 +143,7 @@ export function AddFileModal({ isOpen, onClose, onAddFile, commonApps }: AddFile
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-      <div className="bg-flow-bg-secondary border border-flow-border rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+      <div className="scrollbar-elegant max-h-[90vh] w-full max-w-md overflow-y-auto rounded-lg border border-flow-border bg-flow-bg-secondary shadow-xl">
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-2">

--- a/src/renderer/layout/components/AppFileWindow.tsx
+++ b/src/renderer/layout/components/AppFileWindow.tsx
@@ -1170,7 +1170,7 @@ export function AppFileWindow({
                         <div className="text-xs font-medium text-flow-text-muted mb-3 uppercase tracking-wide">
                           Folder Contents ({file.files.length} items):
                         </div>
-                        <div className="space-y-2 max-h-40 overflow-y-auto">
+                        <div className="scrollbar-elegant max-h-40 space-y-2 overflow-y-auto">
                           {file.files.slice(0, 10).map((subFile: any, index: number) => (
                             <div key={index} className="flex items-center gap-3 p-3 bg-flow-bg-primary rounded-lg border border-flow-border">
                               <FileIcon type={subFile.type || 'default'} className="w-4 h-4 flex-shrink-0" />

--- a/src/renderer/layout/components/AppManager.tsx
+++ b/src/renderer/layout/components/AppManager.tsx
@@ -15,6 +15,7 @@ import {
   placeInstalledSidebarAppOnMinimized,
   placeInstalledSidebarAppOnMonitor,
 } from "../utils/sidebarExplicitPlacement";
+import { SidebarOverlayMenu } from "./SidebarOverlayMenu";
 
 interface AppManagerProps {
   profiles: any[];
@@ -86,7 +87,10 @@ export function AppManager({
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [showAppSettings, setShowAppSettings] = useState(false);
   const [expandedApp, setExpandedApp] = useState<string | null>(null);
-  const [addMenuApp, setAddMenuApp] = useState<string | null>(null);
+  const [addMenuOpen, setAddMenuOpen] = useState<{
+    appName: string;
+    anchor: HTMLElement;
+  } | null>(null);
   const [sortOption, setSortOption] = useState<'name' | 'lastAccessed' | 'size'>('name');
   const installedApps = useInstalledApps();
   const allApps = useMemo<AppType[]>(() => (
@@ -148,7 +152,7 @@ export function AppManager({
   }, [currentProfile?.monitors]);
 
   useEffect(() => {
-    setAddMenuApp(null);
+    setAddMenuOpen(null);
   }, [currentProfile?.id]);
 
   const getAppUsage = (appName: string) => {
@@ -287,7 +291,7 @@ export function AppManager({
         onAddApp(mid, newApp);
       },
     });
-    setAddMenuApp(null);
+    setAddMenuOpen(null);
   };
 
   const handleAddInstalledToMinimized = (app: AppType) => {
@@ -304,7 +308,7 @@ export function AppManager({
         onAddAppToMinimized(newApp);
       },
     });
-    setAddMenuApp(null);
+    setAddMenuOpen(null);
   };
 
   if (compact) {
@@ -322,9 +326,9 @@ export function AppManager({
           <span className="flow-sidebar-meta">{filteredApps.length} available</span>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col px-3 pb-3 pt-3">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col pl-3 pr-0 pb-3 pt-3">
           {!sidebarSearchControlled ? (
-            <div className="relative mb-3">
+            <div className="relative mb-3 shrink-0">
               <Search className="absolute left-3 top-1/2 h-3 w-3 -translate-y-1/2 transform text-flow-text-muted" />
               <input
                 type="text"
@@ -336,7 +340,7 @@ export function AppManager({
             </div>
           ) : null}
 
-          <div className="mb-3 rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3">
+          <div className="mb-3 shrink-0 rounded-lg border border-flow-border/50 bg-flow-surface/60 p-3">
             <div className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
               <Move className="h-3.5 w-3.5 shrink-0 text-flow-accent-blue" strokeWidth={1.75} />
               <span>
@@ -346,7 +350,8 @@ export function AppManager({
             </div>
           </div>
 
-        <div className="scrollbar-elegant max-h-[60vh] min-h-0 flex-1 space-y-2 overflow-x-hidden overflow-y-auto">
+        <div className="scrollbar-elegant flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto overscroll-contain">
+          <div className="flex min-h-0 flex-col gap-2 pr-2.5">
           {filteredApps.map((app, index) => {
             const usage = getAppUsage(app.name);
             const isExpanded = expandedApp === app.name || expandedApp === 'toggle-all';
@@ -406,7 +411,7 @@ export function AppManager({
                         }
                         onClick={(e) => {
                           e.stopPropagation();
-                          setAddMenuApp(null);
+                          setAddMenuOpen(null);
                           setExpandedApp(
                             isExpanded ? null : app.name,
                           );
@@ -414,7 +419,7 @@ export function AppManager({
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();
-                            setAddMenuApp(null);
+                            setAddMenuOpen(null);
                             setExpandedApp(
                               isExpanded ? null : app.name,
                             );
@@ -457,22 +462,28 @@ export function AppManager({
                             : "Add to a monitor or minimized row"
                         }
                         aria-label={`Add ${app.name} to layout`}
-                        aria-expanded={addMenuApp === app.name}
+                        aria-expanded={addMenuOpen?.appName === app.name}
                         aria-haspopup="menu"
                         onClick={(e) => {
                           stopRowPointerForDrag(e);
-                          setAddMenuApp(
-                            addMenuApp === app.name ? null : app.name,
+                          setAddMenuOpen((prev) =>
+                            prev?.appName === app.name
+                              ? null
+                              : {
+                                  appName: app.name,
+                                  anchor: e.currentTarget as HTMLElement,
+                                },
                           );
                         }}
                         className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
                       </button>
-                      {addMenuApp === app.name ? (
-                        <div
-                          className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
-                          role="menu"
+                      {addMenuOpen?.appName === app.name ? (
+                        <SidebarOverlayMenu
+                          open
+                          anchorEl={addMenuOpen.anchor}
+                          onClose={() => setAddMenuOpen(null)}
                         >
                           {monitorsSortedForMenu.length ? (
                             monitorsSortedForMenu.map((m) => (
@@ -480,14 +491,16 @@ export function AppManager({
                                 key={m.id}
                                 type="button"
                                 role="menuitem"
-                                className="flow-menu-item text-left text-xs"
+                                className="flow-menu-item min-w-0 text-left text-xs"
                                 onClick={(e) => {
                                   stopRowPointerForDrag(e);
                                   handleAddInstalledToMonitor(app, m.id);
                                 }}
                               >
-                                {(m.name || m.id) +
-                                  (m.primary ? " (primary)" : "")}
+                                <span className="truncate">
+                                  {(m.name || m.id) +
+                                    (m.primary ? " (primary)" : "")}
+                                </span>
                               </button>
                             ))
                           ) : (
@@ -516,10 +529,10 @@ export function AppManager({
                           >
                             Minimized row
                           </button>
-                          <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
+                          <div className="border-t border-flow-border/40 px-2 py-1.5 text-[10px] leading-snug text-flow-text-muted">
                             Drag the app icon to drop on a specific tile.
                           </div>
-                        </div>
+                        </SidebarOverlayMenu>
                       ) : null}
                     </div>
                   </div>
@@ -563,13 +576,14 @@ export function AppManager({
               </div>
             );
           })}
+          </div>
         </div>
         </div>
 
         {/* App Settings Modal */}
         {showAppSettings && selectedApp && (
           <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-            <div className="bg-flow-surface-elevated backdrop-blur-xl border border-flow-border rounded-2xl p-4 max-w-md w-full max-h-[80vh] overflow-y-auto">
+            <div className="scrollbar-elegant max-h-[80vh] w-full max-w-md overflow-y-auto rounded-2xl border border-flow-border bg-flow-surface-elevated p-4 backdrop-blur-xl">
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center gap-3">
                   <div 

--- a/src/renderer/layout/components/AppSettings.tsx
+++ b/src/renderer/layout/components/AppSettings.tsx
@@ -129,7 +129,7 @@ export function AppSettings({
   };
 
   return (
-    <div className="bg-flow-surface-elevated backdrop-blur-xl border border-flow-border rounded-2xl p-6 max-w-md w-full max-h-[80vh] overflow-y-auto">
+    <div className="scrollbar-elegant max-h-[80vh] w-full max-w-md overflow-y-auto rounded-2xl border border-flow-border bg-flow-surface-elevated p-6 backdrop-blur-xl">
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <div 
@@ -279,7 +279,7 @@ export function AppSettings({
           </div>
 
           {associatedFiles.length > 0 ? (
-            <div className="space-y-2 max-h-32 overflow-y-auto">
+            <div className="scrollbar-elegant max-h-32 space-y-2 overflow-y-auto">
               {associatedFiles.map((file, index) => (
                 <div key={file.id} className="flex items-center gap-3 p-2 bg-flow-surface border border-flow-border rounded-lg">
                   <FileIcon type={file.type} className="w-4 h-4 flex-shrink-0" />

--- a/src/renderer/layout/components/BookmarkManager.tsx
+++ b/src/renderer/layout/components/BookmarkManager.tsx
@@ -114,7 +114,7 @@ export function BookmarkManager({
         </div>
 
         {/* Compact Bookmark List */}
-        <div className="space-y-2 max-h-96 overflow-y-auto">
+        <div className="scrollbar-elegant max-h-96 space-y-2 overflow-y-auto">
           {filteredBookmarks.map((bookmark) => {
             const isBeingDragged = draggedBookmark?.id === bookmark.id;
             

--- a/src/renderer/layout/components/ContentManager.tsx
+++ b/src/renderer/layout/components/ContentManager.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo } from "react";
 import { Link, FileText, Plus, Settings, Search, Star, ExternalLink, ChevronRight, ChevronDown, Folder, Home, Heart, Clock, Filter, HelpCircle, Info, Upload, LayoutGrid, List, Grid3X3 } from "lucide-react";
 import { FileIcon, getFileTypeColor } from "./FileIcon";
 import { AddContentModal } from "./AddContentModal";
+import { SidebarOverlayMenu } from "./SidebarOverlayMenu";
 import {
   restoreDocumentTextSelection,
   suspendDocumentTextSelection,
@@ -220,9 +221,10 @@ export function ContentManager({
   const [showAddModal, setShowAddModal] = useState(false);
   const [addModalType, setAddModalType] = useState<'link' | 'file'>('link');
   const [appDropdownOpen, setAppDropdownOpen] = useState<string | null>(null);
-  const [compactAddMenuKey, setCompactAddMenuKey] = useState<string | null>(
-    null,
-  );
+  const [compactAddMenu, setCompactAddMenu] = useState<{
+    key: string;
+    anchor: HTMLElement;
+  } | null>(null);
   const libraryHydratedRef = useRef(false);
   const lastExternalLibrarySigRef = useRef("");
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -302,7 +304,7 @@ export function ContentManager({
   }, [currentProfile?.id, externalContentItems, externalContentFolders]);
 
   useEffect(() => {
-    setCompactAddMenuKey(null);
+    setCompactAddMenu(null);
   }, [currentProfile?.id]);
 
   useEffect(() => {
@@ -732,13 +734,13 @@ export function ContentManager({
   const handleAddContentToMonitor = (item: ContentItem, monitorId: string) => {
     if (!onPlaceContentOnMonitor) return;
     onPlaceContentOnMonitor(monitorId, item);
-    setCompactAddMenuKey(null);
+    setCompactAddMenu(null);
   };
 
   const handleAddContentToMinimized = (item: ContentItem) => {
     if (!onPlaceContentOnMinimized) return;
     onPlaceContentOnMinimized(item);
-    setCompactAddMenuKey(null);
+    setCompactAddMenu(null);
   };
 
   const handleAddLibraryFolderToMonitor = (
@@ -747,13 +749,13 @@ export function ContentManager({
   ) => {
     if (!onPlaceLibraryFolderOnMonitor) return;
     onPlaceLibraryFolderOnMonitor(monitorId, folder);
-    setCompactAddMenuKey(null);
+    setCompactAddMenu(null);
   };
 
   const handleAddLibraryFolderToMinimized = (folder: ContentFolder) => {
     if (!onPlaceLibraryFolderOnMinimized) return;
     onPlaceLibraryFolderOnMinimized(folder);
-    setCompactAddMenuKey(null);
+    setCompactAddMenu(null);
   };
 
   /** Compact sidebar: + menu for a content item */
@@ -775,21 +777,26 @@ export function ContentManager({
                 : "Add to a monitor or minimized row"
             }
             aria-label={`Add ${item.name} to layout`}
-            aria-expanded={compactAddMenuKey === k}
+            aria-expanded={compactAddMenu?.key === k}
             aria-haspopup="menu"
             onClick={(e) => {
               stopContentRowPointer(e);
               setAppDropdownOpen(null);
-              setCompactAddMenuKey(compactAddMenuKey === k ? null : k);
+              setCompactAddMenu((prev) =>
+                prev?.key === k
+                  ? null
+                  : { key: k, anchor: e.currentTarget as HTMLElement },
+              );
             }}
             className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
           </button>
-          {compactAddMenuKey === k ? (
-            <div
-              className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
-              role="menu"
+          {compactAddMenu?.key === k ? (
+            <SidebarOverlayMenu
+              open
+              anchorEl={compactAddMenu.anchor}
+              onClose={() => setCompactAddMenu(null)}
             >
               {monitorsSortedForMenu.length ? (
                 monitorsSortedForMenu.map((m) => (
@@ -797,13 +804,15 @@ export function ContentManager({
                     key={m.id}
                     type="button"
                     role="menuitem"
-                    className="flow-menu-item text-left text-xs"
+                    className="flow-menu-item min-w-0 text-left text-xs"
                     onClick={(e) => {
                       stopContentRowPointer(e);
                       handleAddContentToMonitor(item, m.id);
                     }}
                   >
-                    {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                    <span className="truncate">
+                      {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                    </span>
                   </button>
                 ))
               ) : (
@@ -825,11 +834,11 @@ export function ContentManager({
               >
                 Minimized row
               </button>
-              <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
-                Drag the row to place on a specific tile. Click the row to see
-                full path and change “Opens with” in the panel.
+              <div className="border-t border-flow-border/40 px-2 py-1.5 text-[10px] leading-snug text-flow-text-muted">
+                Drag the row to drop on a tile. Row click: path and “Opens with”
+                in the panel.
               </div>
-            </div>
+            </SidebarOverlayMenu>
           ) : null}
         </div>
       </div>
@@ -850,21 +859,26 @@ export function ContentManager({
             disabled={!currentProfile}
             title="Add folder contents as one layout tile"
             aria-label={`Add folder ${folder.name} to layout`}
-            aria-expanded={compactAddMenuKey === k}
+            aria-expanded={compactAddMenu?.key === k}
             aria-haspopup="menu"
             onClick={(e) => {
               stopContentRowPointer(e);
               setAppDropdownOpen(null);
-              setCompactAddMenuKey(compactAddMenuKey === k ? null : k);
+              setCompactAddMenu((prev) =>
+                prev?.key === k
+                  ? null
+                  : { key: k, anchor: e.currentTarget as HTMLElement },
+              );
             }}
             className="rounded-md p-1.5 text-flow-text-muted transition-colors hover:bg-flow-surface hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Plus className="h-4 w-4" strokeWidth={2} aria-hidden />
           </button>
-          {compactAddMenuKey === k ? (
-            <div
-              className="flow-menu-panel absolute right-0 top-full z-[30000] mt-1 max-h-56 min-w-[11rem] overflow-y-auto py-0.5"
-              role="menu"
+          {compactAddMenu?.key === k ? (
+            <SidebarOverlayMenu
+              open
+              anchorEl={compactAddMenu.anchor}
+              onClose={() => setCompactAddMenu(null)}
             >
               {monitorsSortedForMenu.length ? (
                 monitorsSortedForMenu.map((m) => (
@@ -872,13 +886,15 @@ export function ContentManager({
                     key={m.id}
                     type="button"
                     role="menuitem"
-                    className="flow-menu-item text-left text-xs"
+                    className="flow-menu-item min-w-0 text-left text-xs"
                     onClick={(e) => {
                       stopContentRowPointer(e);
                       handleAddLibraryFolderToMonitor(folder, m.id);
                     }}
                   >
-                    {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                    <span className="truncate">
+                      {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                    </span>
                   </button>
                 ))
               ) : (
@@ -899,11 +915,10 @@ export function ContentManager({
               >
                 Minimized row
               </button>
-              <div className="border-t border-flow-border/40 px-3 py-2 text-[10px] leading-snug text-flow-text-muted">
-                Adds one tile with all files in this folder (including nested
-                folders). Links are skipped.
+              <div className="border-t border-flow-border/40 px-2 py-1.5 text-[10px] leading-snug text-flow-text-muted">
+                One tile: all files in this folder (nested included). Links skipped.
               </div>
-            </div>
+            </SidebarOverlayMenu>
           ) : null}
         </div>
       </div>
@@ -1008,7 +1023,7 @@ export function ContentManager({
                   
                   {appDropdownOpen === folder.id && (
                     <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                      <div className="max-h-40 overflow-y-auto">
+                      <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                         {AVAILABLE_APPS.map((app) => (
                           <button
                             key={app}
@@ -1089,7 +1104,7 @@ export function ContentManager({
                   
                   {appDropdownOpen === folder.id && (
                     <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                      <div className="max-h-40 overflow-y-auto">
+                      <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                         {AVAILABLE_APPS.map((app) => (
                           <button
                             key={app}
@@ -1178,7 +1193,7 @@ export function ContentManager({
                 
                 {appDropdownOpen === folder.id && (
                   <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                    <div className="max-h-40 overflow-y-auto">
+                    <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                       {AVAILABLE_APPS.map((app) => (
                         <button
                           key={app}
@@ -1287,7 +1302,7 @@ export function ContentManager({
                   
                   {appDropdownOpen === item.id && (
                     <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                      <div className="max-h-40 overflow-y-auto">
+                      <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                         {AVAILABLE_APPS.map((app) => (
                           <button
                             key={app}
@@ -1371,7 +1386,7 @@ export function ContentManager({
                   
                   {appDropdownOpen === item.id && (
                     <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                      <div className="max-h-40 overflow-y-auto">
+                      <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                         {AVAILABLE_APPS.map((app) => (
                           <button
                             key={app}
@@ -1458,7 +1473,7 @@ export function ContentManager({
                 
                 {appDropdownOpen === item.id && (
                   <div className="absolute top-full left-0 mt-1 w-48 bg-flow-surface-elevated border border-flow-border rounded-lg shadow-lg overflow-hidden z-50">
-                    <div className="max-h-40 overflow-y-auto">
+                    <div className="scrollbar-elegant max-h-40 overflow-y-auto">
                       {AVAILABLE_APPS.map((app) => (
                         <button
                           key={app}
@@ -1666,7 +1681,7 @@ export function ContentManager({
       </div>
 
       <div
-        className={`space-y-3 ${compact ? "mb-3 px-3 pt-3" : "mb-4"}`}
+        className={`space-y-3 ${compact ? "mb-3 shrink-0 px-3 pt-3" : "mb-4"}`}
       >
         {!sidebarSearchControlled ? (
           <div className="relative">
@@ -1775,7 +1790,7 @@ export function ContentManager({
       {breadcrumbs.length > 1 && selectedType === 'all' && (
         <div
           className={`flex items-center gap-1 border border-flow-border bg-flow-surface p-2 rounded-lg ${
-            compact ? "mx-3 mb-3" : "mb-4"
+            compact ? "mx-3 mb-3 shrink-0" : "mb-4"
           }`}
         >
           <Home className="w-3 h-3 text-flow-text-muted" />
@@ -1799,12 +1814,17 @@ export function ContentManager({
 
 
 
-      {/* Content List - Smart scrolling with elegant scrollbar, no horizontal scroll */}
+      {/* Content list: compact = fill sidebar remainder, scroll only when rows overflow; non-compact = capped height */}
       <div
-        className={`${viewMode === "simplified" ? "space-y-1" : "space-y-2"} max-h-[60vh] overflow-x-hidden overflow-y-auto scrollbar-elegant ${
-          compact ? "min-h-0 flex-1 px-3 pb-3" : ""
-        }`}
+        className={
+          compact
+            ? "scrollbar-elegant min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pl-3 pb-3 pr-0"
+            : "scrollbar-elegant max-h-[60vh] overflow-x-hidden overflow-y-auto"
+        }
       >
+        <div
+          className={`${viewMode === "simplified" ? "space-y-1" : "space-y-2"}${compact ? " pr-2.5" : ""}`}
+        >
         {displayFolders.length === 0 && displayContent.length === 0 ? (
           <div className="text-center py-8">
             <FileText className="w-8 h-8 text-flow-text-muted mx-auto mb-2" />
@@ -1831,6 +1851,7 @@ export function ContentManager({
             {displayContent.map((item) => renderContentItem(item))}
           </>
         )}
+        </div>
       </div>
 
       {/* Add Content Modal */}

--- a/src/renderer/layout/components/FileWindow.tsx
+++ b/src/renderer/layout/components/FileWindow.tsx
@@ -200,7 +200,7 @@ export function FileWindow({
 
           {/* Expanded Folder Contents */}
           {file.isFolder && isExpanded && file.files && (
-            <div className="absolute top-full left-0 right-0 bg-flow-surface border border-flow-border rounded-lg shadow-lg mt-1 p-2 z-20 max-h-32 overflow-y-auto">
+            <div className="scrollbar-elegant absolute left-0 right-0 top-full z-20 mt-1 max-h-32 overflow-y-auto rounded-lg border border-flow-border bg-flow-surface p-2 shadow-lg">
               <div className="space-y-1">
                 {file.files.slice(0, 5).map((subFile: any, index: number) => (
                   <div key={index} className="flex items-center gap-2 text-xs">

--- a/src/renderer/layout/components/MonitorLayout.tsx
+++ b/src/renderer/layout/components/MonitorLayout.tsx
@@ -1695,7 +1695,7 @@ export function MonitorLayout({
       {/* Minimized Apps: overflow visible so hover popovers are not clipped; min-height fits one full tile row */}
       <div className="flex-shrink-0 border-t border-flow-border/30 min-h-[clamp(7.5rem,12vh,11rem)] overflow-x-hidden overflow-y-visible">
         <div
-          className={`min-h-0 max-h-[min(40vh,18rem)] overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable] ${
+          className={`scrollbar-elegant min-h-0 max-h-[min(40vh,18rem)] overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable] ${
             densePreviewMode || layoutColumnHeight < 720 ? 'px-2 py-1' : 'px-3 py-1.5'
           }`}
         >

--- a/src/renderer/layout/components/MonitorLayoutConfig.tsx
+++ b/src/renderer/layout/components/MonitorLayoutConfig.tsx
@@ -344,7 +344,7 @@ export function MonitorLayoutConfig({ monitor, onLayoutChange, isDropdown = fals
             </div>
             
             {/* Predefined Layouts */}
-            <div className="space-y-2 max-h-64 overflow-y-auto">
+            <div className="scrollbar-elegant max-h-64 space-y-2 overflow-y-auto">
               <div className="text-flow-text-secondary text-xs font-medium mb-2 uppercase tracking-wide">
                 Predefined Layouts
               </div>

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -238,7 +238,7 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
       {showDetails && !showActions && !profile.isActive && (
         <div className="absolute top-0 left-full ml-4 w-80 p-4 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-50">
           <h4 className="text-[11px] font-semibold uppercase tracking-wider text-flow-text-secondary mb-3">Apps &amp; layout</h4>
-          <div className="space-y-3 max-h-64 overflow-y-auto">
+          <div className="scrollbar-elegant max-h-64 space-y-3 overflow-y-auto">
             {(Array.isArray(profile.monitors) ? profile.monitors : []).map((monitor, index) => (
               <div key={monitor?.id || index} className="space-y-2">
                 <div className="flex items-center gap-2 text-flow-text-secondary text-sm">

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import { Monitor, Folder, Globe, MoreVertical, Copy, Edit, Trash2, Download, Zap, ZapOff, Clock, Layers } from "lucide-react";
+import { useState } from "react";
+import { Monitor, Globe, MoreVertical, Copy, Edit, Trash2, Download, Zap, ZapOff, Clock, Layers } from "lucide-react";
 import { LucideIcon } from "lucide-react";
 import { ProfileIconGlyph } from "../utils/profileHeaderPresentation";
 import { formatUnit } from "../../utils/pluralize";
@@ -47,27 +47,8 @@ interface ProfileCardProps {
 }
 
 export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelete, onExport, onSetOnStartup, disabled = false }: ProfileCardProps) {
-  const [showDetails, setShowDetails] = useState(false);
   const [showActions, setShowActions] = useState(false);
-  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const clearHoverTimer = () => {
-    if (hoverTimerRef.current) {
-      clearTimeout(hoverTimerRef.current);
-      hoverTimerRef.current = null;
-    }
-  };
-
-  useEffect(() => () => clearHoverTimer(), []);
-
-  const renderPreviewAppIcon = (app: any) => {
-    const IconComponent = app?.icon;
-    if (typeof IconComponent === "function") {
-      return <IconComponent className="w-2 h-2 text-white" />;
-    }
-    return <Folder className="w-2 h-2 text-white" />;
-  };
-  
   const handleActionClick = (e: React.MouseEvent, action: () => void) => {
     e.stopPropagation();
     action();
@@ -78,17 +59,6 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
     <div className="relative">
       <div
         onClick={disabled ? undefined : onClick}
-        onMouseEnter={() => {
-          if (disabled) return;
-          clearHoverTimer();
-          hoverTimerRef.current = setTimeout(() => {
-            setShowDetails(true);
-          }, 150);
-        }}
-        onMouseLeave={() => {
-          clearHoverTimer();
-          if (!disabled) setShowDetails(false);
-        }}
         className={`relative p-3.5 rounded-xl transition-all duration-150 ease-out group border ${
           disabled
             ? 'bg-flow-surface/80 border-flow-border/50 opacity-60 cursor-not-allowed'
@@ -112,14 +82,14 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
             )}
           </div>
         )}
-        
+
         <div className="flex items-start gap-3">
           <div className={`p-2 rounded-lg transition-colors duration-150 ${
             profile.isActive ? 'bg-flow-accent-blue/15' : 'bg-flow-bg-tertiary/80 group-hover:bg-flow-surface'
           }`}>
             <ProfileIconGlyph icon={profile.icon} className="w-4 h-4" />
           </div>
-          
+
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
               <h3 className={`text-sm font-semibold tracking-tight truncate ${
@@ -131,9 +101,9 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
                 </span>
               )}
             </div>
-            
+
             <p className="text-flow-text-muted text-[11px] leading-snug mb-3 line-clamp-2">{profile.description}</p>
-            
+
             <div className="grid grid-cols-2 gap-2 text-xs">
               <div className="flex items-center gap-1 text-flow-text-muted">
                 <Layers className="w-3 h-3" />
@@ -187,7 +157,7 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
               >
                 <MoreVertical className="h-3 w-3" />
               </button>
-            
+
               {showActions && (
                 <div className="absolute top-6 right-0 w-48 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-10 py-1">
                   {onSetOnStartup && (
@@ -233,63 +203,6 @@ export function ProfileCard({ profile, onClick, onSettings, onDuplicate, onDelet
           </div>
         )}
       </div>
-      
-      {/* Hover details tooltip */}
-      {showDetails && !showActions && !profile.isActive && (
-        <div className="absolute top-0 left-full ml-4 w-80 p-4 bg-flow-surface-elevated border border-flow-border/60 rounded-xl shadow-flow-shadow-lg z-50">
-          <h4 className="text-[11px] font-semibold uppercase tracking-wider text-flow-text-secondary mb-3">Apps &amp; layout</h4>
-          <div className="scrollbar-elegant max-h-64 space-y-3 overflow-y-auto">
-            {(Array.isArray(profile.monitors) ? profile.monitors : []).map((monitor, index) => (
-              <div key={monitor?.id || index} className="space-y-2">
-                <div className="flex items-center gap-2 text-flow-text-secondary text-sm">
-                  <Monitor className="w-3 h-3" />
-                  <span>{monitor?.name || `Monitor ${index + 1}`}</span>
-                  {monitor.primary && (
-                    <span className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full bg-flow-accent-blue/20 text-flow-accent-blue border border-flow-accent-blue/30">Primary</span>
-                  )}
-                </div>
-                <div className="flex flex-wrap gap-1.5 ml-4">
-                  {(Array.isArray(monitor?.apps) ? monitor.apps : []).slice(0, 6).map((app, appIndex) => (
-                    <div key={appIndex} className="flex items-center gap-1.5 px-2 py-1 bg-flow-surface rounded text-xs text-flow-text-muted">
-                      <div 
-                        className="w-3 h-3 rounded flex items-center justify-center"
-                        style={{ backgroundColor: `${app?.color || "#64748b"}40` }}
-                      >
-                        {renderPreviewAppIcon(app)}
-                      </div>
-                      <span>{app?.name || "Unknown app"}</span>
-                    </div>
-                  ))}
-                  {(Array.isArray(monitor?.apps) ? monitor.apps.length : 0) > 6 && (
-                    <span className="text-xs text-flow-text-muted px-2 py-1">
-                      +{(Array.isArray(monitor?.apps) ? monitor.apps.length : 0) - 6} more
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-            
-            {profile.minimizedApps && profile.minimizedApps.length > 0 && (
-              <div className="space-y-2 pt-2 border-t border-flow-border">
-                <div className="text-flow-text-secondary text-sm">Minimized Apps</div>
-                <div className="flex flex-wrap gap-1.5">
-                  {profile.minimizedApps.map((app, appIndex) => (
-                    <div key={appIndex} className="flex items-center gap-1.5 px-2 py-1 bg-flow-surface rounded text-xs text-flow-text-muted">
-                      <div 
-                        className="w-3 h-3 rounded flex items-center justify-center"
-                        style={{ backgroundColor: `${app?.color || "#64748b"}40` }}
-                      >
-                        {renderPreviewAppIcon(app)}
-                      </div>
-                      <span>{app?.name || "Unknown app"}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/renderer/layout/components/SidebarOverlayMenu.tsx
+++ b/src/renderer/layout/components/SidebarOverlayMenu.tsx
@@ -1,0 +1,122 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+const MENU_MAX_H_PX = 224; // matches max-h-56
+
+type SidebarOverlayMenuProps = {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  children: React.ReactNode;
+};
+
+/**
+ * Renders a dropdown fixed to the viewport so it is not clipped by
+ * `overflow-y-auto` sidebar lists (and does not inflate list scroll height).
+ */
+export function SidebarOverlayMenu({
+  open,
+  anchorEl,
+  onClose,
+  children,
+}: SidebarOverlayMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [layoutTick, setLayoutTick] = useState(0);
+  const bumpLayout = useCallback(() => {
+    setLayoutTick((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!open || !anchorEl) return;
+    if (!anchorEl.isConnected) onClose();
+  }, [open, anchorEl, onClose]);
+
+  useLayoutEffect(() => {
+    if (!open || !anchorEl || !menuRef.current) return;
+
+    const menu = menuRef.current;
+    const r = anchorEl.getBoundingClientRect();
+    const margin = 6;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    menu.style.maxHeight = `${MENU_MAX_H_PX}px`;
+
+    const mw = Math.min(menu.offsetWidth, vw - margin * 2);
+
+    let left = r.right - mw;
+    left = Math.max(margin, Math.min(left, vw - mw - margin));
+
+    let top = r.bottom + margin;
+
+    let h = menu.offsetHeight;
+    if (top + h > vh - margin) {
+      const aboveTop = r.top - margin - h;
+      if (aboveTop >= margin) {
+        top = aboveTop;
+      } else {
+        const maxH = Math.max(120, vh - top - margin);
+        menu.style.maxHeight = `${maxH}px`;
+        h = menu.offsetHeight;
+        if (top + h > vh - margin) {
+          top = Math.max(margin, vh - margin - h);
+        }
+      }
+    }
+
+    menu.style.position = "fixed";
+    menu.style.top = `${top}px`;
+    menu.style.left = `${left}px`;
+    menu.style.right = "auto";
+    menu.style.bottom = "auto";
+    menu.style.zIndex = "30000";
+  }, [open, anchorEl, layoutTick]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onScrollOrResize = () => bumpLayout();
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [open, bumpLayout]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const t = e.target as Node;
+      if (menuRef.current?.contains(t) || anchorEl?.contains(t)) return;
+      onClose();
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open, onClose, anchorEl]);
+
+  if (!open || !anchorEl) return null;
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="flow-menu-panel flow-menu-panel--compact scrollbar-elegant max-h-56 overflow-y-auto py-0.5"
+      role="menu"
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}

--- a/src/renderer/layout/components/profile-settings/RestrictedApps.tsx
+++ b/src/renderer/layout/components/profile-settings/RestrictedApps.tsx
@@ -14,7 +14,7 @@ export function RestrictedApps({ restrictedApps, onToggleApp }: RestrictedAppsPr
         Restricted Applications
       </h4>
       <p className="text-white/60 text-sm">Prevent these apps from being launched in this profile</p>
-      <div className="space-y-2 max-h-32 overflow-y-auto">
+      <div className="scrollbar-elegant max-h-32 space-y-2 overflow-y-auto">
         {commonRestrictedApps.map((appName) => (
           <label key={appName} className="flex items-center gap-3 p-2 bg-white/5 rounded-lg cursor-pointer hover:bg-white/10 transition-colors">
             <input


### PR DESCRIPTION
## Summary
- **Scrollbars**: Unlayered \::-webkit-scrollbar\ styling for \.scrollbar-elegant\ / \.scrollbar-enhanced\ / \.scrollbar-auto-hide\ with a muted palette; Firefox-only \scrollbar-*\ behind \@supports\. Applied \scrollbar-elegant\ to list/modal scroll surfaces.
- **Windows**: Append \FluentScrollbar\ to \--disable-features\ so Chromium uses stylable WebKit scrollbars.
- **Layout**: \MainLayout\ root/main row use \min-h-0\ / \overflow-hidden\ so sidebars scroll correctly without bogus horizontal overflow.
- **Menus**: New \SidebarOverlayMenu\ portals Apps/Content \+\ and overflow menus to \document.body\ with fixed positioning and reposition on scroll/resize; left nav lists use \pr-0\ + inner \pr-2.5\ for thumb vs card gap.

## Notes
- Remote has no \dev\ branch; PR targets \main\.

## Test plan
- [ ] \
pm run dev\ — left Apps/Content/Profiles lists: thin thumb, no full-column gray bar; thumb near nav edge with gap to cards
- [ ] \+\ and overflow menus — not clipped; width matches Apps row
- [ ] Modals / Monitor layout / bookmarks — scrollbars still elegant
- [ ] Firefox (optional): scrollbar width/color still OK

Made with [Cursor](https://cursor.com)