### PR TITLE
fix: marketing download links and release hints

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -30,6 +30,8 @@ The logo file `flowswitch-logo.png` is duplicated here from `public/` so the mar
 
    Wait for the **Release** workflow to finish, then confirm the release assets match the filenames in `website/latest.json` under `files` (for example `FlowSwitch-0.1.0-win-x64-installer.exe` and `FlowSwitch-0.1.0-win-x64-portable.exe`).
 
+If download links open GitHub’s **Not Found** page, the tag exists but the workflow did not attach the `.exe` files (failed job, wrong glob, or Actions disabled). Open **Actions → Release** for that tag and fix the failing step; the marketing page also shows a hint if `latest.json` fails to load.
+
 3. Replace placeholder support text on `privacy.html` before broad marketing.
 
 ## Build the Windows installer (local)

--- a/website/index.html
+++ b/website/index.html
@@ -32,7 +32,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/lenis@1.1.18/dist/lenis.css" />
-    <link rel="stylesheet" href="./styles.css?v=8" />
+    <link rel="stylesheet" href="./styles.css?v=9" />
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/ScrollTrigger.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/lenis@1.1.18/dist/lenis.min.js"></script>
@@ -56,7 +56,13 @@
           <a href="./changelog.html">Changelog</a>
           <a href="./privacy.html">Privacy</a>
         </nav>
-        <a href="#download" id="header-download" class="btn-header-cta" role="button">Download</a>
+        <a
+          href="https://github.com/jmpanackal/FlowSwitch/releases/download/v0.1.0/FlowSwitch-0.1.0-win-x64-installer.exe"
+          id="header-download"
+          class="btn-header-cta"
+          role="button"
+          data-download-link="1"
+        >Download</a>
       </div>
     </header>
 
@@ -78,7 +84,13 @@
             <div class="download-glow-ring">
               <div class="download-glow-ring__inner">
                 <div class="btn-split">
-                  <a href="#download" id="download-installer" class="btn-split-seg btn-split-seg--main" role="button">
+                  <a
+                    href="https://github.com/jmpanackal/FlowSwitch/releases/download/v0.1.0/FlowSwitch-0.1.0-win-x64-installer.exe"
+                    id="download-installer"
+                    class="btn-split-seg btn-split-seg--main"
+                    role="button"
+                    data-download-link="1"
+                  >
                     <svg
                       class="btn-icon"
                       xmlns="http://www.w3.org/2000/svg"
@@ -120,7 +132,20 @@
             <p class="hero-download-meta" id="download-version-meta">
               v0.1.0 &middot; Supports Windows 10+
               <br />
-              <a href="#download" id="download-portable" class="link-portable">Portable .exe &rarr;</a>
+              <a
+                href="https://github.com/jmpanackal/FlowSwitch/releases/download/v0.1.0/FlowSwitch-0.1.0-win-x64-portable.exe"
+                id="download-portable"
+                class="link-portable"
+                data-download-link="1"
+                >Portable .exe &rarr;</a>
+            </p>
+            <p id="download-error" class="download-error" hidden>
+              Could not refresh release metadata. If the button opens a GitHub error page, the Windows build may not
+              be attached to
+              <a href="https://github.com/jmpanackal/FlowSwitch/releases/tag/v0.1.0">release v0.1.0</a>
+              yet—check
+              <a href="https://github.com/jmpanackal/FlowSwitch/actions">Actions</a>
+              for the Release workflow, then confirm both <code>.exe</code> files appear under that release.
             </p>
           </div>
         </div>

--- a/website/site-core.js
+++ b/website/site-core.js
@@ -15,8 +15,11 @@
       }
     }
     const repo = String(data.githubRepository || '').replace(/^\/+|\/+$/g, '');
-    const tag = encodeURIComponent(String(data.releaseTag || ''));
-    const file = encodeURIComponent(String(fileName || ''));
+    const tag = String(data.releaseTag || '').trim();
+    const file = String(fileName || '').trim();
+    if (!/^[\w.-]+$/.test(tag) || !/^[\w.-]+$/.test(file)) {
+      return `https://github.com/${repo}/releases`;
+    }
     return `https://github.com/${repo}/releases/download/${tag}/${file}`;
   };
 
@@ -62,7 +65,10 @@
 
   const showDownloadError = () => {
     const err = byId('download-error');
-    if (err) err.hidden = false;
+    if (err) {
+      err.hidden = false;
+      err.setAttribute('aria-live', 'polite');
+    }
   };
 
   if (byId('download-installer')) {
@@ -103,6 +109,7 @@
   document.addEventListener('click', (e) => {
     const a = e.target.closest('a[href^="#"]');
     if (!a || !lenis) return;
+    if (a.dataset.downloadLink === '1') return;
     const hash = a.getAttribute('href');
     if (!hash || hash === '#') return;
     const id = hash.slice(1);

--- a/website/styles.css
+++ b/website/styles.css
@@ -400,6 +400,28 @@ a:hover {
   color: var(--text-muted);
 }
 
+.download-error {
+  max-width: 36rem;
+  margin: 1.25rem auto 0;
+  padding: 1rem 1.15rem;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: #fecaca;
+  text-align: center;
+  background: rgba(220, 38, 38, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  border-radius: var(--radius);
+}
+
+.download-error a {
+  color: #fde68a;
+}
+
+.download-error code {
+  font-size: 0.85em;
+  color: #fecaca;
+}
+
 .link-portable {
   font-weight: 500;
   color: var(--text-secondary) !important;


### PR DESCRIPTION
Hardens the marketing site download experience after GitHub release assets went live.

## Changes
- Default primary/header/portable \href\s to the GitHub release asset URLs so downloads work even if \latest.json\ is slow or fails.
- Skip Lenis hash interception for elements with \data-download-link\ so the installer link is not treated as in-page smooth scroll.
- Build GitHub download URLs without over-encoding the tag; safe fallback to the repo releases page if tag/filename look invalid.
- Show \#download-error\ when \latest.json\ cannot be loaded, with links to the v0.1.0 release and Actions.
- README note on GitHub 404 meaning missing assets or a failed Release workflow.

## Checks
- \
pm run lint\
- \
pm run typecheck\

Made with [Cursor](https://cursor.com)