### PR TITLE
feat: inspector sidebar design and chrome

### DIFF
--- a/docs/superpowers/feature-braindump.md
+++ b/docs/superpowers/feature-braindump.md
@@ -245,7 +245,7 @@ Canonical cross-doc snapshot lives in `docs/superpowers/unified-backlog.md`.
   - group primary launch status feedback directly under the Launch control for clearer cause-and-effect reading order
   - center Launch button label when no hotkey hint is shown, if layout spec calls for symmetry
 - Merged inbox items: Batch C launch status below launch button, launch label centering for non-hotkey profiles.
-- **Progress (2026-05-05, `feature/inspector-sidebar-design`):** Inspector path card (`InspectorPathDisplay`: exe row + Open in Explorer + copy + truncated path); app/content inspectors use library-style icon tab rails for narrow width; library rail matches (icon-only tabs); tightened vertical rhythm between uppercase section labels and fields (`inspectorStyles`, Overview section stacks).
+- **Progress (2026-05-05, `feature/inspector-sidebar-design`):** Inspector path card (`InspectorPathDisplay`: exe row + Open in Explorer + copy + truncated path); app/content inspectors use library-style icon tab rails for narrow width; library rail matches (icon-only tabs); tightened vertical rhythm between uppercase section labels and fields (`inspectorStyles`, Overview section stacks); fixed inspector **Inspect / Progress** chrome (`Activity`, tooltips); Overview inspector tab **`AppWindow`** (library Apps stays **`LayoutGrid`**).
 - Done when: app remains readable, usable, and visually consistent at reduced sizes.
 
 1. Profile list at-a-glance composition

--- a/docs/superpowers/feature-braindump.md
+++ b/docs/superpowers/feature-braindump.md
@@ -245,6 +245,7 @@ Canonical cross-doc snapshot lives in `docs/superpowers/unified-backlog.md`.
   - group primary launch status feedback directly under the Launch control for clearer cause-and-effect reading order
   - center Launch button label when no hotkey hint is shown, if layout spec calls for symmetry
 - Merged inbox items: Batch C launch status below launch button, launch label centering for non-hotkey profiles.
+- **Progress (2026-05-05, `feature/inspector-sidebar-design`):** Inspector path card (`InspectorPathDisplay`: exe row + Open in Explorer + copy + truncated path); app/content inspectors use library-style icon tab rails for narrow width; library rail matches (icon-only tabs); tightened vertical rhythm between uppercase section labels and fields (`inspectorStyles`, Overview section stacks).
 - Done when: app remains readable, usable, and visually consistent at reduced sizes.
 
 1. Profile list at-a-glance composition

--- a/docs/superpowers/unified-backlog.md
+++ b/docs/superpowers/unified-backlog.md
@@ -74,6 +74,7 @@ Status legend:
 4. Layout editor ergonomics and history (`not_started`)
 5. Responsive behavior for smaller window sizes (`mostly_done` for inspector chrome)
    - **Done on branch `fix/content-launch-followups` (2026-05-01):** associated-content **+ Add** menu stays within the narrow inspector (full-width grid row + width cap); removed dead **`pt-12`** top padding on app/content inspect roots (Launch tab unchanged).
+   - **Latest (2026-05-05, `feature/inspector-sidebar-design`):** `InspectorPathDisplay` path card; app/content inspector tab rails aligned with library narrow variant; icon-only library tabs (Profiles / Apps / Content, `Package` for Content); section label spacing tightened (`inspectorStyles` + Overview stacks).
 6. Catalog curation quick commands (`not_started`)
 7. Edit/view affordance + first-run guidance (`not_started`)
 

--- a/docs/superpowers/unified-backlog.md
+++ b/docs/superpowers/unified-backlog.md
@@ -74,7 +74,7 @@ Status legend:
 4. Layout editor ergonomics and history (`not_started`)
 5. Responsive behavior for smaller window sizes (`mostly_done` for inspector chrome)
    - **Done on branch `fix/content-launch-followups` (2026-05-01):** associated-content **+ Add** menu stays within the narrow inspector (full-width grid row + width cap); removed dead **`pt-12`** top padding on app/content inspect roots (Launch tab unchanged).
-   - **Latest (2026-05-05, `feature/inspector-sidebar-design`):** `InspectorPathDisplay` path card; app/content inspector tab rails aligned with library narrow variant; icon-only library tabs (Profiles / Apps / Content, `Package` for Content); section label spacing tightened (`inspectorStyles` + Overview stacks).
+   - **Latest (2026-05-05, `feature/inspector-sidebar-design`):** `InspectorPathDisplay` path card; app/content inspector tab rails aligned with library narrow variant; icon-only library tabs (Profiles / Apps / Content, `Package` for Content); section label spacing tightened (`inspectorStyles` + Overview stacks); fixed inspector header segmented control renamed **Launch → Progress** with icons/tooltips (distinct from per-app Launch settings); Overview tab uses **`AppWindow`** vs **`LayoutGrid`** on library Apps tab.
 6. Catalog curation quick commands (`not_started`)
 7. Edit/view affordance + first-run guidance (`not_started`)
 

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -493,6 +493,32 @@
     box-shadow: 0 0 0 2px color-mix(in oklch, var(--flow-accent-blue) 45%, transparent);
   }
 
+  /** Icon-only tabs (library + inspectors): no label column, centered glyph. */
+  .flow-library-tab.flow-library-tab--icon-only {
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    padding-inline: 0.3125rem;
+  }
+
+  @media (min-width: 640px) {
+    .flow-library-tab.flow-library-tab--icon-only {
+      padding-inline: 0.4375rem;
+    }
+  }
+
+  /**
+   * Right-hand inspectors use the same rail as the library but in a narrow panel.
+   */
+  .flow-library-tablist.flow-library-tablist--inspector-narrow .flow-library-tablist-rail {
+    min-width: 0;
+  }
+
+  .flow-library-tablist.flow-library-tablist--inspector-narrow .flow-library-tab {
+    min-width: 0;
+  }
+
   /** Installed-apps sidebar: loading hero + row placeholders (Apps tab) */
   @keyframes flow-installed-apps-breathe {
     0%,

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -56,7 +56,7 @@ import {
   Edit,
   PenLine,
   LayoutGrid,
-  Link,
+  Package,
   Users,
   ArrowRight,
   ChevronRight,
@@ -1917,7 +1917,7 @@ export default function App() {
         >
           <div className="flex shrink-0 flex-col gap-2 border-b border-white/[0.06] px-3 py-2.5 md:px-4">
             <div className="flow-library-tablist" role="tablist" aria-label="Sidebar view">
-              <div className="flow-library-tablist-rail">
+              <div className="flow-library-tablist-rail gap-1">
                 <div
                   className="pointer-events-none absolute bottom-0 left-0 z-10 h-0.5 w-1/3 rounded-full bg-flow-accent-blue flow-tab-slide-track"
                   aria-hidden
@@ -1925,51 +1925,66 @@ export default function App() {
                     transform: `translate3d(calc(${librarySidebarSlideIndex} * 100%), 0, 0)`,
                   }}
                 />
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={currentView === "profiles"}
-                  onClick={() => setCurrentView("profiles")}
-                  className={`flow-library-tab ${
-                    currentView === "profiles"
-                      ? "flow-library-tab-active"
-                      : "flow-library-tab-idle"
-                  }`}
-                  aria-label={`Profiles, ${profiles.length} total`}
+                <FlowTooltip
+                  label={`Profiles · ${profiles.length}`}
+                  side="bottom"
                 >
-                  <Users className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
-                  Profiles
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={currentView === "apps"}
-                  onClick={() => setCurrentView("apps")}
-                  className={`flow-library-tab ${
-                    currentView === "apps"
-                      ? "flow-library-tab-active"
-                      : "flow-library-tab-idle"
-                  }`}
-                  aria-label={`Installed apps, ${installedCatalogApps.length} in catalog`}
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={currentView === "profiles"}
+                    onClick={() => setCurrentView("profiles")}
+                    className={`flow-library-tab flow-library-tab--icon-only ${
+                      currentView === "profiles"
+                        ? "flow-library-tab-active"
+                        : "flow-library-tab-idle"
+                    }`}
+                    aria-label={`Profiles, ${profiles.length} total`}
+                  >
+                    <Users className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">Profiles</span>
+                  </button>
+                </FlowTooltip>
+                <FlowTooltip
+                  label={`Apps · ${installedCatalogApps.length}`}
+                  side="bottom"
                 >
-                  <LayoutGrid className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
-                  Apps
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={currentView === "content"}
-                  onClick={() => setCurrentView("content")}
-                  className={`flow-library-tab ${
-                    currentView === "content"
-                      ? "flow-library-tab-active"
-                      : "flow-library-tab-idle"
-                  }`}
-                  aria-label={`Content library, ${contentLibraryEntryCount} entries`}
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={currentView === "apps"}
+                    onClick={() => setCurrentView("apps")}
+                    className={`flow-library-tab flow-library-tab--icon-only ${
+                      currentView === "apps"
+                        ? "flow-library-tab-active"
+                        : "flow-library-tab-idle"
+                    }`}
+                    aria-label={`Installed apps, ${installedCatalogApps.length} in catalog`}
+                  >
+                    <LayoutGrid className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">Apps</span>
+                  </button>
+                </FlowTooltip>
+                <FlowTooltip
+                  label={`Content · ${contentLibraryEntryCount}`}
+                  side="bottom"
                 >
-                  <Link className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
-                  Content
-                </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={currentView === "content"}
+                    onClick={() => setCurrentView("content")}
+                    className={`flow-library-tab flow-library-tab--icon-only ${
+                      currentView === "content"
+                        ? "flow-library-tab-active"
+                        : "flow-library-tab-idle"
+                    }`}
+                    aria-label={`Content library, ${contentLibraryEntryCount} entries`}
+                  >
+                    <Package className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">Content</span>
+                  </button>
+                </FlowTooltip>
               </div>
             </div>
           </div>

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -51,12 +51,14 @@ import {
 } from "./components/SelectedContentDetails";
 import { SelectedAppDetails } from "./components/SelectedAppDetails";
 import {
+  Activity,
   Play,
   Settings,
   Edit,
   PenLine,
   LayoutGrid,
   Package,
+  PanelRight,
   Users,
   ArrowRight,
   ChevronRight,
@@ -129,6 +131,16 @@ import {
   uniqueProfileDisplayName,
   validateMemoryCapture,
 } from "./utils/buildNewProfile";
+
+/** Top segmented control in the fixed inspector (selection vs live launch run). */
+const FLOW_INSPECTOR_MODE_TAB_BASE =
+  "inline-flex min-h-[30px] shrink-0 items-center justify-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold tracking-tight whitespace-nowrap transition-[color,background-color,box-shadow] duration-200 ease-out focus:outline-none focus-visible:ring-2 focus-visible:ring-flow-accent-blue/50 focus-visible:ring-offset-2 focus-visible:ring-offset-flow-bg-secondary motion-reduce:transition-none";
+
+const FLOW_INSPECTOR_MODE_TAB_SELECTED =
+  "bg-flow-accent-blue/[0.14] text-flow-accent-blue shadow-[0_0_0_1px_rgba(56,189,248,0.75),0_0_14px_rgba(56,189,248,0.18)]";
+
+const FLOW_INSPECTOR_MODE_TAB_IDLE =
+  "text-flow-text-muted hover:bg-white/[0.06] hover:text-flow-text-secondary";
 
 /**
  * Application shell: profile grid, monitor layout editor, app/content managers, and the custom
@@ -2666,43 +2678,71 @@ export default function App() {
             <div className="flex items-center justify-between gap-2 border-b border-flow-border px-3 py-2">
               <div
                 role="tablist"
-                aria-label="Sidebar: selection details or launch progress"
-                className="inline-flex max-w-full shrink-0 flex-nowrap items-stretch rounded-full border border-white/[0.12] bg-black/40 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-sm"
+                aria-label="Inspector: selection details or launch progress"
+                className="inline-flex max-w-full shrink-0 flex-nowrap items-stretch gap-px rounded-[10px] border border-white/[0.12] bg-black/40 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-sm"
               >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={inspectorMode === "inspect"}
-                  onClick={() => setInspectorMode("inspect")}
-                  aria-label="Inspect: app or content details"
-                  className={`inline-flex shrink-0 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-semibold tracking-tight whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-flow-accent-blue/50 focus-visible:ring-offset-2 focus-visible:ring-offset-flow-bg-secondary ${
-                    inspectorMode === "inspect"
-                      ? "bg-flow-accent-blue/[0.14] text-flow-accent-blue shadow-[0_0_0_1px_rgba(56,189,248,0.75),0_0_14px_rgba(56,189,248,0.18)]"
-                      : "text-flow-text-muted hover:bg-white/[0.06] hover:text-flow-text-secondary"
-                  }`}
+                <FlowTooltip
+                  side="bottom"
+                  delayDuration={380}
+                  label={
+                    "Placement, paths, and per-app Launch settings for your selection.\n"
+                    + "Live profile launch timeline is on Progress—not this tab."
+                  }
                 >
-                  Inspect
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={inspectorMode === "launch"}
-                  onClick={() => setInspectorMode("launch")}
-                  aria-label="Launch: progress and log for the current run"
-                  className={`relative inline-flex shrink-0 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-[11px] font-semibold tracking-tight whitespace-nowrap transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-flow-accent-blue/50 focus-visible:ring-offset-2 focus-visible:ring-offset-flow-bg-secondary ${
-                    inspectorMode === "launch"
-                      ? "bg-flow-accent-blue/[0.14] text-flow-accent-blue shadow-[0_0_0_1px_rgba(56,189,248,0.75),0_0_14px_rgba(56,189,248,0.18)]"
-                      : "text-flow-text-muted hover:bg-white/[0.06] hover:text-flow-text-secondary"
-                  }`}
-                >
-                  Launch
-                  {isLaunching || launchFeedback.status !== "idle" || lastLaunchProgress ? (
-                    <span
-                      className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-flow-accent-blue"
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={inspectorMode === "inspect"}
+                    onClick={() => setInspectorMode("inspect")}
+                    aria-label="Inspect: details for the selected app or content"
+                    className={`${FLOW_INSPECTOR_MODE_TAB_BASE} ${
+                      inspectorMode === "inspect"
+                        ? FLOW_INSPECTOR_MODE_TAB_SELECTED
+                        : FLOW_INSPECTOR_MODE_TAB_IDLE
+                    }`}
+                  >
+                    <PanelRight
+                      className="h-3.5 w-3.5 shrink-0 opacity-[0.92]"
+                      strokeWidth={2}
                       aria-hidden
                     />
-                  ) : null}
-                </button>
+                    Inspect
+                  </button>
+                </FlowTooltip>
+                <FlowTooltip
+                  side="bottom"
+                  delayDuration={380}
+                  label={
+                    "Live profile launch: timeline, confirmations, and cancel.\n"
+                    + "This panel opens automatically while a launch is running."
+                  }
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={inspectorMode === "launch"}
+                    onClick={() => setInspectorMode("launch")}
+                    aria-label="Progress: live launch status for the active or last profile run"
+                    className={`relative ${FLOW_INSPECTOR_MODE_TAB_BASE} ${
+                      inspectorMode === "launch"
+                        ? FLOW_INSPECTOR_MODE_TAB_SELECTED
+                        : FLOW_INSPECTOR_MODE_TAB_IDLE
+                    }`}
+                  >
+                    <Activity
+                      className="h-3.5 w-3.5 shrink-0 opacity-[0.92]"
+                      strokeWidth={2}
+                      aria-hidden
+                    />
+                    Progress
+                    {isLaunching || launchFeedback.status !== "idle" || lastLaunchProgress ? (
+                      <span
+                        className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-flow-accent-blue ring-2 ring-flow-bg-secondary"
+                        aria-hidden
+                      />
+                    ) : null}
+                  </button>
+                </FlowTooltip>
               </div>
 
               <button

--- a/src/renderer/layout/components/InspectorPathDisplay.tsx
+++ b/src/renderer/layout/components/InspectorPathDisplay.tsx
@@ -1,0 +1,78 @@
+import { Check, Clipboard, FolderOpen } from "lucide-react";
+import { FlowTooltip } from "./ui/tooltip";
+import { inspectorTextLinkClass } from "./inspectorStyles";
+
+function pathLeaf(path: string): string {
+  const t = path.replace(/[/\\]+$/, "");
+  const parts = t.split(/[/\\]/);
+  return parts[parts.length - 1] || t;
+}
+
+export type InspectorPathDisplayProps = {
+  path: string;
+  copyNotice: string | null;
+  onCopy: () => void;
+  canRevealInExplorer: boolean;
+  onRevealInExplorer: () => void | Promise<void>;
+};
+
+/**
+ * Executable card: filename row with Open in Explorer + copy, then full path (truncated RTL).
+ */
+export function InspectorPathDisplay({
+  path,
+  copyNotice,
+  onCopy,
+  canRevealInExplorer,
+  onRevealInExplorer,
+}: InspectorPathDisplayProps) {
+  const trimmed = path.trim();
+  if (!trimmed) return null;
+  const leaf = pathLeaf(trimmed);
+
+  return (
+    <div className="min-w-0 divide-y divide-flow-border/35 rounded-lg border border-flow-border/50 bg-flow-bg-tertiary/30">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5 px-3 py-2">
+        <FlowTooltip label={trimmed}>
+          <span className="min-w-0 flex-1 basis-[8rem] truncate font-mono text-[13px] text-flow-text-primary">
+            {leaf}
+          </span>
+        </FlowTooltip>
+        <div className="ml-auto flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
+          {canRevealInExplorer ? (
+            <button
+              type="button"
+              onClick={() => void onRevealInExplorer()}
+              className={`${inspectorTextLinkClass} !min-h-0 gap-1 py-0.5 text-[11px]`}
+              title="Show this file in File Explorer"
+            >
+              <FolderOpen className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+              Open in Explorer
+            </button>
+          ) : null}
+          <FlowTooltip label="Copy path">
+            <button
+              type="button"
+              onClick={() => void onCopy()}
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-flow-text-secondary transition-colors hover:border-flow-border/50 hover:bg-flow-surface-elevated hover:text-flow-text-primary"
+              aria-label="Copy executable path"
+            >
+              {copyNotice ? (
+                <Check className="h-4 w-4 text-flow-accent-green" strokeWidth={2} aria-hidden />
+              ) : (
+                <Clipboard className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+              )}
+            </button>
+          </FlowTooltip>
+        </div>
+      </div>
+      <div
+        className="min-w-0 truncate px-3 py-1.5 font-mono text-[11px] leading-snug text-flow-text-muted"
+        title={trimmed}
+        dir="rtl"
+      >
+        <span dir="ltr">{trimmed}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/layout/components/SelectedAppDetails.tsx
+++ b/src/renderer/layout/components/SelectedAppDetails.tsx
@@ -28,7 +28,7 @@ import {
   Upload,
   Folder,
   GripVertical,
-  LayoutDashboard,
+  AppWindow,
   HelpCircle,
 } from "lucide-react";
 import { LucideIcon } from "lucide-react";
@@ -308,7 +308,7 @@ export function SelectedAppDetails({
   }, [monitors]);
 
   const tabs: { id: TabType; label: string; icon: LucideIcon }[] = [
-    { id: "overview", label: "Overview", icon: LayoutDashboard },
+    { id: "overview", label: "Overview", icon: AppWindow },
     { id: "launch", label: "Launch", icon: Sliders },
     { id: "content", label: "Content", icon: Package },
   ];

--- a/src/renderer/layout/components/SelectedAppDetails.tsx
+++ b/src/renderer/layout/components/SelectedAppDetails.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { FlowTooltip } from "./ui/tooltip";
 import { safeIconSrc } from "../../utils/safeIconSrc";
 import {
-  Settings,
   Trash2,
   Monitor,
   Clock,
@@ -11,9 +10,7 @@ import {
   Globe,
   FileText,
   Plus,
-  Edit,
   Save,
-  X,
   Volume2,
   VolumeX,
   Maximize2,
@@ -32,10 +29,11 @@ import {
   Folder,
   GripVertical,
   LayoutDashboard,
+  HelpCircle,
 } from "lucide-react";
 import { LucideIcon } from "lucide-react";
 import { FileIcon } from "./FileIcon";
-import { ClickCopyPathBlock } from "./ClickCopyPathBlock";
+import { InspectorPathDisplay } from "./InspectorPathDisplay";
 import type { InstalledAppCatalogKeySource } from "../../utils/installedAppCatalogKey";
 import {
   APP_LIBRARY_CATEGORIES,
@@ -53,7 +51,6 @@ import {
   inspectorFieldLabelClass,
   inspectorHelperTextClass,
   inspectorPanelCompactButtonClass,
-  inspectorPanelCompactButtonDisabledClass,
   inspectorPanelDangerButtonClass,
   inspectorPanelGridButtonDisabledClass,
   inspectorPanelListButtonClass,
@@ -65,7 +62,12 @@ import {
   inspectorPanelSwitchRowClass,
   inspectorPanelSwitchTitleClass,
   inspectorPanelSwitchTrackClass,
-  inspectorSectionPrimaryTitleClass,
+  inspectorMenuItemClass,
+  inspectorMenuPanelClass,
+  inspectorMenuTriggerClass,
+  inspectorSectionLabelClass,
+  inspectorSectionLabelTextClass,
+  inspectorTextLinkClass,
 } from "./inspectorStyles";
 
 const isRenderableIconComponent = (value: unknown): value is LucideIcon => {
@@ -185,6 +187,12 @@ export function SelectedAppDetails({
   const { push: pushSnackbar } = useFlowSnackbar();
   const [addAssocMenuOpen, setAddAssocMenuOpen] = useState(false);
   const addAssocMenuRef = useRef<HTMLDivElement>(null);
+  const [movePlacementMenuOpen, setMovePlacementMenuOpen] = useState(false);
+  const [addToLayoutMenuOpen, setAddToLayoutMenuOpen] = useState(false);
+  const movePlacementMenuRef = useRef<HTMLDivElement>(null);
+  const addToLayoutMenuRef = useRef<HTMLDivElement>(null);
+  const [appLibraryTypeMenuOpen, setAppLibraryTypeMenuOpen] = useState(false);
+  const appLibraryTypeMenuRef = useRef<HTMLDivElement>(null);
   const [activeTab, setActiveTab] = useState<TabType>("overview");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [revealPathError, setRevealPathError] = useState<string | null>(null);
@@ -216,12 +224,48 @@ export function SelectedAppDetails({
 
   useEffect(() => {
     setAddAssocMenuOpen(false);
+    setMovePlacementMenuOpen(false);
+    setAddToLayoutMenuOpen(false);
+    setAppLibraryTypeMenuOpen(false);
   }, [
     selectedApp?.data?.instanceId,
     selectedApp?.monitorId,
     selectedApp?.appIndex,
     selectedApp?.source,
   ]);
+
+  useEffect(() => {
+    if (!movePlacementMenuOpen && !addToLayoutMenuOpen && !appLibraryTypeMenuOpen) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      const moveEl = movePlacementMenuRef.current;
+      const addEl = addToLayoutMenuRef.current;
+      const typeEl = appLibraryTypeMenuRef.current;
+      if (movePlacementMenuOpen && moveEl && !moveEl.contains(t)) {
+        setMovePlacementMenuOpen(false);
+      }
+      if (addToLayoutMenuOpen && addEl && !addEl.contains(t)) {
+        setAddToLayoutMenuOpen(false);
+      }
+      if (appLibraryTypeMenuOpen && typeEl && !typeEl.contains(t)) {
+        setAppLibraryTypeMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onDocMouseDown);
+    return () => document.removeEventListener("mousedown", onDocMouseDown);
+  }, [movePlacementMenuOpen, addToLayoutMenuOpen, appLibraryTypeMenuOpen]);
+
+  useEffect(() => {
+    if (!movePlacementMenuOpen && !addToLayoutMenuOpen && !appLibraryTypeMenuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      setMovePlacementMenuOpen(false);
+      setAddToLayoutMenuOpen(false);
+      setAppLibraryTypeMenuOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [movePlacementMenuOpen, addToLayoutMenuOpen, appLibraryTypeMenuOpen]);
 
   const showAddToLayout =
     selectedApp?.source === "sidebar"
@@ -307,7 +351,7 @@ export function SelectedAppDetails({
   }, [selectedApp, pushSnackbar]);
 
   const handlePickCatalogLaunchExeOverride = useCallback(async () => {
-    if (!selectedApp || selectedApp.source !== "sidebar") return;
+    if (!selectedApp || selectedApp.type !== "app") return;
     if (!window.electron?.pickCatalogLaunchExeOverride) {
       pushSnackbar("File picker is not available.", { variant: "error" });
       return;
@@ -334,7 +378,7 @@ export function SelectedAppDetails({
   }, [selectedApp, onCatalogLaunchExeChanged, pushSnackbar]);
 
   const handleClearCatalogLaunchExeOverride = useCallback(async () => {
-    if (!selectedApp || selectedApp.source !== "sidebar") return;
+    if (!selectedApp || selectedApp.type !== "app") return;
     if (!window.electron?.clearCatalogLaunchExeOverride) {
       pushSnackbar("Clear override is not available.", { variant: "error" });
       return;
@@ -449,13 +493,15 @@ export function SelectedAppDetails({
     }
   };
 
-  // Render app icon with proper fallback
-  const renderAppIcon = (app: any, size: string = "w-12 h-12") => {
+  // Render app icon with proper fallback (header = 32px / 6px radius per inspector sidebar spec)
+  const renderAppIcon = (app: any, variant: "default" | "header" = "default") => {
+    const size = variant === "header" ? "w-8 h-8" : "w-12 h-12";
+    const radius = variant === "header" ? "rounded-md" : "rounded-xl";
     const iconSrc = safeIconSrc(app.iconPath);
     if (iconSrc) {
       return (
         <div
-          className={`${size} rounded-xl flex items-center justify-center border border-white/20 shadow-sm overflow-hidden`}
+          className={`${size} ${radius} flex items-center justify-center border border-white/20 shadow-sm overflow-hidden`}
           style={{ backgroundColor: `${app.color || '#666666'}40` }}
         >
           <img
@@ -470,17 +516,17 @@ export function SelectedAppDetails({
 
     if (!app.icon) {
       return (
-        <div className={`${size} bg-flow-surface rounded-xl flex items-center justify-center border border-flow-border`}>
+        <div className={`${size} ${radius} flex items-center justify-center border border-flow-border bg-flow-surface`}>
           <span className="text-flow-text-muted text-lg">📱</span>
         </div>
       );
     }
-    
+
     if (isRenderableIconComponent(app.icon)) {
       const IconComponent = app.icon;
       return (
         <div
-          className={`${size} rounded-xl flex items-center justify-center border border-white/20 shadow-sm`}
+          className={`${size} ${radius} flex items-center justify-center border border-white/20 shadow-sm`}
           style={{ backgroundColor: `${app.color}80` }}
         >
           <IconComponent className="w-1/2 h-1/2 text-white" />
@@ -488,7 +534,7 @@ export function SelectedAppDetails({
       );
     }
     return (
-      <div className={`${size} bg-flow-surface rounded-xl flex items-center justify-center border border-flow-border`}>
+      <div className={`${size} ${radius} flex items-center justify-center border border-flow-border bg-flow-surface`}>
         <span className="text-flow-text-muted text-lg">❓</span>
       </div>
     );
@@ -526,129 +572,190 @@ export function SelectedAppDetails({
     const showInspectorTestLaunch =
       source === "sidebar" || (isProfileSlot && (type === "app" || type === "browser"));
 
+    const currentLibraryCategory = isAppLibraryCategory(currentData.category)
+      ? currentData.category
+      : inferInstalledAppLibraryCategory(String(currentData.name ?? ""));
+
+    const layoutHelpLong =
+      source === "sidebar"
+        ? "Place on the active profile from here, or use + or drag in the Apps list."
+        : `Move this tile on the active profile.${showAddToLayout ? " From the Apps list you can also use + or drag the icon." : ""}${showMoveToSection && !showAddToLayout ? (source === "monitor" ? " Choose another monitor or the minimized row from Move to…." : " Choose a monitor from Move to….") : ""}`;
+
+    const movePlacementDestinations: { key: string; label: string; run: () => void }[] = [];
+    for (const m of moveToMonitorTargets) {
+      movePlacementDestinations.push({
+        key: m.id,
+        label: `${m.name || m.id}${m.primary ? " (primary)" : ""}`,
+        run: () => {
+          onMoveToMonitor?.(m.id);
+          setMovePlacementMenuOpen(false);
+        },
+      });
+    }
+    if (source === "monitor") {
+      movePlacementDestinations.push({
+        key: "__minimized__",
+        label: "Minimized row",
+        run: () => {
+          onMoveToMinimized?.();
+          setMovePlacementMenuOpen(false);
+        },
+      });
+    }
+    const movePlacementMenuEnabled = showMoveToSection && movePlacementDestinations.length > 0;
+
     return (
-    <div className="min-w-0 space-y-6">
-      <div className="min-w-0 space-y-3">
-        <div className="min-w-0">
-          <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>
-            Layout
-          </label>
-          {source === "sidebar" ? (
-            <p className={inspectorHelperTextClass}>
-              Place on the active profile from here, or use{" "}
-              <span className="font-medium text-flow-text-primary">+</span> / drag in the Apps list.
-            </p>
-          ) : (
-            <p className={inspectorHelperTextClass}>
-              Move, add, or remove this app on the active profile.
-              {showAddToLayout ? (
-                <>
-                  {" "}
-                  From the Apps list you can also use{" "}
-                  <span className="font-medium text-flow-text-primary">+</span> or drag the icon.
-                </>
-              ) : null}
-              {showMoveToSection && !showAddToLayout ? (
-                <>
-                  {" "}
-                  {source === "monitor"
-                    ? "Use the buttons below to move to another monitor or the minimized row."
-                    : "Use the buttons below to move onto a monitor."}
-                </>
-              ) : null}
-            </p>
-          )}
+    <div className="min-w-0 space-y-5">
+      <div className="min-w-0 space-y-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className={inspectorSectionLabelTextClass}>Layout</span>
+          <FlowTooltip label={layoutHelpLong}>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-flow-text-muted transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-secondary"
+              aria-label="Placement tips"
+            >
+              <HelpCircle className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
+            </button>
+          </FlowTooltip>
         </div>
+        <p className={inspectorHelperTextClass}>
+          {source === "sidebar"
+            ? "Place on this profile from the menu, or use + in the Apps list."
+            : "Move this tile with Move to… when it is on the layout."}
+        </p>
+
+        {!isProfileSlot ? (
+          <p className="rounded-lg border border-flow-border/50 bg-flow-bg-tertiary/30 px-3 py-2 text-[11px] leading-snug text-flow-text-muted">
+            This app is not on the current profile layout. Use the + button on its row in the Apps sidebar to place it on a monitor or the minimized row.
+          </p>
+        ) : null}
 
         <div className="min-w-0 space-y-2">
-          <div className="flex min-w-0 flex-col gap-2">
-            <FlowTooltip label="Coming soon: swap this slot for another app from search.">
-              <span className="inline-flex w-full">
-                <button
-                  type="button"
-                  disabled
-                  aria-disabled="true"
-                  className={`${inspectorPanelGridButtonDisabledClass} w-full`}
-                >
-                  <Replace className="h-3.5 w-3.5 shrink-0" aria-hidden />
-                  Replace
-                </button>
-              </span>
-            </FlowTooltip>
+          <FlowTooltip label="Coming soon: swap this slot for another app from search.">
+            <span className="inline-flex w-full">
+              <button
+                type="button"
+                disabled
+                aria-disabled="true"
+                className={`${inspectorPanelGridButtonDisabledClass} w-full`}
+              >
+                <Replace className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                Replace
+              </button>
+            </span>
+          </FlowTooltip>
+
+          {isProfileSlot ? (
             <FlowTooltip
               label={
-                !isProfileSlot
-                  ? "Only apps on the layout can be removed here"
-                  : !onDeleteApp
-                    ? "Remove is unavailable"
-                    : undefined
+                !onDeleteApp
+                  ? "Remove is unavailable"
+                  : "Remove this app from the current profile layout"
               }
             >
               <span className="inline-flex w-full">
                 <button
                   type="button"
                   onClick={() => onDeleteApp?.()}
-                  disabled={!onDeleteApp || !isProfileSlot}
-                  aria-disabled={!onDeleteApp || !isProfileSlot}
+                  disabled={!onDeleteApp}
+                  aria-disabled={!onDeleteApp}
                   className={`${inspectorPanelDangerButtonClass} w-full`}
                 >
                   <Trash2 className="h-3.5 w-3.5 shrink-0" aria-hidden />
-                  Remove
+                  Remove from profile
                 </button>
               </span>
             </FlowTooltip>
-          </div>
+          ) : null}
 
           {showAddToLayout ? (
-            <div className="flex flex-col gap-1">
-              {monitorsSortedForAdd.length ? (
-                monitorsSortedForAdd.map((m) => (
-                  <button
-                    key={m.id}
-                    type="button"
-                    onClick={() => onAddSidebarAppToMonitor?.(m.id)}
-                    className={inspectorPanelListButtonClass}
-                  >
-                    Add to {(m.name || m.id) + (m.primary ? " (primary)" : "")}
-                  </button>
-                ))
-              ) : (
-                <p className="text-xs text-flow-text-muted">No monitors in profile.</p>
-              )}
+            <div ref={addToLayoutMenuRef} className="relative min-w-0">
               <button
                 type="button"
-                onClick={() => onAddSidebarAppToMinimized?.()}
-                className={inspectorPanelListButtonClass}
+                className={inspectorMenuTriggerClass}
+                aria-haspopup="menu"
+                aria-expanded={addToLayoutMenuOpen}
+                onClick={() => {
+                  setAddToLayoutMenuOpen((o) => !o);
+                  setMovePlacementMenuOpen(false);
+                  setAppLibraryTypeMenuOpen(false);
+                }}
               >
-                Add to minimized row
+                <span>Add to layout…</span>
+                <ChevronDown className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
               </button>
+              {addToLayoutMenuOpen ? (
+                <div className={inspectorMenuPanelClass} role="menu">
+                  {monitorsSortedForAdd.length ? (
+                    monitorsSortedForAdd.map((m) => (
+                      <button
+                        key={m.id}
+                        type="button"
+                        role="menuitem"
+                        className={inspectorMenuItemClass}
+                        onClick={() => {
+                          onAddSidebarAppToMonitor?.(m.id);
+                          setAddToLayoutMenuOpen(false);
+                        }}
+                      >
+                        {(m.name || m.id) + (m.primary ? " (primary)" : "")}
+                      </button>
+                    ))
+                  ) : (
+                    <div className="px-3 py-2 text-[13px] text-flow-text-muted">No monitors in profile.</div>
+                  )}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={inspectorMenuItemClass}
+                    onClick={() => {
+                      onAddSidebarAppToMinimized?.();
+                      setAddToLayoutMenuOpen(false);
+                    }}
+                  >
+                    Minimized row
+                  </button>
+                </div>
+              ) : null}
             </div>
           ) : null}
 
           {showMoveToSection ? (
-            <div className="flex flex-col gap-1">
-              {moveToMonitorTargets.length ? (
-                moveToMonitorTargets.map((m) => (
-                  <button
-                    key={m.id}
-                    type="button"
-                    onClick={() => onMoveToMonitor?.(m.id)}
-                    className={inspectorPanelListButtonClass}
-                  >
-                    Move to {(m.name || m.id) + (m.primary ? " (primary)" : "")}
-                  </button>
-                ))
-              ) : source === "minimized" ? (
-                <p className="text-xs text-flow-text-muted">No monitors in profile.</p>
+            <div ref={movePlacementMenuRef} className="relative min-w-0">
+              <button
+                type="button"
+                className={inspectorMenuTriggerClass}
+                disabled={!movePlacementMenuEnabled}
+                aria-haspopup="menu"
+                aria-expanded={movePlacementMenuOpen}
+                onClick={() => {
+                  if (!movePlacementMenuEnabled) return;
+                  setMovePlacementMenuOpen((o) => !o);
+                  setAddToLayoutMenuOpen(false);
+                  setAppLibraryTypeMenuOpen(false);
+                }}
+              >
+                <span>Move to…</span>
+                <ChevronDown className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+              </button>
+              {movePlacementMenuOpen && movePlacementMenuEnabled ? (
+                <div className={inspectorMenuPanelClass} role="menu">
+                  {movePlacementDestinations.map((d) => (
+                    <button
+                      key={d.key}
+                      type="button"
+                      role="menuitem"
+                      className={inspectorMenuItemClass}
+                      onClick={d.run}
+                    >
+                      {d.label}
+                    </button>
+                  ))}
+                </div>
               ) : null}
-              {source === "monitor" ? (
-                <button
-                  type="button"
-                  onClick={() => onMoveToMinimized?.()}
-                  className={inspectorPanelListButtonClass}
-                >
-                  Move to minimized row
-                </button>
+              {showMoveToSection && !movePlacementMenuEnabled && source === "minimized" ? (
+                <p className="text-[13px] text-flow-text-muted">No monitors in profile.</p>
               ) : null}
             </div>
           ) : null}
@@ -661,197 +768,169 @@ export function SelectedAppDetails({
         ) : null}
       </div>
 
-      {/* Basic Info */}
-      <div className="min-w-0 space-y-4">
-        <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>
-          Basic Information
-        </label>
-
-        {!isProfileSlot ? (
-          <p className="rounded-lg border border-flow-border/50 bg-flow-bg-tertiary/30 px-3 py-2 text-[11px] leading-snug text-flow-text-muted">
-            This app is not on the current profile layout. Use the + button on its row in the Apps sidebar to place it on a monitor or the minimized row.
-          </p>
-        ) : null}
-
-        {type === "app" &&
-        typeof onSetInstalledAppLibraryCategory === "function" ? (
-          <div className="min-w-0">
-            <label
-              className={inspectorFieldLabelClass}
-              htmlFor={installedAppTypeFieldId}
-            >
-              App type
-            </label>
-            <select
-              id={installedAppTypeFieldId}
-              className={inspectorPanelNativeSelectClass}
-              value={
-                isAppLibraryCategory(currentData.category)
-                  ? currentData.category
-                  : inferInstalledAppLibraryCategory(
-                      String(currentData.name ?? ""),
-                    )
-              }
-              onChange={(e) => {
-                const v = e.target.value;
-                if (isAppLibraryCategory(v)) {
-                  onSetInstalledAppLibraryCategory(
-                    {
-                      name: String(currentData.name ?? ""),
-                      executablePath: currentData.executablePath ?? null,
-                      shortcutPath: currentData.shortcutPath ?? null,
-                      launchUrl: currentData.launchUrl ?? null,
-                    },
-                    v,
-                  );
-                }
-              }}
-            >
-              {APP_LIBRARY_CATEGORIES.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
-            <p className={`${inspectorHelperTextClass} mt-1.5`}>
-              Used for the type chip in the Apps library. Your choice is saved on this device.
-            </p>
-          </div>
-        ) : null}
-
-        {showInspectorTestLaunch ? (
-          <div className="min-w-0 space-y-2 rounded-lg border border-flow-border/40 bg-flow-bg-tertiary/20 px-3 py-3">
-            <label className={inspectorFieldLabelClass}>Test launch</label>
-            <p className={inspectorHelperTextClass}>
-              {source === "sidebar"
-                ? "Runs this catalog entry once on Windows (.exe, shortcut, or supported URL)."
-                : "Runs once using the paths saved for this slot on Windows (.exe, shortcut, or supported URL)."}
-            </p>
-            <button
-              type="button"
-              onClick={() => void handleCatalogTestLaunchFromInspector()}
-              disabled={catalogTestLaunchDisabled}
-              aria-disabled={catalogTestLaunchDisabled}
-              className={`${inspectorPanelListButtonClass}${
-                catalogTestLaunchDisabled ? " cursor-not-allowed opacity-40" : ""
-              }`}
-            >
-              Test launch
-            </button>
-          </div>
-        ) : null}
-
-        <div>
-          <label className={inspectorFieldLabelClass}>Executable Path</label>
-          {rawExe ? (
-            <ClickCopyPathBlock
-              value={rawExe}
-              notice={identityPathCopyNotice}
-              onCopy={() => void copyIdentityExecutablePath()}
-            />
-          ) : isProfileSlot ? (
-            <input
-              type="text"
-              value={typeof currentData.executablePath === "string" ? currentData.executablePath : ""}
-              onChange={(e) => handleFieldUpdate("executablePath", e.target.value)}
-              className={inspectorPanelNativeMonoInputClass}
-              placeholder="C:\\Program Files\\App\\app.exe"
-            />
-          ) : (
-            <p className="rounded-lg border border-flow-border/40 bg-flow-bg-tertiary/20 px-3 py-2 text-xs text-flow-text-muted">
-              No executable path set for this app.
-            </p>
-          )}
-          {source === "sidebar" ? (
-            <div
-              className="mt-2 rounded-md border border-flow-border/40 bg-flow-bg-primary/15 px-2 py-2"
-              aria-label="Launch path and Explorer"
-            >
-              <div className="flex flex-wrap items-center gap-2">
+      {type === "app" && typeof onSetInstalledAppLibraryCategory === "function" ? (
+        <div className="min-w-0 space-y-2">
+          <span className={inspectorSectionLabelTextClass}>Library</span>
+          <div ref={appLibraryTypeMenuRef} className="relative min-w-0 space-y-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className={`${inspectorFieldLabelClass} mb-0 flex-1`}>App type</span>
+              <FlowTooltip label="Used for the type chip in the Apps library. Your choice is saved on this device.">
                 <button
                   type="button"
-                  disabled={
-                    catalogExeOverrideBusy
-                    || typeof window === "undefined"
-                    || typeof window.electron?.pickCatalogLaunchExeOverride !== "function"
-                  }
-                  onClick={() => void handlePickCatalogLaunchExeOverride()}
-                  className={inspectorPanelCompactButtonClass}
+                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-flow-text-muted transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-secondary"
+                  aria-label="About app type"
                 >
-                  <Edit className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
-                  Edit launch file
+                  <HelpCircle className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden />
                 </button>
-                {catalogExeOverrideActive ? (
-                  <button
-                    type="button"
-                    disabled={
-                      catalogExeOverrideBusy
-                      || typeof window === "undefined"
-                      || typeof window.electron?.clearCatalogLaunchExeOverride !== "function"
-                    }
-                    onClick={() => void handleClearCatalogLaunchExeOverride()}
-                    className={inspectorPanelCompactButtonClass}
-                  >
-                    Clear override
-                  </button>
-                ) : null}
-                <FlowTooltip
-                  label={
-                    canRevealInExplorer
-                      ? "Show executable or saved shortcut in File Explorer"
-                      : "Set an executable path above to open its location on disk."
-                  }
-                >
-                  <span className="inline-flex">
-                    <button
-                      type="button"
-                      onClick={() => void handleRevealInExplorer()}
-                      disabled={!canRevealInExplorer}
-                      aria-disabled={!canRevealInExplorer}
-                      className={
-                        canRevealInExplorer
-                          ? inspectorPanelCompactButtonClass
-                          : inspectorPanelCompactButtonDisabledClass
-                      }
-                    >
-                      <FolderOpen className="h-3 w-3 shrink-0" aria-hidden />
-                      Open in Explorer
-                    </button>
-                  </span>
-                </FlowTooltip>
-              </div>
-              <p className={`${inspectorHelperTextClass} mt-1.5`}>
-                Opens a file dialog; the file you pick becomes what FlowSwitch launches for this catalog entry (confirm to apply).
-              </p>
-            </div>
-          ) : (
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <FlowTooltip
-                label={
-                  canRevealInExplorer
-                    ? "Show executable or saved shortcut in File Explorer"
-                    : "Set an executable path above to open its location on disk."
-                }
-              >
-                <span className="inline-flex">
-                  <button
-                    type="button"
-                    onClick={() => void handleRevealInExplorer()}
-                    disabled={!canRevealInExplorer}
-                    aria-disabled={!canRevealInExplorer}
-                    className={
-                      canRevealInExplorer
-                        ? inspectorPanelCompactButtonClass
-                        : inspectorPanelCompactButtonDisabledClass
-                    }
-                  >
-                    <FolderOpen className="h-3 w-3 shrink-0" aria-hidden />
-                    Open in Explorer
-                  </button>
-                </span>
               </FlowTooltip>
             </div>
-          )}
+            <button
+              type="button"
+              id={installedAppTypeFieldId}
+              className={inspectorMenuTriggerClass}
+              aria-haspopup="menu"
+              aria-expanded={appLibraryTypeMenuOpen}
+              aria-label={`App type, currently ${currentLibraryCategory}`}
+              onClick={() => {
+                setAppLibraryTypeMenuOpen((o) => !o);
+                setMovePlacementMenuOpen(false);
+                setAddToLayoutMenuOpen(false);
+              }}
+            >
+              <span className="min-w-0 flex-1 truncate text-left">{currentLibraryCategory}</span>
+              <ChevronDown className="h-4 w-4 shrink-0 opacity-70" aria-hidden />
+            </button>
+            {appLibraryTypeMenuOpen ? (
+              <div className={inspectorMenuPanelClass} role="menu">
+                {APP_LIBRARY_CATEGORIES.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    role="menuitem"
+                    className={`${inspectorMenuItemClass}${
+                      c === currentLibraryCategory ? " bg-flow-bg-primary/20 text-flow-text-primary" : ""
+                    }`}
+                    onClick={() => {
+                      onSetInstalledAppLibraryCategory(
+                        {
+                          name: String(currentData.name ?? ""),
+                          executablePath: currentData.executablePath ?? null,
+                          shortcutPath: currentData.shortcutPath ?? null,
+                          launchUrl: currentData.launchUrl ?? null,
+                        },
+                        c,
+                      );
+                      setAppLibraryTypeMenuOpen(false);
+                    }}
+                  >
+                    {c}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="min-w-0 space-y-2">
+        <span className={inspectorSectionLabelTextClass}>Paths</span>
+        <div className="min-w-0 space-y-3">
+          <div className="min-w-0 space-y-2">
+            <span className={`${inspectorFieldLabelClass} !mb-0 block min-w-0`}>Executable path</span>
+            <div className="min-w-0">
+              {rawExe ? (
+                <InspectorPathDisplay
+                  path={rawExe}
+                  copyNotice={identityPathCopyNotice}
+                  onCopy={() => void copyIdentityExecutablePath()}
+                  canRevealInExplorer={canRevealInExplorer}
+                  onRevealInExplorer={() => void handleRevealInExplorer()}
+                />
+              ) : isProfileSlot ? (
+                <input
+                  type="text"
+                  value={typeof currentData.executablePath === "string" ? currentData.executablePath : ""}
+                  onChange={(e) => handleFieldUpdate("executablePath", e.target.value)}
+                  className={inspectorPanelNativeMonoInputClass}
+                  placeholder="C:\\Program Files\\App\\app.exe"
+                />
+              ) : (
+                <p className="rounded-lg border border-flow-border/40 bg-flow-bg-tertiary/20 px-3 py-2 text-xs text-flow-text-muted">
+                  No executable path set for this app.
+                </p>
+              )}
+            </div>
+
+            {!rawExe && canRevealInExplorer ? (
+              <div className="flex min-w-0 flex-wrap items-center gap-2 rounded-lg border border-flow-border/40 bg-flow-bg-tertiary/20 px-3 py-2">
+                <button
+                  type="button"
+                  onClick={() => void handleRevealInExplorer()}
+                  className={inspectorTextLinkClass}
+                  title="Show shortcut or path in File Explorer"
+                >
+                  <FolderOpen className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} aria-hidden />
+                  Open in Explorer
+                </button>
+              </div>
+            ) : null}
+          </div>
+
+          {showInspectorTestLaunch || type === "app" ? (
+            <div className="flex min-w-0 flex-wrap items-center gap-2 rounded-lg border border-flow-border/45 bg-flow-bg-primary/[0.07] px-2.5 py-2">
+              {showInspectorTestLaunch ? (
+                <button
+                  type="button"
+                  onClick={() => void handleCatalogTestLaunchFromInspector()}
+                  disabled={catalogTestLaunchDisabled}
+                  aria-disabled={catalogTestLaunchDisabled}
+                  title="Run once with current paths (Windows)"
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-flow-border/50 bg-flow-surface px-2.5 py-1.5 text-[11px] font-medium text-flow-text-secondary transition-colors hover:border-flow-border-accent hover:bg-flow-surface-elevated hover:text-flow-text-primary disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none"
+                >
+                  <Zap className="h-3.5 w-3.5 shrink-0 text-flow-accent-blue" strokeWidth={2} aria-hidden />
+                  Test launch
+                </button>
+              ) : null}
+              {type === "app" ? (
+                <>
+                  <FlowTooltip label="Opens the Windows file picker to choose a different .exe. Confirm to save it for this catalog entry.">
+                    <button
+                      type="button"
+                      disabled={
+                        catalogExeOverrideBusy
+                        || typeof window === "undefined"
+                        || typeof window.electron?.pickCatalogLaunchExeOverride !== "function"
+                      }
+                      onClick={() => void handlePickCatalogLaunchExeOverride()}
+                      className={`${inspectorPanelCompactButtonClass} gap-2`}
+                      aria-busy={catalogExeOverrideBusy}
+                      title="Pick a different executable (Windows file picker)"
+                    >
+                      <FolderOpen className="h-3.5 w-3.5 shrink-0 text-flow-accent-blue" strokeWidth={1.75} aria-hidden />
+                      Edit launch file
+                    </button>
+                  </FlowTooltip>
+                  {catalogExeOverrideActive ? (
+                    <button
+                      type="button"
+                      disabled={
+                        catalogExeOverrideBusy
+                        || typeof window === "undefined"
+                        || typeof window.electron?.clearCatalogLaunchExeOverride !== "function"
+                      }
+                      onClick={() => void handleClearCatalogLaunchExeOverride()}
+                      className={`${inspectorTextLinkClass}${
+                        catalogExeOverrideBusy ? " pointer-events-none opacity-50" : ""
+                      }`}
+                    >
+                      Clear override
+                    </button>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          ) : null}
+
           {revealPathError ? (
             <p className="mt-1.5 text-[11px] leading-snug text-flow-accent-red" role="status">
               {revealPathError}
@@ -876,7 +955,7 @@ export function SelectedAppDetails({
     <div className="min-w-0 space-y-6">
       {/* Monitor Assignment */}
       <div>
-        <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>Monitor Assignment</label>
+        <span className={inspectorSectionLabelClass}>Monitor assignment</span>
         <div>
           <label className={inspectorFieldLabelClass}>Target Monitor</label>
             <select 
@@ -895,7 +974,7 @@ export function SelectedAppDetails({
 
       {/* Window Settings */}
       <div>
-        <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>Window Settings</label>
+        <span className={inspectorSectionLabelClass}>Window settings</span>
         
         <div className="space-y-4">
           <div>
@@ -929,7 +1008,7 @@ export function SelectedAppDetails({
 
       {/* Launch Options */}
       <div>
-        <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>Launch Options</label>
+        <span className={inspectorSectionLabelClass}>Launch options</span>
         <div className="space-y-2">
           <div className={inspectorPanelSwitchRowClass}>
             <div className="min-w-0 flex-1">
@@ -989,9 +1068,7 @@ export function SelectedAppDetails({
 
       {/* Custom Launch Arguments */}
       <div>
-        <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>
-          Custom Launch Arguments
-        </label>
+        <span className={inspectorSectionLabelClass}>Custom launch arguments</span>
         <input
           type="text"
           value={currentData.customArgs || ""}
@@ -1368,9 +1445,7 @@ export function SelectedAppDetails({
       <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-6">
         {/* Quick Add Section */}
         <div className="min-w-0 shrink-0">
-          <label className={`${inspectorSectionPrimaryTitleClass} mb-3`}>
-            Quick Add Content
-          </label>
+          <span className={inspectorSectionLabelClass}>Quick add content</span>
           <div className="min-w-0 space-y-2 rounded-lg border border-flow-border bg-flow-surface p-3 sm:p-4">
             <div className="min-w-0">
               <label className={inspectorFieldLabelClass}>
@@ -1402,9 +1477,9 @@ export function SelectedAppDetails({
         {isBrowser && (
           <div className="max-h-48 shrink-0 overflow-hidden">
             <div className="mb-3 flex min-w-0 items-center justify-between gap-2">
-              <label className={`${inspectorSectionPrimaryTitleClass} mb-0`}>
-                Browser Tabs
-              </label>
+              <span className={`${inspectorSectionLabelTextClass} min-w-0`}>
+                Browser tabs
+              </span>
               <span className="shrink-0 text-xs text-flow-text-muted">
                 {appBrowserTabs.length} tab{appBrowserTabs.length !== 1 ? "s" : ""}
               </span>
@@ -1479,9 +1554,9 @@ export function SelectedAppDetails({
         {/* Associated Content (fills remaining tab height) */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
           <div className="grid min-w-0 shrink-0 grid-cols-1 gap-x-2 gap-y-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-            <label className={`${inspectorSectionPrimaryTitleClass} mb-0 min-w-0`}>
-              Associated Content
-            </label>
+            <span className={`${inspectorSectionLabelTextClass} min-w-0`}>
+              Associated content
+            </span>
             {onUpdateAssociatedFiles && hasDesktopPicker ? (
               <div
                 className="relative z-[60] flex w-full min-w-0 shrink-0 justify-end overflow-visible sm:w-auto sm:justify-self-end"
@@ -1599,17 +1674,17 @@ export function SelectedAppDetails({
     activeTab === "overview" ? 0 : activeTab === "launch" ? 1 : 2;
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col bg-flow-bg-secondary/95">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-transparent">
       {/* App Header - Always visible */}
-      <div className="border-b border-flow-border/50 bg-flow-surface/30 px-3 py-3 backdrop-blur-sm sm:px-4">
+      <div className="border-b border-white/[0.06] bg-flow-bg-primary/[0.04] px-3 py-3 backdrop-blur-sm sm:px-4">
         <div className="flex min-w-0 items-start gap-3 sm:gap-4">
-          {renderAppIcon(currentData)}
-          <div className="flex-1 min-w-0">
-            <h2 className="text-base font-semibold tracking-tight text-flow-text-primary break-words">
+          {renderAppIcon(currentData, "header")}
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-[15px] font-semibold leading-snug tracking-tight text-flow-text-primary">
               {currentData.name}
             </h2>
             <p
-              className={`mt-1 text-xs font-medium ${
+              className={`mt-0.5 text-[12px] font-normal leading-snug ${
                 source === "sidebar"
                   ? "text-flow-text-muted"
                   : "text-flow-text-secondary"
@@ -1621,34 +1696,42 @@ export function SelectedAppDetails({
         </div>
       </div>
 
-      {/* Tab Navigation */}
-      <div className="border-b border-flow-border/50 bg-flow-bg-secondary/80">
-        <div className="relative flex min-w-0">
-          <div
-            className="pointer-events-none absolute bottom-0 left-0 z-10 h-0.5 w-1/3 bg-flow-accent-blue flow-tab-slide-track"
-            style={{
-              transform: `translate3d(calc(${appInspectorTabSlideIndex} * 100%), 0, 0)`,
-            }}
-            aria-hidden
-          />
-          {tabs.map((tab) => {
-            const IconComponent = tab.icon;
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`relative z-0 flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 border-b-2 border-transparent px-1 py-2 text-[10px] font-medium leading-tight transition-colors duration-150 ease-out ${
-                  activeTab === tab.id
-                    ? "bg-flow-bg-primary/40 text-flow-accent-blue"
-                    : "text-flow-text-muted hover:bg-flow-surface/50 hover:text-flow-text-primary"
-                }`}
-              >
-                <IconComponent className="h-3 w-3 shrink-0" />
-                <span className="max-w-full truncate text-center">{tab.label}</span>
-              </button>
-            );
-          })}
+      {/* Tab navigation — same rail + slide indicator as library sidebar (Profiles / Apps / Content) */}
+      <div className="shrink-0 border-b border-white/[0.06] px-2 py-2 sm:px-3 sm:py-2.5 md:px-4">
+        <div
+          className="flow-library-tablist flow-library-tablist--inspector-narrow"
+          role="tablist"
+          aria-label="App inspector"
+        >
+          <div className="flow-library-tablist-rail gap-1">
+            <div
+              className="pointer-events-none absolute bottom-0 left-0 z-10 h-0.5 w-1/3 rounded-full bg-flow-accent-blue flow-tab-slide-track"
+              style={{
+                transform: `translate3d(calc(${appInspectorTabSlideIndex} * 100%), 0, 0)`,
+              }}
+              aria-hidden
+            />
+            {tabs.map((tab) => {
+              const IconComponent = tab.icon;
+              return (
+                <FlowTooltip key={tab.id} label={tab.label} side="bottom">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    aria-label={tab.label}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`flow-library-tab flow-library-tab--icon-only min-w-0 ${
+                      activeTab === tab.id ? "flow-library-tab-active" : "flow-library-tab-idle"
+                    }`}
+                  >
+                    <IconComponent className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">{tab.label}</span>
+                  </button>
+                </FlowTooltip>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/src/renderer/layout/components/SelectedContentDetails.tsx
+++ b/src/renderer/layout/components/SelectedContentDetails.tsx
@@ -599,8 +599,8 @@ export function SelectedContentDetails({
   );
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col">
-      <div className="border-b border-flow-border/50 px-3 pt-3 pb-3 sm:px-4">
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-transparent">
+      <div className="border-b border-white/[0.06] bg-flow-bg-primary/[0.04] px-3 pb-3 pt-3 backdrop-blur-sm sm:px-4">
         <div className="flex min-w-0 items-start gap-3">
           <div className="mt-0.5 shrink-0 text-flow-text-muted">
             {isFolder ? (
@@ -619,33 +619,41 @@ export function SelectedContentDetails({
         </div>
       </div>
 
-      <div className="border-b border-flow-border/50 bg-flow-bg-secondary/80">
-        <div className="relative flex min-w-0">
-          <div
-            className="pointer-events-none absolute bottom-0 left-0 z-10 h-0.5 w-1/3 bg-flow-accent-blue flow-tab-slide-track"
-            style={{
-              transform: `translate3d(calc(${contentInspectorTabSlideIndex} * 100%), 0, 0)`,
-            }}
-            aria-hidden
-          />
-          {tabs.map((tab) => {
-            const IconComponent = tab.icon;
-            return (
-              <button
-                type="button"
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`relative z-0 flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 border-b-2 border-transparent px-1 py-2 text-[10px] font-medium leading-tight transition-colors duration-150 ease-out ${
-                  activeTab === tab.id
-                    ? "bg-flow-bg-primary/40 text-flow-accent-blue"
-                    : "text-flow-text-muted hover:bg-flow-surface/50 hover:text-flow-text-primary"
-                }`}
-              >
-                <IconComponent className="h-3 w-3 shrink-0" aria-hidden />
-                <span className="max-w-full truncate text-center">{tab.label}</span>
-              </button>
-            );
-          })}
+      <div className="shrink-0 border-b border-white/[0.06] px-2 py-2 sm:px-3 sm:py-2.5 md:px-4">
+        <div
+          className="flow-library-tablist flow-library-tablist--inspector-narrow"
+          role="tablist"
+          aria-label="Content library entry"
+        >
+          <div className="flow-library-tablist-rail gap-1">
+            <div
+              className="pointer-events-none absolute bottom-0 left-0 z-10 h-0.5 w-1/3 rounded-full bg-flow-accent-blue flow-tab-slide-track"
+              style={{
+                transform: `translate3d(calc(${contentInspectorTabSlideIndex} * 100%), 0, 0)`,
+              }}
+              aria-hidden
+            />
+            {tabs.map((tab) => {
+              const IconComponent = tab.icon;
+              return (
+                <FlowTooltip key={tab.id} label={tab.label} side="bottom">
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    aria-label={tab.label}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`flow-library-tab flow-library-tab--icon-only min-w-0 ${
+                      activeTab === tab.id ? "flow-library-tab-active" : "flow-library-tab-idle"
+                    }`}
+                  >
+                    <IconComponent className="h-4 w-4 shrink-0" strokeWidth={1.75} aria-hidden />
+                    <span className="sr-only">{tab.label}</span>
+                  </button>
+                </FlowTooltip>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/src/renderer/layout/components/inspectorStyles.ts
+++ b/src/renderer/layout/components/inspectorStyles.ts
@@ -7,6 +7,35 @@
 export const inspectorSectionPrimaryTitleClass =
   "block text-sm font-medium text-flow-text-secondary";
 
+/**
+ * Inspector sidebar section label (11px uppercase, muted) — use instead of h2/h3
+ * inside narrow inspectors. See SKILL-inspector-sidebar.
+ */
+export const inspectorSectionLabelTextClass =
+  "block text-[11px] font-medium uppercase tracking-[0.06em] text-flow-text-primary/45";
+
+/** Bottom margin for labels not wrapped in a `space-y-*` stack (e.g. Launch tab). */
+export const inspectorSectionLabelClass = `${inspectorSectionLabelTextClass} mb-2`;
+
+/** Top rule + spacing before destructive-only block. */
+export const inspectorDangerZoneClass =
+  "mt-4 border-t border-flow-border/50 pt-4";
+
+/** Text link for tertiary actions (e.g. Open in Explorer) in inspectors. */
+export const inspectorTextLinkClass =
+  "inline-flex min-h-[28px] items-center gap-1.5 text-[12px] font-medium text-flow-accent-blue transition-colors hover:text-flow-accent-blue-hover hover:underline motion-reduce:transition-none";
+
+/** Anchored dropdown panel under inspector triggers. */
+export const inspectorMenuPanelClass =
+  "absolute left-0 right-0 z-50 mt-1 max-h-[min(320px,50vh)] overflow-y-auto rounded-lg border border-flow-border/60 bg-flow-surface py-1 shadow-lg motion-reduce:transition-none";
+
+export const inspectorMenuItemClass =
+  "flex w-full items-center px-3 py-2 text-left text-[13px] font-medium text-flow-text-secondary transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-primary motion-reduce:transition-none";
+
+/** Trigger row for “Move to…” / “Add to layout…” menus (matches list row weight). */
+export const inspectorMenuTriggerClass =
+  "flex min-h-[36px] min-w-0 w-full items-center justify-between gap-2 rounded-lg border border-flow-border/50 bg-flow-surface px-3 py-2 text-left text-[13px] font-medium text-flow-text-secondary transition-[color,background-color,border-color] duration-200 ease-out hover:border-flow-border-accent hover:bg-flow-surface-elevated hover:text-flow-text-primary active:brightness-95 motion-reduce:transition-none motion-reduce:active:brightness-100";
+
 /** Same weight as primary title, without `block` (toolbar / flex row labels). */
 export const inspectorSectionPrimaryEmphasisClass =
   "text-sm font-medium text-flow-text-secondary";


### PR DESCRIPTION
## Summary
- Inspector path card (InspectorPathDisplay), tighter section spacing, library-aligned icon tab rails (app/content inspectors + library nav).
- Fixed inspector header: **Inspect** / **Progress** segmented control (icons, tooltips; Launch renamed to Progress vs per-app Launch settings).
- Overview tab uses **AppWindow** so it is distinct from library **Apps** (LayoutGrid).

## Testing
- [ ] \
pm run lint\ / \
pm run typecheck\ (run locally on branch)
- [ ] Manual: inspector Overview / Launch / Content tabs; Inspect vs Progress; launch run auto-switches to Progress


Made with [Cursor](https://cursor.com)