### PR TITLE
chore: marketing site polish (hub, brand, waitlist removal)

### DIFF
--- a/website/changelog.html
+++ b/website/changelog.html
@@ -37,7 +37,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=74" />
+    <link rel="stylesheet" href="./styles.css?v=93" />
     <script defer src="./site-core.js?v=3"></script>
   </head>
   <body class="page-sub">
@@ -47,7 +47,7 @@
       <div class="site-header__pill">
         <a class="brand" href="./">
           <img src="./assets/flowswitch-logo.png" width="38" height="38" alt="FlowSwitch" />
-          <span class="brand__label">FlowSwitch</span>
+          <span class="brand__label" aria-hidden="true"><span class="brand__flow">Flow</span><span class="brand__switch">Switch</span></span>
         </a>
         <nav class="site-nav" aria-label="Site">
           <a href="./">Home</a>

--- a/website/index.html
+++ b/website/index.html
@@ -43,7 +43,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=80" />
+    <link rel="stylesheet" href="./styles.css?v=81" />
     <script defer src="./site-core.js?v=3"></script>
     <script defer src="./site-home.js?v=7"></script>
     <script type="application/ld+json">
@@ -116,7 +116,7 @@
         </nav>
 
         <div class="site-header__actions">
-          <a href="#waitlist" class="btn btn--ghost">Join waitlist</a>
+          <a href="#waitlist" class="btn btn--ghost btn--header-quiet">Join waitlist</a>
           <a
             href="https://github.com/jmpanackal/FlowSwitch/releases/download/v0.1.0/FlowSwitch-0.1.0-win-x64-installer.exe"
             id="header-download"
@@ -173,7 +173,7 @@
             >
               ⊞ Download for Windows
             </a>
-            <a href="#how" class="btn btn--hero-ghost" data-scroll-watch>Watch it switch</a>
+            <a href="#how" class="hero__see-how" data-scroll-watch>See how it works</a>
           </div>
 
           <p class="hero__proof">Built for focused workspaces · Windows · v0.1.0</p>
@@ -190,7 +190,9 @@
             <div class="section-heading section-heading--demo">
               <p class="section-heading__overline">HOW IT WORKS</p>
               <h2 class="section-heading__title-gradient">Create. Arrange. Launch.</h2>
-              <p>Create a profile from what's running or from scratch, arrange it per monitor, launch to restore the full layout.</p>
+              <p class="section-heading__lede">
+                Create a profile from what's running or from scratch, arrange it per monitor, launch to restore the full layout.
+              </p>
             </div>
 
             <div class="demo__monitor-column">
@@ -590,6 +592,9 @@
         <div class="section-heading section-heading--features">
           <p class="section-heading__overline">FEATURES</p>
           <h2 class="section-heading__title-gradient">Built for real desktop complexity.</h2>
+          <p class="section-heading__lede">
+            Placement, launch order, browser context, and minimized windows—mapped to how desks actually behave.
+          </p>
         </div>
 
         <div class="features__hub" aria-hidden="true">
@@ -738,6 +743,7 @@
         <div class="section-heading">
           <p class="section-heading__overline">FAQ</p>
           <h2 class="section-heading__title-gradient">Quick answers before you install.</h2>
+          <p class="section-heading__lede">Install, privacy, and Windows prompts—straight answers, no marketing fog.</p>
         </div>
         <div class="faq-list">
           <details class="faq-item">
@@ -791,6 +797,29 @@
               <p>
                 FlowSwitch is local-first. Profile data stays on your machine by default, and cloud storage is not
                 required for workspace switching.
+              </p>
+            </div>
+          </details>
+          <details class="faq-item">
+            <summary>Does FlowSwitch send my window layouts or apps list to your servers?</summary>
+            <div class="faq-item__body">
+              <p>
+                No. Profiles, captured layouts, and launch metadata are written to local disk under your Windows user
+                profile. Profile switching does not upload your window layouts or app list to FlowSwitch servers. This
+                marketing site may fetch release metadata over HTTPS (for example <code>latest.json</code>) so download
+                buttons can point at the right installer on GitHub.
+              </p>
+            </div>
+          </details>
+          <details class="faq-item">
+            <summary>Why does Windows SmartScreen or “Windows protected your PC” appear when I install?</summary>
+            <div class="faq-item__body">
+              <p>
+                The installer is not yet signed with an expensive commercial code-signing certificate, so Microsoft may
+                show a reputation warning for new downloads. That dialog is about <strong>trust of the file</strong>, not
+                a virus verdict. Choose “More info” (or similar), then “Run anyway,” if you are comfortable installing
+                software from this site and GitHub Releases. Signing the app reduces that friction and is on the
+                roadmap for distribution.
               </p>
             </div>
           </details>

--- a/website/index.html
+++ b/website/index.html
@@ -43,7 +43,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=81" />
+    <link rel="stylesheet" href="./styles.css?v=82" />
     <script defer src="./site-core.js?v=3"></script>
     <script defer src="./site-home.js?v=7"></script>
     <script type="application/ld+json">

--- a/website/index.html
+++ b/website/index.html
@@ -43,9 +43,9 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=82" />
+    <link rel="stylesheet" href="./styles.css?v=93" />
     <script defer src="./site-core.js?v=3"></script>
-    <script defer src="./site-home.js?v=7"></script>
+    <script defer src="./site-home.js?v=8"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -98,7 +98,7 @@
       <div class="site-header__pill">
         <a href="./" class="brand">
           <img src="./assets/flowswitch-logo.png" alt="FlowSwitch" width="30" height="30" />
-          <span class="brand__label">FlowSwitch</span>
+          <span class="brand__label" aria-hidden="true"><span class="brand__flow">Flow</span><span class="brand__switch">Switch</span></span>
         </a>
 
         <button class="menu-toggle" type="button" aria-expanded="false" aria-controls="mobile-menu" data-menu-toggle>
@@ -116,7 +116,6 @@
         </nav>
 
         <div class="site-header__actions">
-          <a href="#waitlist" class="btn btn--ghost btn--header-quiet">Join waitlist</a>
           <a
             href="https://github.com/jmpanackal/FlowSwitch/releases/download/v0.1.0/FlowSwitch-0.1.0-win-x64-installer.exe"
             id="header-download"
@@ -599,13 +598,13 @@
 
         <div class="features__hub" aria-hidden="true">
           <div class="features__hub-inner">
-            <div class="features__hub-pill">
+            <div class="features__hub-disc">
               <img
                 class="features__hub-logo"
                 src="./assets/flowswitch-logo.png"
                 alt="FlowSwitch app icon"
-                width="38"
-                height="38"
+                width="44"
+                height="44"
                 loading="lazy"
                 decoding="async"
               />
@@ -616,36 +615,74 @@
               preserveAspectRatio="none"
               xmlns="http://www.w3.org/2000/svg"
             >
+              <defs>
+                <marker
+                  id="features-hub-arrow-teal"
+                  viewBox="0 0 10 6"
+                  refX="9"
+                  refY="3"
+                  markerWidth="9"
+                  markerHeight="5.5"
+                  markerUnits="userSpaceOnUse"
+                  orient="auto"
+                >
+                  <path d="M 0 0.5 L 8.5 3 L 0 5.5 Z" fill="rgba(111, 212, 191, 0.82)" />
+                </marker>
+                <marker
+                  id="features-hub-arrow-blue"
+                  viewBox="0 0 10 6"
+                  refX="9"
+                  refY="3"
+                  markerWidth="9"
+                  markerHeight="5.5"
+                  markerUnits="userSpaceOnUse"
+                  orient="auto"
+                >
+                  <path d="M 0 0.5 L 8.5 3 L 0 5.5 Z" fill="rgba(140, 178, 255, 0.84)" />
+                </marker>
+                <marker
+                  id="features-hub-arrow-amber"
+                  viewBox="0 0 10 6"
+                  refX="9"
+                  refY="3"
+                  markerWidth="9"
+                  markerHeight="5.5"
+                  markerUnits="userSpaceOnUse"
+                  orient="auto"
+                >
+                  <path d="M 0 0.5 L 8.5 3 L 0 5.5 Z" fill="rgba(255, 214, 140, 0.8)" />
+                </marker>
+              </defs>
               <path
                 class="features__hub-path features__hub-path--left"
-                d="M 500 8 C 500 36 385 74 163 120"
+                d="M 500 0 C 500 24 444 54 330 64 C 250 70 178 100 163 120"
                 fill="none"
                 stroke="rgba(111, 212, 191, 0.58)"
-                stroke-width="1.45"
+                stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
+                marker-end="url(#features-hub-arrow-teal)"
               />
               <path
                 class="features__hub-path features__hub-path--mid"
-                d="M 500 8 L 500 120"
+                d="M 500 0 L 500 120"
                 fill="none"
                 stroke="rgba(140, 178, 255, 0.62)"
-                stroke-width="1.45"
+                stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
+                marker-end="url(#features-hub-arrow-blue)"
               />
               <path
                 class="features__hub-path features__hub-path--right"
-                d="M 500 8 C 500 36 615 74 837 120"
+                d="M 500 0 C 500 24 556 54 670 64 C 750 70 822 100 837 120"
                 fill="none"
                 stroke="rgba(255, 214, 140, 0.55)"
-                stroke-width="1.45"
+                stroke-width="1.5"
                 stroke-linecap="round"
                 stroke-linejoin="round"
+                marker-end="url(#features-hub-arrow-amber)"
               />
-              <circle class="features__hub-cap features__hub-cap--left" cx="163" cy="120" r="2.6" fill="rgba(111, 212, 191, 0.75)" />
-              <circle class="features__hub-cap features__hub-cap--mid" cx="500" cy="120" r="2.6" fill="rgba(140, 178, 255, 0.78)" />
-              <circle class="features__hub-cap features__hub-cap--right" cx="837" cy="120" r="2.6" fill="rgba(255, 214, 140, 0.72)" />
             </svg>
           </div>
         </div>
@@ -831,7 +868,7 @@
           <div class="site-footer__brand">
             <a class="brand brand--footer" href="./">
               <img src="./assets/flowswitch-logo.png" alt="FlowSwitch" width="28" height="28" />
-              <span class="brand__label">FlowSwitch</span>
+              <span class="brand__label" aria-hidden="true"><span class="brand__flow">Flow</span><span class="brand__switch">Switch</span></span>
             </a>
             <p class="site-footer__tagline">One profile. Your whole workspace.</p>
           </div>
@@ -848,13 +885,7 @@
                     data-download-link="1"
                     >Download for Windows</a>
                 </li>
-              </ul>
-            </div>
-            <div class="site-footer__col">
-              <p class="site-footer__heading">Updates</p>
-              <ul class="site-footer__list">
                 <li><a href="./changelog.html">Changelog</a></li>
-                <li><a href="#waitlist">Join waitlist</a></li>
               </ul>
             </div>
             <div class="site-footer__col">
@@ -864,29 +895,6 @@
                 <li><a href="./privacy.html">Privacy</a></li>
               </ul>
             </div>
-          </div>
-        </div>
-
-        <div class="site-footer__newsletter" id="waitlist">
-          <div class="site-footer__newsletter-copy">
-            <h2 class="site-footer__newsletter-title section-heading__title-gradient">Get product updates in your inbox.</h2>
-            <p class="site-footer__newsletter-lead">New Windows releases and changelog highlights. No spam.</p>
-          </div>
-          <div class="site-footer__newsletter-aside">
-            <form class="site-footer__waitlist-form" data-waitlist-form>
-              <label class="sr-only" for="waitlist-email">Email address</label>
-              <input
-                id="waitlist-email"
-                name="email"
-                type="email"
-                placeholder="you@example.com"
-                autocomplete="email"
-                required
-              />
-              <button type="submit" class="btn btn--newsletter">Subscribe</button>
-            </form>
-            <p class="site-footer__waitlist-state" data-waitlist-state aria-live="polite"></p>
-            <p class="site-footer__newsletter-note">Occasional emails only. Unsubscribe anytime.</p>
           </div>
         </div>
       </footer>

--- a/website/index.html
+++ b/website/index.html
@@ -43,7 +43,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=77" />
+    <link rel="stylesheet" href="./styles.css?v=80" />
     <script defer src="./site-core.js?v=3"></script>
     <script defer src="./site-home.js?v=7"></script>
     <script type="application/ld+json">

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -37,7 +37,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="./styles.css?v=74" />
+    <link rel="stylesheet" href="./styles.css?v=93" />
     <script defer src="./site-core.js?v=3"></script>
   </head>
   <body class="page-sub">
@@ -47,7 +47,7 @@
       <div class="site-header__pill">
         <a class="brand" href="./">
           <img src="./assets/flowswitch-logo.png" width="38" height="38" alt="FlowSwitch" />
-          <span class="brand__label">FlowSwitch</span>
+          <span class="brand__label" aria-hidden="true"><span class="brand__flow">Flow</span><span class="brand__switch">Switch</span></span>
         </a>
         <nav class="site-nav" aria-label="Site">
           <a href="./">Home</a>

--- a/website/site-home.js
+++ b/website/site-home.js
@@ -18,9 +18,6 @@
   const mobileLinks = mobileMenuNav ? [...mobileMenuNav.querySelectorAll("a[href]")] : [];
   const mobileMenuDismiss = mobileMenu ? [...mobileMenu.querySelectorAll("[data-mobile-menu-dismiss]")] : [];
 
-  const waitlistForm = document.querySelector("[data-waitlist-form]");
-  const waitlistState = document.querySelector("[data-waitlist-state]");
-  const waitlistButton = waitlistForm?.querySelector("button[type='submit']");
   const flowCanvas = document.querySelector("[data-flow-canvas]");
   const flowBackground = document.querySelector("[data-flow-background]");
 
@@ -370,37 +367,6 @@
 
     mobileLinks.forEach((link) => {
       link.addEventListener("click", () => setMenuOpen(false));
-    });
-  }
-
-  if (waitlistForm && waitlistState && waitlistButton) {
-    waitlistForm.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      markInteracted();
-
-      const formData = new FormData(waitlistForm);
-      const email = String(formData.get("email") || "").trim();
-      if (!email) return;
-
-      waitlistButton.disabled = true;
-      waitlistButton.textContent = "Sending...";
-      waitlistState.textContent = "";
-
-      try {
-        await new Promise((resolve) => {
-          window.setTimeout(resolve, 700);
-        });
-        const aside = waitlistForm.closest(".site-footer__newsletter-aside");
-        const success = document.createElement("p");
-        success.className = "site-footer__waitlist-success";
-        success.textContent = "You're on the list.";
-        if (aside) aside.replaceChildren(success);
-        else waitlistForm.replaceWith(success);
-      } catch {
-        waitlistState.textContent = "Something went wrong — try again";
-        waitlistButton.disabled = false;
-        waitlistButton.textContent = "Subscribe";
-      }
     });
   }
 

--- a/website/styles.css
+++ b/website/styles.css
@@ -129,8 +129,22 @@ input {
 }
 
 .brand__label {
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.9375rem;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+}
+
+/* Wordmark: same white; 500 vs 600 weight for subtle rhythm */
+.brand__flow {
+  font-weight: 500;
+  color: var(--text);
+}
+
+.brand__switch {
+  font-weight: 600;
+  color: var(--text);
 }
 
 .version-pill {
@@ -193,24 +207,6 @@ input {
   display: inline-flex;
   gap: 0.5rem;
   white-space: nowrap;
-}
-
-/* Secondary header action: quieter than Download so the primary CTA reads first */
-.site-header__actions .btn--header-quiet {
-  min-height: 34px;
-  padding: 0 0.65rem;
-  font-size: 0.74rem;
-  font-weight: 500;
-  color: var(--text-muted);
-  border-color: rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.02);
-}
-
-.site-header__actions .btn--header-quiet:hover,
-.site-header__actions .btn--header-quiet:focus-visible {
-  color: var(--text-soft);
-  border-color: rgba(255, 255, 255, 0.16);
-  background: rgba(255, 255, 255, 0.05);
 }
 
 .btn {
@@ -2611,33 +2607,46 @@ main {
   align-items: center;
 }
 
-.features__hub-pill {
+.features__hub-disc {
   position: relative;
   z-index: 1;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0.35rem 0.42rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: linear-gradient(180deg, rgba(22, 24, 28, 0.95), rgba(10, 10, 12, 0.92));
-  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.45);
+  width: 4.5rem;
+  height: 4.5rem;
+  flex-shrink: 0;
+  /* Squircle: superellipse when `corner-shape` is supported; % radius approximates on other engines */
+  border-radius: 31.5%;
+  corner-shape: squircle;
+  isolation: isolate;
+  /* Squircle “orbit”: soft top rim + inner halo + matte base + lift shadow */
+  background:
+    radial-gradient(ellipse 100% 100% at 50% 42%, rgba(111, 212, 191, 0.15) 0%, transparent 58%),
+    radial-gradient(ellipse 115% 72% at 50% 0%, rgba(255, 255, 255, 0.07) 0%, transparent 52%),
+    linear-gradient(168deg, rgba(34, 36, 44, 0.98) 0%, rgba(11, 11, 15, 0.98) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.085);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -12px 26px rgba(0, 0, 0, 0.4),
+    0 16px 40px rgba(0, 0, 0, 0.52),
+    0 0 0 1px rgba(0, 0, 0, 0.42);
 }
 
 .features__hub-logo {
   display: block;
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
+  width: 44px;
+  height: 44px;
+  border-radius: 11px;
   object-fit: contain;
-  box-shadow: 0 0 22px rgba(111, 212, 191, 0.2);
+  filter: drop-shadow(0 0 16px rgba(111, 212, 191, 0.2));
 }
 
 .features__hub-svg {
   display: block;
   width: 100%;
   height: 118px;
-  margin-top: -4px;
+  margin-top: -7px;
   overflow: visible;
 }
 
@@ -2654,22 +2663,6 @@ main {
 }
 
 .features__hub-path--right {
-  animation-delay: 0.7s;
-}
-
-.features__hub-cap {
-  animation: features-hub-line 3.4s ease-in-out infinite;
-}
-
-.features__hub-cap--left {
-  animation-delay: 0s;
-}
-
-.features__hub-cap--mid {
-  animation-delay: 0.35s;
-}
-
-.features__hub-cap--right {
   animation-delay: 0.7s;
 }
 
@@ -3111,17 +3104,9 @@ main {
     color: var(--text);
   }
 
-  .features__hub-path,
-  .features__hub-cap {
-    animation: none;
-  }
-
   .features__hub-path {
-    opacity: 0.5;
-  }
-
-  .features__hub-cap {
-    opacity: 0.85;
+    animation: none;
+    opacity: 0.52;
   }
 
   .feature-card__viz {
@@ -3286,7 +3271,7 @@ main {
 
 .site-footer__columns {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem 1.5rem;
 }
 
@@ -3317,122 +3302,6 @@ main {
 
 .site-footer__list a:hover,
 .site-footer__list a:focus-visible {
-  color: var(--text-soft);
-}
-
-.site-footer__newsletter {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 22rem);
-  gap: 1.25rem 2.5rem;
-  align-items: start;
-  padding-top: 1.5rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  scroll-margin-top: 96px;
-}
-
-.site-footer__newsletter-title {
-  margin: 0;
-  font-size: 0.98rem;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.35;
-  color: var(--text);
-}
-
-.site-footer__newsletter-title.section-heading__title-gradient {
-  background: linear-gradient(115deg, #f7f7f7 0%, rgba(247, 247, 247, 0.92) 38%, #9fe8d8 52%, #b8c7ff 72%, #f7f7f7 100%);
-  background-size: 200% auto;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: section-title-shimmer 11s ease-in-out infinite;
-}
-
-.site-footer__newsletter-lead {
-  margin: 0.35rem 0 0;
-  font-size: 0.8rem;
-  line-height: 1.45;
-  color: var(--text-muted);
-  max-width: 20rem;
-}
-
-.site-footer__newsletter-aside {
-  min-width: 0;
-}
-
-.site-footer__waitlist-form {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.45rem;
-  margin: 0;
-}
-
-.site-footer__waitlist-form input {
-  flex: 1 1 10rem;
-  min-width: 0;
-  min-height: 36px;
-  padding: 0 0.75rem;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.05);
-  font-size: 0.8rem;
-  outline: none;
-}
-
-.site-footer__waitlist-form input::placeholder {
-  color: rgba(255, 255, 255, 0.32);
-}
-
-.site-footer__waitlist-form input:focus {
-  border-color: rgba(255, 255, 255, 0.22);
-  box-shadow: 0 0 0 2px rgba(111, 212, 191, 0.12);
-}
-
-.btn--newsletter {
-  flex: 0 0 auto;
-  min-height: 36px;
-  padding: 0 1rem;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  background: #d6d6d6;
-  color: #0a0a0a;
-  font-size: 0.78rem;
-  font-weight: 600;
-}
-
-.btn--newsletter:hover {
-  background: #e8e8e8;
-}
-
-.btn--newsletter:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.btn--newsletter:disabled {
-  opacity: 0.65;
-  cursor: not-allowed;
-}
-
-.site-footer__waitlist-state {
-  margin: 0.4rem 0 0;
-  min-height: 1rem;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.site-footer__newsletter-note {
-  margin: 0.4rem 0 0;
-  max-width: 26rem;
-  font-size: 0.68rem;
-  line-height: 1.45;
-  color: rgba(255, 255, 255, 0.38);
-}
-
-.site-footer__waitlist-success {
-  margin: 0;
-  font-size: 0.8rem;
   color: var(--text-soft);
 }
 
@@ -3814,14 +3683,6 @@ main {
   }
 }
 
-@media (max-width: 860px) {
-  .site-footer__newsletter {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    padding-top: 1.25rem;
-  }
-}
-
 @media (max-width: 767px) {
   .site-header__pill {
     grid-template-columns: 1fr auto;
@@ -3899,14 +3760,5 @@ main {
 
   .feature-grid {
     grid-template-columns: 1fr;
-  }
-
-  .site-footer__waitlist-form {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .site-footer__waitlist-form .btn--newsletter {
-    width: 100%;
   }
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -15,7 +15,11 @@
   --accent-soft: rgba(111, 212, 191, 0.2);
   --radius: 16px;
   --radius-pill: 999px;
+  --radius-card: 14px;
+  --radius-monitor: clamp(18px, 3.2vw, 26px);
   --wrap: min(1120px, calc(100% - 2.25rem));
+  --max-read: 38rem;
+  --font-lede: clamp(0.95rem, 2.1vw, 1.06rem);
   --font-body: "Inter", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 }
@@ -189,6 +193,24 @@ input {
   display: inline-flex;
   gap: 0.5rem;
   white-space: nowrap;
+}
+
+/* Secondary header action: quieter than Download so the primary CTA reads first */
+.site-header__actions .btn--header-quiet {
+  min-height: 34px;
+  padding: 0 0.65rem;
+  font-size: 0.74rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.site-header__actions .btn--header-quiet:hover,
+.site-header__actions .btn--header-quiet:focus-visible {
+  color: var(--text-soft);
+  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .btn {
@@ -553,17 +575,52 @@ main {
 
 .hero__subhead {
   margin: 1rem auto 0;
-  max-width: 32rem;
+  max-width: var(--max-read);
   color: rgba(255, 255, 255, 0.55);
-  font-size: clamp(1rem, 2.4vw, 1.1rem);
+  font-size: var(--font-lede);
+  line-height: 1.55;
 }
 
 .hero__actions {
   margin-top: 1.55rem;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
-  gap: 0.7rem;
-  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.hero__see-how {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.22);
+  padding: 0.15rem 0.1rem 0.2rem;
+  transition:
+    color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.hero__see-how:hover,
+.hero__see-how:focus-visible {
+  color: var(--text-soft);
+  border-bottom-color: rgba(111, 212, 191, 0.45);
+}
+
+.hero__see-how:focus-visible {
+  outline: 2px solid rgba(111, 212, 191, 0.45);
+  outline-offset: 4px;
+  border-radius: 2px;
+}
+
+@media (min-width: 520px) {
+  .hero__actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.85rem 1.1rem;
+  }
 }
 
 .hero__proof {
@@ -621,9 +678,10 @@ main {
 }
 
 .section-heading h2 {
-  margin: 0.7rem 0 0.5rem;
-  font-size: clamp(1.8rem, 4vw, 2rem);
+  margin: 0.65rem 0 0.45rem;
+  font-size: clamp(1.75rem, 3.8vw, 2rem);
   letter-spacing: -0.03em;
+  line-height: 1.18;
 }
 
 .section-heading__title-gradient {
@@ -639,6 +697,14 @@ main {
 .section-heading p {
   margin: 0;
   color: var(--text-muted);
+}
+
+.section-heading__lede {
+  max-width: var(--max-read);
+  margin: 0.35rem auto 0;
+  font-size: var(--font-lede);
+  line-height: 1.55;
+  color: rgba(255, 255, 255, 0.52);
 }
 
 .demo__scroll-shell {
@@ -677,7 +743,7 @@ main {
   flex-direction: column;
   min-height: min(66vh, 640px);
   padding: 12px;
-  border-radius: 28px;
+  border-radius: var(--radius-monitor);
   background: linear-gradient(180deg, #1a1a1a, #090909);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow:
@@ -705,7 +771,7 @@ main {
   width: 100%;
   margin: 0;
   padding: 1rem;
-  border-radius: 16px;
+  border-radius: var(--radius);
   border: 1px solid rgba(255, 255, 255, 0.07);
   background: #0d0d0d;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
@@ -812,7 +878,7 @@ main {
 
 .demo-window {
   margin-top: 1rem;
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   border: 1px solid rgba(255, 255, 255, 0.06);
   background: rgba(255, 255, 255, 0.03);
   padding: 0.85rem;
@@ -3152,6 +3218,15 @@ main {
   max-width: 70ch;
 }
 
+.faq-item__body code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  padding: 0.06rem 0.32rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.82);
+}
+
 @supports selector(::details-content) {
   .faq-item::details-content {
     overflow: clip;
@@ -3777,9 +3852,14 @@ main {
     align-items: stretch;
   }
 
-  .btn--hero-primary,
-  .btn--hero-ghost {
+  .btn--hero-primary {
     width: 100%;
+    max-width: 22rem;
+    margin-inline: auto;
+  }
+
+  .hero__see-how {
+    align-self: center;
   }
 
   .demo {
@@ -3790,7 +3870,6 @@ main {
   .demo__monitor-shell {
     min-height: min(52vh, 460px);
     padding: 8px;
-    border-radius: 20px;
   }
 
   .demo__sticky-card {

--- a/website/styles.css
+++ b/website/styles.css
@@ -1126,18 +1126,25 @@ main {
 .demo-mock__vscode-tabrow {
   display: flex;
   gap: 0.12rem;
+  min-width: 0;
   padding: 0.15rem 0.25rem 0;
   background: rgba(30, 34, 38, 0.95);
   border-bottom: 1px solid rgba(101, 241, 207, 0.12);
+  overflow: hidden;
 }
 
 .demo-mock__vscode-tab {
+  flex: 1 1 0;
+  min-width: 0;
   padding: 0.12rem 0.32rem 0.15rem;
   border-radius: 4px 4px 0 0;
   font-family: var(--font-mono);
   font-size: 0.44rem;
   color: rgba(200, 210, 208, 0.45);
   background: rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .demo-mock__vscode-tab--on {
@@ -1447,6 +1454,7 @@ main {
   display: flex;
   flex-direction: column;
   flex: 1 1 0;
+  min-width: 0;
   min-height: 0;
   padding: 0.55rem 0.6rem;
 }
@@ -1454,9 +1462,10 @@ main {
 .arrange-demo {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(5rem, 17%) 1fr;
+  grid-template-columns: minmax(5rem, 17%) minmax(0, 1fr);
   gap: 0.55rem;
   flex: 1 1 0;
+  min-width: 0;
   min-height: 0;
   z-index: 0;
 }
@@ -1494,7 +1503,7 @@ main {
 .arrange-demo__main {
   display: flex;
   flex-direction: column;
-  min-width: 0;
+  min-width: 0; /* allow grid track to shrink on narrow viewports */
   min-height: 0;
 }
 
@@ -1512,10 +1521,11 @@ main {
   position: relative;
   flex: 1;
   min-height: 0;
+  min-width: 0;
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(0, 0, 0, 0.38);
-  overflow: visible;
+  overflow: hidden; /* clip board vs. monitor frame (was visible; VSCode mock could spill) */
 }
 
 .arrange-demo__m-tag {
@@ -1535,16 +1545,19 @@ main {
   position: absolute;
   inset: 1.55rem 0.42rem 0.42rem 0.42rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   grid-template-rows: 1fr 1fr;
   gap: 0.45rem;
   align-content: stretch;
+  min-width: 0;
+  min-height: 0;
 }
 
 .arrange-demo__slot {
   position: relative;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
   border-radius: 10px;
 }
@@ -1596,7 +1609,9 @@ main {
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-width: 0;
   min-height: 0;
+  max-width: 100%;
   border-radius: 10px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(14, 16, 20, 0.92);
@@ -1684,6 +1699,7 @@ main {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
   padding: 0.32rem 0.38rem 0.38rem;
   color: var(--text-muted);
@@ -3781,31 +3797,23 @@ main {
     padding: 0.65rem;
   }
 
+  /* Arrange demo: keep Apps as a left rail (same story as desktop); only tighten track sizing. */
   .arrange-demo {
-    grid-template-columns: 1fr;
-    gap: 0.45rem;
+    grid-template-columns: minmax(4.1rem, 24%) minmax(0, 1fr);
+    gap: 0.4rem;
   }
 
   .arrange-demo__rail {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    align-items: stretch;
-    gap: 0.28rem;
-    padding: 0.35rem 0.4rem;
+    padding: 0.34rem 0.26rem;
   }
 
   .arrange-demo__rail-head {
-    flex: 1 0 100%;
-    margin: 0;
-    padding-bottom: 0.15rem;
+    font-size: 0.52rem;
+    padding: 0.08rem 0.12rem 0.2rem;
   }
 
   .arrange-demo__rail-item {
-    flex: 1 1 calc(50% - 0.2rem);
-    min-width: 0;
-    text-align: center;
-    font-size: 0.56rem;
+    font-size: 0.54rem;
     padding: 0.28rem 0.28rem;
   }
 

--- a/website/styles.css
+++ b/website/styles.css
@@ -694,7 +694,7 @@ main {
   animation: section-title-shimmer 11s ease-in-out infinite;
 }
 
-.section-heading p {
+.section-heading p:not(.section-heading__lede) {
   margin: 0;
   color: var(--text-muted);
 }
@@ -705,6 +705,7 @@ main {
   font-size: var(--font-lede);
   line-height: 1.55;
   color: rgba(255, 255, 255, 0.52);
+  text-align: center;
 }
 
 .demo__scroll-shell {


### PR DESCRIPTION
Website-only changes for flowswitch.app static deploy.

### Summary
- **Features hub:** squircle container, larger logo, symmetric sigmoid connector paths with compact arrow markers; tangent fix so side arrows follow the curve.
- **Brand:** Flow/Switch wordmark styling and section lede centering (CSS specificity).
- **Waitlist:** removed header CTA, footer link, and newsletter block until backend exists; removed related \site-home.js\ and CSS.
- **Cache bust:** stylesheet and \site-home.js\ query params on index, changelog, privacy.

### QA
- \
pm run lint\ / \
pm run typecheck\ passed before commit.
- Manually verify desktop Features section (>1023px), header/footer, changelog and privacy pages after deploy.

No \package.json\ version bump — static site redeploy only per AGENTS.md.

Made with [Cursor](https://cursor.com)