### PR TITLE
feat: profile library keyboard and accessible naming

### DIFF
--- a/docs/superpowers/unified-backlog.md
+++ b/docs/superpowers/unified-backlog.md
@@ -56,9 +56,10 @@ Status legend:
    - Launch-time risk/duration messaging.
    - Optional sequencing for dependency-sensitive launches.
 
-5. Shell accessibility — profile library keyboard parity (`not_started`)
+5. Shell accessibility — profile library keyboard parity (`done` — `feature/profile-library-keyboard-parity`)
    - **Evidence:** `docs/superpowers/specs/2026-05-03-ui-ux-evaluation-report.md` (C1); `ProfileCard` uses `div` + `onClick` without `tabIndex` — cards not in tab order; no Enter/Space semantics.
    - **Done when:** Profile rows are operable with keyboard only (prefer `<button type="button">` for card surface, preserve settings `stopPropagation`), with concise per-profile accessible naming.
+   - **Latest:** `ProfileCard` uses a transparent full-card `button` (tab + Enter/Space) with `aria-labelledby` on the profile title and `aria-current` when active; inner settings / “Set hotkey” controls use `pointer-events-auto` so they are not nested inside that button.
 
 6. About dialog / chrome version source of truth (`done` — `fix/about-version-source-of-truth`)
    - **Evidence:** report M1; `AppChromeModals.tsx` hardcodes `APP_VERSION` out of sync with `package.json` (e.g. 0.1.0 vs shipped 0.1.3).
@@ -129,7 +130,7 @@ Current focus phase: `Phase 2 - Reliability Hardening`
 3. Start app-discovery trust pass (manual exe + launchability classification + non-system-drive icon/path robustness).
 4. Start large-profile guardrails (thresholds, warnings, sequencing policy).
 5. Continue orchestration P0 in-progress tasks to done before opening new P1 items.
-6. **UI/UX evaluation follow-ups:** **P0 §6 (About version)** is done on `fix/about-version-source-of-truth`; pick up **P0 §5** (profile card keyboard) next for trust and accessibility; batch **P1 §8–11** with the next renderer-focused PR or `fix/*` branch as appropriate.
+6. **UI/UX evaluation follow-ups:** **P0 §5–6** (profile card keyboard, About version) are done; batch **P1 §8–11** (renderer hygiene, landmarks, tab hit-testing, SR row semantics) with the next renderer-focused PR or `fix/*` branch as appropriate.
 
 ## Recently Landed / Verified Status
 
@@ -146,3 +147,4 @@ Current focus phase: `Phase 2 - Reliability Hardening`
 - Launch summary + profile fidelity merge landed (main): header hierarchy (outcome by title, counter separate), launched-profile inspector binding and poll id during active launch, quiet OK vs pill states, “Reused existing window” smart-decision copy (backward-compatible with legacy “Reusing” text).
 - Canonical backlog process landed: `unified-backlog.md`, `AGENTS.md` post-commit sync rule, removal of superseded standalone launch plan docs under `docs/superpowers/plans/`.
 - First-launch blur: not fixed, low reproducibility.
+- Profile library keyboard parity landed (2026-05-04): `ProfileCard` primary selection is a focusable control with proper naming; nested actions remain separate buttons with `stopPropagation`.

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -2020,11 +2020,13 @@ export default function App() {
                 transform: `translate3d(calc(-100% / 3 * ${librarySidebarSlideIndex}), 0, 0)`,
               }}
             >
+              {/* Inert removes inactive columns from tab order (pointer-events/aria-hidden alone do not). */}
               <div
                 className={`flex min-h-0 w-1/3 min-w-0 flex-shrink-0 flex-col ${
                   currentView === "profiles" ? "" : "pointer-events-none select-none"
                 }`}
                 aria-hidden={currentView !== "profiles"}
+                {...(currentView !== "profiles" ? { inert: "" as const } : {})}
               >
                 <FlowLibraryToolbar
                   toolbarEnd={
@@ -2135,6 +2137,7 @@ export default function App() {
                   currentView === "apps" ? "" : "pointer-events-none select-none"
                 }`}
                 aria-hidden={currentView !== "apps"}
+                {...(currentView !== "apps" ? { inert: "" as const } : {})}
               >
                 <AppManager
                   profiles={profiles}
@@ -2165,6 +2168,7 @@ export default function App() {
                   currentView === "content" ? "" : "pointer-events-none select-none"
                 }`}
                 aria-hidden={currentView !== "content"}
+                {...(currentView !== "content" ? { inert: "" as const } : {})}
               >
                 <ContentManager
                   profiles={profiles}

--- a/src/renderer/layout/components/ProfileCard.tsx
+++ b/src/renderer/layout/components/ProfileCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { Settings, Zap, Clock, Layers, Keyboard } from "lucide-react";
 import { LucideIcon } from "lucide-react";
 import { ProfileIconFrame } from "../utils/profileHeaderPresentation";
@@ -57,6 +58,55 @@ const cardSurfaceClass = (profile: Profile, disabled: boolean) =>
       ? "border-flow-border-accent/35 bg-flow-surface-elevated ring-1 ring-flow-accent-blue/35 shadow-flow-shadow-md cursor-pointer"
       : "flow-card-quiet flow-card-quiet-library cursor-pointer";
 
+const primaryHitClass =
+  "absolute inset-0 z-0 m-0 cursor-pointer rounded-xl border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-flow-accent-blue/50 focus-visible:ring-offset-0 disabled:cursor-not-allowed";
+
+type ProfileCardShellProps = {
+  profile: Profile;
+  disabled: boolean;
+  onClick: () => void;
+  titleId: string;
+  pad: string;
+  surfaceExtraClass?: string;
+  children: ReactNode;
+  settingsSlot: ReactNode;
+};
+
+/**
+ * Primary selection is a full-size transparent `button` (keyboard + SR) so we never nest
+ * interactive buttons. Secondary actions sit above with `pointer-events-auto`.
+ */
+function ProfileCardShell({
+  profile,
+  disabled,
+  onClick,
+  titleId,
+  pad,
+  surfaceExtraClass = "",
+  children,
+  settingsSlot,
+}: ProfileCardShellProps) {
+  const surface = `${cardSurfaceClass(profile, disabled)} ${surfaceExtraClass}`.trim();
+  return (
+    <div className="relative min-w-0">
+      <div
+        className={`relative ${pad} rounded-xl transition-all duration-150 ease-out group border ${surface}`}
+      >
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={disabled ? undefined : onClick}
+          className={primaryHitClass}
+          aria-labelledby={titleId}
+          aria-current={profile.isActive ? "true" : undefined}
+        />
+        <div className="relative z-[1] min-w-0 pointer-events-none">{children}</div>
+        {settingsSlot}
+      </div>
+    </div>
+  );
+}
+
 export function ProfileCard({
   profile,
   onClick,
@@ -67,18 +117,19 @@ export function ProfileCard({
   const pad =
     density === "compact" ? "p-2" : density === "grid" ? "p-2.5" : "p-2.5";
   const titleCls = "text-xs";
+  const titleId = `profile-card-title-${profile.id}`;
 
   const statusBadges =
     profile.autoLaunchOnBoot || profile.autoSwitchTime ? (
       <div className="absolute top-2 left-2 z-[1] flex gap-1">
         {profile.autoLaunchOnBoot && (
           <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-green/30 bg-flow-accent-green/20 px-1.5 py-0.5 text-xs font-medium text-flow-accent-green">
-            <Zap className="h-2.5 w-2.5" />
+            <Zap className="h-2.5 w-2.5" aria-hidden />
           </span>
         )}
         {profile.autoSwitchTime && (
           <span className="inline-flex items-center gap-1 rounded-full border border-flow-accent-purple/30 bg-flow-accent-purple/20 px-1.5 py-0.5 text-xs font-medium text-flow-accent-purple">
-            <Clock className="h-2.5 w-2.5" />
+            <Clock className="h-2.5 w-2.5" aria-hidden />
           </span>
         )}
       </div>
@@ -87,7 +138,7 @@ export function ProfileCard({
   const settingsBtn =
     !disabled && onSettings ? (
       <div
-        className={`absolute z-[1] flex items-center ${
+        className={`pointer-events-auto absolute z-[2] flex items-center ${
           density === "grid" || density === "compact"
             ? "top-2 right-2"
             : "top-2.5 right-2.5"
@@ -112,52 +163,55 @@ export function ProfileCard({
 
   if (density === "grid") {
     return (
-      <div className="relative min-w-0">
-        <div
-          onClick={disabled ? undefined : onClick}
-          className={`relative ${pad} rounded-xl transition-all duration-150 ease-out group border ${cardSurfaceClass(
-            profile,
-            disabled,
-          )} flex min-w-0 flex-col items-center text-center`}
-        >
-          {statusBadges}
-          <div className="flex w-full min-w-0 flex-col items-center gap-2 pt-1">
-            <div
-              className={`rounded-[12px] p-0.5 transition-[box-shadow,transform] duration-150 ${
-                profile.isActive
-                  ? "shadow-[0_0_0_2px_color-mix(in_oklch,var(--flow-accent-blue)_42%,transparent)]"
-                  : "group-hover:scale-[1.02]"
-              }`}
-            >
-              <ProfileIconFrame icon={profile.icon} variant="default" />
-            </div>
-            <h3
-              className={`w-full min-w-0 truncate font-semibold tracking-tight ${titleCls} ${
-                profile.isActive
-                  ? "text-flow-accent-blue"
-                  : "text-flow-text-primary"
-              }`}
-            >
-              {profile.name}
-            </h3>
-            <div className="flex w-full min-w-0 flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[10px] text-flow-text-muted">
-              <span className="inline-flex min-w-0 items-center gap-0.5">
-                <Layers className="h-3 w-3 shrink-0" aria-hidden />
-                <span className="truncate">
-                  {formatUnit(profile.appCount, "app")}
-                </span>
+      <ProfileCardShell
+        profile={profile}
+        disabled={disabled}
+        onClick={onClick}
+        titleId={titleId}
+        pad={pad}
+        surfaceExtraClass="flex min-w-0 flex-col items-center text-center"
+        settingsSlot={settingsBtn}
+      >
+        {statusBadges}
+        <div className="flex w-full min-w-0 flex-col items-center gap-2 pt-1">
+          <div
+            className={`rounded-[12px] p-0.5 transition-[box-shadow,transform] duration-150 ${
+              profile.isActive
+                ? "shadow-[0_0_0_2px_color-mix(in_oklch,var(--flow-accent-blue)_42%,transparent)]"
+                : "group-hover:scale-[1.02]"
+            }`}
+          >
+            <ProfileIconFrame icon={profile.icon} variant="default" />
+          </div>
+          <h3
+            id={titleId}
+            className={`w-full min-w-0 truncate font-semibold tracking-tight ${titleCls} ${
+              profile.isActive
+                ? "text-flow-accent-blue"
+                : "text-flow-text-primary"
+            }`}
+          >
+            {profile.name}
+          </h3>
+          <div className="flex w-full min-w-0 flex-wrap items-center justify-center gap-x-2 gap-y-0.5 text-[10px] text-flow-text-muted">
+            <span className="inline-flex min-w-0 items-center gap-0.5">
+              <Layers className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="truncate">
+                {formatUnit(profile.appCount, "app")}
               </span>
-              <span className="inline-flex min-w-0 items-center gap-0.5">
-                <Clock className="h-3 w-3 shrink-0" aria-hidden />
-                <span className="truncate">{profile.estimatedStartupTime}s</span>
-              </span>
-            </div>
-            <div className="flex w-full min-w-0 items-center justify-center gap-0.5 text-[10px] text-flow-text-muted">
-              <Keyboard className="h-3 w-3 shrink-0" aria-hidden />
-              {profile.hotkey ? (
-                <span className="min-w-0 truncate">{profile.hotkey}</span>
-              ) : (
-                <FlowTooltip label="Edit profile → Automation to set a launch hotkey">
+            </span>
+            <span className="inline-flex min-w-0 items-center gap-0.5">
+              <Clock className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="truncate">{profile.estimatedStartupTime}s</span>
+            </span>
+          </div>
+          <div className="flex w-full min-w-0 items-center justify-center gap-0.5 text-[10px] text-flow-text-muted">
+            <Keyboard className="h-3 w-3 shrink-0" aria-hidden />
+            {profile.hotkey ? (
+              <span className="min-w-0 truncate">{profile.hotkey}</span>
+            ) : (
+              <FlowTooltip label="Edit profile → Automation to set a launch hotkey">
+                <span className="pointer-events-auto inline-flex max-w-full min-w-0">
                   <button
                     type="button"
                     disabled={disabled || !onSettings}
@@ -169,65 +223,27 @@ export function ProfileCard({
                   >
                     Set hotkey
                   </button>
-                </FlowTooltip>
-              )}
-            </div>
+                </span>
+              </FlowTooltip>
+            )}
           </div>
-          {settingsBtn}
         </div>
-      </div>
+      </ProfileCardShell>
     );
   }
 
   if (density === "compact") {
     return (
-      <div className="relative min-w-0">
-        <div
-          onClick={disabled ? undefined : onClick}
-          className={`relative ${pad} rounded-xl transition-all duration-150 ease-out group border ${cardSurfaceClass(
-            profile,
-            disabled,
-          )} ${!disabled && onSettings ? "pr-9" : ""}`}
-        >
-          <div className="flex min-w-0 items-center gap-2">
-            <div
-              className={`shrink-0 rounded-[10px] p-0.5 transition-[box-shadow,transform] duration-150 ${
-                profile.isActive
-                  ? "shadow-[0_0_0_2px_color-mix(in_oklch,var(--flow-accent-blue)_42%,transparent)]"
-                  : "group-hover:scale-[1.02]"
-              }`}
-            >
-              <ProfileIconFrame icon={profile.icon} variant="sidebar" />
-            </div>
-            <h3
-              className={`min-w-0 flex-1 truncate font-semibold tracking-tight ${titleCls} ${
-                profile.isActive
-                  ? "text-flow-accent-blue"
-                  : "text-flow-text-primary"
-              }`}
-            >
-              {profile.name}
-            </h3>
-          </div>
-          {settingsBtn}
-        </div>
-      </div>
-    );
-  }
-
-  /* List (`default`): former “compact” card — stats + hotkey, tighter padding */
-  return (
-    <div className="relative">
-      <div
-        onClick={disabled ? undefined : onClick}
-        className={`relative ${pad} rounded-xl transition-all duration-150 ease-out group border ${cardSurfaceClass(
-          profile,
-          disabled,
-        )}`}
+      <ProfileCardShell
+        profile={profile}
+        disabled={disabled}
+        onClick={onClick}
+        titleId={titleId}
+        pad={pad}
+        surfaceExtraClass={!disabled && onSettings ? "pr-9" : ""}
+        settingsSlot={settingsBtn}
       >
-        {statusBadges}
-
-        <div className="flex items-start gap-3">
+        <div className="flex min-w-0 items-center gap-2">
           <div
             className={`shrink-0 rounded-[10px] p-0.5 transition-[box-shadow,transform] duration-150 ${
               profile.isActive
@@ -237,37 +253,76 @@ export function ProfileCard({
           >
             <ProfileIconFrame icon={profile.icon} variant="sidebar" />
           </div>
+          <h3
+            id={titleId}
+            className={`min-w-0 flex-1 truncate font-semibold tracking-tight ${titleCls} ${
+              profile.isActive
+                ? "text-flow-accent-blue"
+                : "text-flow-text-primary"
+            }`}
+          >
+            {profile.name}
+          </h3>
+        </div>
+      </ProfileCardShell>
+    );
+  }
 
-          <div className="min-w-0 flex-1">
-            <div className="mb-1">
-              <h3
-                className={`${titleCls} truncate font-semibold tracking-tight ${
-                  profile.isActive
-                    ? "text-flow-accent-blue"
-                    : "text-flow-text-primary"
-                }`}
-              >
-                {profile.name}
-              </h3>
+  /* List (`default`): former “compact” card — stats + hotkey, tighter padding */
+  return (
+    <ProfileCardShell
+      profile={profile}
+      disabled={disabled}
+      onClick={onClick}
+      titleId={titleId}
+      pad={pad}
+      settingsSlot={settingsBtn}
+    >
+      {statusBadges}
+
+      <div className="flex items-start gap-3">
+        <div
+          className={`shrink-0 rounded-[10px] p-0.5 transition-[box-shadow,transform] duration-150 ${
+            profile.isActive
+              ? "shadow-[0_0_0_2px_color-mix(in_oklch,var(--flow-accent-blue)_42%,transparent)]"
+              : "group-hover:scale-[1.02]"
+          }`}
+        >
+          <ProfileIconFrame icon={profile.icon} variant="sidebar" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="mb-1">
+            <h3
+              id={titleId}
+              className={`${titleCls} truncate font-semibold tracking-tight ${
+                profile.isActive
+                  ? "text-flow-accent-blue"
+                  : "text-flow-text-primary"
+              }`}
+            >
+              {profile.name}
+            </h3>
+          </div>
+
+          <div className="grid grid-cols-2 gap-1 text-[11px] text-flow-text-muted">
+            <div className="flex min-w-0 items-center gap-1">
+              <Layers className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="truncate">
+                {formatUnit(profile.appCount, "app")}
+              </span>
             </div>
-
-            <div className="grid grid-cols-2 gap-1 text-[11px] text-flow-text-muted">
-              <div className="flex min-w-0 items-center gap-1">
-                <Layers className="h-3 w-3 shrink-0" aria-hidden />
-                <span className="truncate">
-                  {formatUnit(profile.appCount, "app")}
-                </span>
-              </div>
-              <div className="flex min-w-0 items-center gap-1">
-                <Clock className="h-3 w-3 shrink-0" aria-hidden />
-                <span className="truncate">{profile.estimatedStartupTime}s</span>
-              </div>
-              <div className="col-span-2 flex min-w-0 items-center gap-1">
-                <Keyboard className="h-3 w-3 shrink-0" aria-hidden />
-                {profile.hotkey ? (
-                  <span className="truncate">{profile.hotkey}</span>
-                ) : (
-                  <FlowTooltip label="Edit profile → Automation to set a launch hotkey">
+            <div className="flex min-w-0 items-center gap-1">
+              <Clock className="h-3 w-3 shrink-0" aria-hidden />
+              <span className="truncate">{profile.estimatedStartupTime}s</span>
+            </div>
+            <div className="col-span-2 flex min-w-0 items-center gap-1">
+              <Keyboard className="h-3 w-3 shrink-0" aria-hidden />
+              {profile.hotkey ? (
+                <span className="truncate">{profile.hotkey}</span>
+              ) : (
+                <FlowTooltip label="Edit profile → Automation to set a launch hotkey">
+                  <span className="pointer-events-auto inline-flex min-w-0 max-w-full">
                     <button
                       type="button"
                       disabled={disabled || !onSettings}
@@ -279,15 +334,13 @@ export function ProfileCard({
                     >
                       Set launch hotkey
                     </button>
-                  </FlowTooltip>
-                )}
-              </div>
+                  </span>
+                </FlowTooltip>
+              )}
             </div>
           </div>
         </div>
-
-        {settingsBtn}
       </div>
-    </div>
+    </ProfileCardShell>
   );
 }


### PR DESCRIPTION
## Summary (P0 section 5)

- ProfileCard: primary profile switch is a full-card transparent button (tab order, Enter/Space).
- aria-labelledby points at the visible profile title; aria-current when profile is active.
- Settings and Set hotkey stay separate buttons with stopPropagation; pointer-events-none layer + pointer-events-auto on those controls avoids nested buttons.
- ProfileCardShell shared for default, compact, and grid densities.

## Backlog

- docs/superpowers/unified-backlog.md updated (P0 item 5 done, queue note).

## Verification

npm run lint, typecheck, test, build — all pass.

## Manual QA

- Profiles: Tab to each card; Enter/Space switches profile.
- Tab to settings gear; activates without switching profile.
- Try grid, compact, list layouts; edit mode still disables switch.
