### PR TITLE
feat: large-profile launch guardrails, placement salvage, launch UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+Copyright (c) 2026 Jacob Panackal. All rights reserved.
+Unauthorized copying, modification, or distribution of this software is strictly prohibited.

--- a/docs/superpowers/feature-braindump.md
+++ b/docs/superpowers/feature-braindump.md
@@ -168,6 +168,7 @@ Canonical cross-doc snapshot lives in `docs/superpowers/unified-backlog.md`.
   - define soft threshold warning and hard threshold constraints
   - explain expected launch duration/risk before run
   - optional launch sequencing support for dependency-sensitive apps
+- **Status (2026-05-05):** Phases 1–2 implemented (`launch-weight-limits`, `computeLaunchWeight`, main `LAUNCH_TOO_LARGE`, renderer weight IPC + large-launch confirm). **Phase 3 slice:** skipped (non-launchable) app tiles from gather are included in weight IPC and the soft modal; same summary on hard-reject `details`. Full Phase 3 validation vertical + Phase 4 monitor re-weight + Phase 5 stall timeout remain per spec.
 - Merged inbox items: constraints for too many apps, profile launch order, Batch C “competing apps” guidance (soft warnings / copy where overlaps exist with singleton or resource-heavy launch patterns).
 - Done when: users are warned/protected before risky launches and can intentionally choose launch order.
 

--- a/docs/superpowers/specs/large-profile-launch-guardrails.md
+++ b/docs/superpowers/specs/large-profile-launch-guardrails.md
@@ -1,0 +1,135 @@
+# Large profile launch guardrails and pre-launch validation
+
+Date: 2026-05-05  
+Owner: FlowSwitch  
+Branch: `feature/large-profile-launch-guardrails` (implementation)  
+Status: Approved plan — **not committed** until merged with implementation PRs as needed
+
+## Purpose
+
+This spec consolidates:
+
+- P0 backlog item **“Safe launch guardrails for large profiles”** (`docs/superpowers/unified-backlog.md`)
+- Pre-launch validation, monitor geometry checks, and related guardrails validated in product discussion
+- Locked sequencing and API decisions so implementation does not drift
+
+Canonical backlog remains `docs/superpowers/unified-backlog.md`; update that file when this work ships.
+
+## Goals
+
+1. **Launch weight** — Single canonical definition of “how big is this run?” (deduped app launches, browser tabs, content units, etc.) with **constants in one module** both processes consume (see **Renderer access to weight constants** below). No hand-duplicated numeric literals in the renderer.
+2. **Hard ceiling** — Main process rejects launches that exceed a **hard max** before heavy orchestration work. Response must be **structured** so the renderer shows specific copy (not a generic failure).
+3. **Soft threshold** — Renderer confirms when weight is high but under the hard cap: counts, heuristic duration / risk copy, and optional summary of pre-launch policies (what will move, minimize, or close).
+4. **Pre-launch validation (single pass)** — Path existence (aggregate report), URL/tab alignment with existing allow-lists, schema normalization, **import** strict validation, and icon path rules share **one validation layer** to avoid multiple edits to the same sanitization surface.
+5. **Monitor geometry** — Missing display detection and resolution/DPI mismatch warnings; **best-effort launch** recomputes launch weight using **the same function** with `connectedMonitors` / excluded monitor ids (not a second ad-hoc counter).
+6. **Per-app stall / timeout** — Align with workflow orchestration run-budget direction; mark items timed out and continue without wedging confirmation or placement-verify flows.
+
+## Non-goals (explicit deferrals)
+
+- **Per-launch modal** for “reuse existing window vs spawn new” beyond existing `preLaunchInProfileBehavior` / profile settings (high edge-case cost; revisit later).
+- **Pre-spawn elevation detection** as a guarantee (Windows signals are messy); prefer clear **post-failure** copy when spawn fails with elevation-related errors.
+- **Per-window “unsaved work”** detection (not reliable cross-process); only **coarse** warnings (counts / names of apps affected by pre-launch minimize/close/reuse).
+- **Profile overwrite confirmation** when capturing from running — valid work, **orthogonal**; track as a separate small feature.
+- Dedicated `**preview-launch-scope` IPC** in v1 (optional later for pre-click parity without starting a run).
+
+## Locked decisions
+
+### Structured errors without preview IPC (v1)
+
+- **Phase 1 does not** add `preview-launch-scope`.
+- When main rejects early (e.g. over hard cap), `**launch-profile` IPC** returns a structured payload, for example:
+  - `ok: false`
+  - `code`: stable machine string (e.g. `LAUNCH_TOO_LARGE`)
+  - `message`: user-facing summary
+  - `details` (optional): `{ breakdown, limits }` for rich renderer copy
+- Soft threshold UI may use a **renderer-side estimate** using the **same formula and constants** as main; acceptable minor drift until preview IPC exists (formula drift only—**not** threshold literal drift).
+
+### Renderer access to weight constants (no duplication)
+
+- **Rule:** Thresholds and weight multipliers used for soft/hard guardrails must exist in **exactly one place** in source (single module or single exported object).
+- **Rule:** The renderer must **import** that module (or a barrel that re-exports it) into the Vite bundle—**never** copy-paste the same numbers into renderer-only files.
+- **Implementation note:** Today `src/main/utils/limits.js` is CommonJS and may not be directly importable from the renderer build. Prefer adding `**src/shared/launch-weight-limits.ts`** (or `.js` if both sides stay JS) that **main** `require()`s or imports and the **renderer** imports; alternatively extend `limits.js` and add a thin TypeScript **re-export** under `src/` that Vite resolves—whichever matches repo conventions after a quick build check. Document the chosen path in this spec’s revision history when implementation lands.
+
+### One validation vertical slice
+
+- Path + URL + schema + import + icon rules ship as **one** change set on a **single shared validation entry point** (e.g. `validateProfileForLaunch(profile, context)` — name illustrative).
+- Avoid splitting into “path phase” then “import phase” if that means two passes over `profile-launch-fields.js` and related rules.
+
+### Launch weight API shape
+
+- `computeLaunchWeight(profile, options)` (or equivalent) accepts `**options`** from day one, including at minimum:
+  - `connectedMonitors` (or equivalent snapshot) for geometry-aware counting
+  - optional `**excludedMonitorIds**` or `**launchMode: 'full' | 'best_effort'**` so monitor dialog paths can recompute weight after the user chooses best-effort placement.
+
+### Phased delivery order
+
+
+| Phase     | Deliverable                                                                                                                                                                                                |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1**     | `computeLaunchWeight(profile, options)` + constants; main **hard cap**; structured `ok: false` + `code` + `details` on existing launch IPC; renderer maps codes to strings. **No preview IPC.**            |
+| **2**     | Soft warning modal + heuristic duration + pre-launch policy summary (coarse); renderer uses same constants as main.                                                                                        |
+| **3**     | **Single validation slice:** aggregate missing-path report (continue policy per **Phase 3: missing-path continue policy**), URL/tab rules, normalize/schema, import gate, icon path sandboxing.            |
+| **4**     | Monitor presence + DPI/resolution mismatch UX; best-effort path calls `computeLaunchWeight` with reduced / remapped geometry before confirm.                                                               |
+| **5**     | Per-app stall timeout / hang (orchestration-aligned; respect confirmation and placement-verify).                                                                                                           |
+| **Later** | Preview IPC; duplicate-instance override modal; safeStorage fallback notice; overwrite confirmation; hotkey conflict save-blocking polish (conflicts already partially surfaced in `ProfileSettings.tsx`). |
+
+
+## UX principles (validated)
+
+- **Aggregate report before blocking** for missing paths — show the **full list** of missing or invalid targets; **continue vs block** follows the explicit **Phase 3: missing-path continue policy** (below)—do not rely on an implicit “≥1 launchable” rule without recording the chosen product rule here.
+- **Never** ship a warning-only modal before **main-enforced** logic exists for the hard cap (foundation first).
+
+### Phase 3: Missing-path continue policy (product decision — set before ship)
+
+The spec originally allowed **continue if at least one launchable target** and **block if zero**. That is unambiguous but can yield a **mostly broken workspace** (e.g. eight apps configured, seven paths missing, one valid—launch proceeds).
+
+**Pick one policy (or a hybrid) before Phase 3 merges** and replace this subsection with the chosen rule + constants:
+
+
+| Option                   | Behavior                                                                                                                                       |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A — Minimum count**    | Continue only if **≥ N** launchable app targets (and analogous rule for tabs/content if applicable).                                           |
+| **B — Minimum fraction** | Continue only if **≥ P%** of configured launch targets have valid paths (e.g. 50%).                                                            |
+| **C — Missing cap**      | Block (or extra-strong confirm) if **more than M** targets are missing, even if ≥1 remains.                                                    |
+| **D — strict minimum**   | Keep **≥1** launchable but pair with a **second modal** when missing count exceeds a threshold (“Most targets are missing; continue anyway?”). |
+
+
+Default recommendation if no product owner weighs in: **D** or **B** at a sensible fraction—document final choice and any copy strings in this section.
+
+## Related code (implementation hints)
+
+- Launch entry: `src/main/services/profile-launch-runner.js` (`launchProfileById`), gather/dedupe near `appLaunches`.
+- IPC: `src/main/ipc/trusted-renderer-ipc.js` (`launch-profile`).
+- Renderer launch: `src/renderer/layout/hooks/useProfileLaunch.ts`.
+- URL / shortcut sanitization: `src/main/utils/profile-launch-fields.js`, `src/main/utils/limits.js`.
+- Profile shape: `src/types/flow-profile.ts`.
+- Hotkey conflict validation (existing): `src/renderer/layout/components/ProfileSettings.tsx` (`validateSettings`).
+
+## Testing and QA
+
+- Boundaries: just under soft threshold; between soft and hard; over hard max.
+- Entry points: **shell Launch**, **hotkey**, and **schedule-triggered launch** — all must hit the **same** main validation and hard-cap paths (schedules are a shipped capability; do not treat schedule as optional).
+- Missing paths: mixed valid/invalid; all invalid; edge case aligned with **Phase 3: missing-path continue policy** (e.g. “only one of many valid”).
+- Import: malformed JSON, traversal attempts, oversized payload, bad URLs.
+- Monitor: undocked layout; best-effort re-weight matches expectations.
+- Timeout phase: does not break confirmation or placement-verify semantics.
+- **Soft-threshold modal (manual):** user **Cancel** — no IPC launch, UI returns to idle; user **Continue** — launch proceeds; optional **re-open modal** if profile state regressed (see below).
+- **Soft-threshold modal while system state changes (manual):** e.g. user opens modal, then disconnects a monitor or an app path becomes invalid before **Continue**—document expected behavior (re-validate on Continue; block with updated message; or dismiss modal—pick one and test it).
+
+## Backlog and doc sync
+
+When implementation status changes:
+
+1. Update `docs/superpowers/unified-backlog.md` (P0 “Safe launch guardrails” and any touched validation bullets).
+2. Update `docs/superpowers/feature-braindump.md` **Now (P0)** section if scope or status changes.
+
+## Revision history
+
+
+| Date       | Change                                                                                                                                                                                                                            |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-05 | Phase 3 slice: `computeLaunchWeight` / `profile-launch-weight` expose `skippedLaunchTargets` (gather `skippedApps`); large-profile soft modal surfaces non-launchable tiles; `LAUNCH_TOO_LARGE` details include the same summary. |
+| 2026-05-05 | Initial spec from consolidated plan + review tightenings (structured errors, merged validation phase, weight API with monitor options, phased order).                                                                             |
+| 2026-05-05 | Review pass: shared constants rule for renderer (no literal duplication); Phase 3 missing-path policy as explicit product decision table; schedule launches first-class in QA; soft-modal manual scenarios.                       |
+
+

--- a/docs/superpowers/unified-backlog.md
+++ b/docs/superpowers/unified-backlog.md
@@ -1,6 +1,6 @@
 # FlowSwitch Unified Backlog (Canonical)
 
-Last updated: 2026-05-05  
+Last updated: 2026-05-05 (launch guardrails Phase 3 slice)  
 Owner: active implementation branch owner
 
 **Release note (marketing):** `package.json` / `website/` prepared for **0.1.4**. Live GitHub downloads require pushing annotated tag **`v0.1.4`** after merge and waiting for the release workflow to attach `FlowSwitch-0.1.4-win-x64-*.exe` assets matching `website/latest.json`.
@@ -51,10 +51,10 @@ Status legend:
    - Harden icon/path handling for non-system drives.
    - **Latest (branch):** Apps sidebar add pill → pick `.exe` → persists `userCatalogExePaths` and merges into catalog (`installed-apps:add-user-exe`); Steam library `common` roots merged into optional deep exe scan; stricter catalog filters (VC++ redistributable titles, Java/AMD/Intel installer noise, Package Cache VC paths), inbox shortcut allow-list extended (Codex, Cursor, Windsurf), WindowsApps shim **display-name** fallbacks when WinRT/manifest names are missing, optional exe scan uses `%ProgramFiles%` / `%ProgramFiles(x86)%` and `FLOWSWITCH_EXE_SCAN_EXTRA_ROOTS`; shell icon script tweaks; matrix doc updated. **Content / layout:** “Add to monitor” from the content ⋯ menu resolves catalog icons at placement time (`getInstalledAppsCatalog` + ref) so tiles match drag-drop; content library gains `FlowSnackbar` provider usage and `AVAILABLE_APPS` moved to `availableAppsForOpensWith` for Fast Refresh hygiene.
 
-4. Safe launch guardrails for large profiles (`not_started`)
-   - Soft threshold warnings and hard constraints.
-   - Launch-time risk/duration messaging.
-   - Optional sequencing for dependency-sensitive launches.
+4. Safe launch guardrails for large profiles (`in_progress` — spec `docs/superpowers/specs/large-profile-launch-guardrails.md`)
+   - **Done (Phase 1–2):** Shared limits in `src/shared/launch-weight-limits.js`; `computeLaunchWeight` + deduped tabs/apps; main `LAUNCH_TOO_LARGE` structured error before run; renderer `getProfileLaunchWeight` + soft **Large profile launch** modal; hard cap surfaced in renderer if estimate passes IPC drift.
+   - **Done (Phase 3 slice, 2026-05-05):** Launch-weight payload includes **skipped non-launchable app tiles** (gather `skippedApps`) for the soft modal; hard-reject `details` includes the same summary.
+   - **Remaining:** Phase 3 full vertical (missing-path policy, URL/schema/import single pass per spec); monitor geometry re-weight UX (Phase 4); stall timeout (Phase 5); optional sequencing for dependency-sensitive launches.
 
 5. Shell accessibility — profile library keyboard parity (`done` — `feature/profile-library-keyboard-parity`)
    - **Evidence:** `docs/superpowers/specs/2026-05-03-ui-ux-evaluation-report.md` (C1); `ProfileCard` uses `div` + `onClick` without `tabIndex` — cards not in tab order; no Enter/Space semantics.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "flowswitch",
   "version": "0.1.4",
   "description": "Windows desktop app for profile-based workspace and window flows.",
+  "license": "UNLICENSED",
   "author": "FlowSwitch",
   "main": "src/main/main.js",
   "scripts": {
@@ -11,7 +12,7 @@
     "typecheck": "node scripts/typecheck-baseline.mjs check",
     "typecheck:full": "tsc --noEmit",
     "typecheck:baseline:update": "node scripts/typecheck-baseline.mjs update",
-    "test": "node --test src/main/utils/ src/main/services/ && tsx --test src/renderer/layout/utils/launchTimeline.test.ts src/renderer/layout/utils/launchTimelineDisplayOrder.test.ts src/renderer/layout/utils/dragFrameScheduler.test.ts src/renderer/layout/utils/layoutDragMoveEvents.test.ts src/renderer/layout/utils/layoutHitTesting.test.ts src/renderer/layout/utils/minimizedStripDragGesture.test.ts src/renderer/layout/utils/buildNewProfile.explorer-content.test.ts",
+    "test": "node --test src/main/utils/ src/main/services/ && tsx --test src/renderer/layout/utils/launchTimeline.test.ts src/renderer/layout/utils/launchTimelineDisplayOrder.test.ts src/renderer/layout/utils/dragFrameScheduler.test.ts src/renderer/layout/utils/layoutDragMoveEvents.test.ts src/renderer/layout/utils/layoutHitTesting.test.ts src/renderer/layout/utils/minimizedStripDragGesture.test.ts src/renderer/layout/utils/buildNewProfile.explorer-content.test.ts src/renderer/utils/installedWebBrowserInference.test.ts",
     "dev:frontend": "vite",
     "dev:electron": "electron .",
     "dev": "npm-run-all -p dev:frontend dev:electron",

--- a/src/main/ipc/trusted-renderer-ipc.js
+++ b/src/main/ipc/trusted-renderer-ipc.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
+const { computeLaunchWeight } = require('../utils/compute-launch-weight');
 const ws = require('windows-shortcuts');
 const {
   getAppxUserPackageLookup,
@@ -149,6 +150,10 @@ const registerTrustedRendererIpc = (handleTrustedIpc, deps) => {
     getRunningWindowProcesses,
     hiddenProcessNamePatterns,
     hiddenWindowTitlePatterns,
+    createProfileMonitorMap,
+    gatherProfileAppLaunches,
+    gatherLegacyActionLaunches,
+    normalizeSafeUrl,
   } = deps;
 
   let installedAppsCatalogCache = null;
@@ -458,6 +463,39 @@ const registerTrustedRendererIpc = (handleTrustedIpc, deps) => {
     return { ok: false, error: 'Failed to load profile' };
   }
 });
+
+  handleTrustedIpc('profile-launch-weight', async (_event, profileId, request = {}) => {
+    try {
+      const safeProfileId = safeLimitedString(profileId, MAX_PROFILE_ID_LENGTH);
+      if (!safeProfileId) return { ok: false, error: 'Invalid profile id' };
+      const { profiles, storeError } = unpackProfilesReadResult(readProfilesFromDisk());
+      if (storeError) {
+        return {
+          ok: false,
+          error: String(storeError?.message || 'Could not load saved profiles.'),
+          code: String(storeError?.code || 'READ_FAILED'),
+        };
+      }
+      const profile = profiles.find(
+        (candidate) => String(candidate?.id || '').trim() === safeProfileId,
+      );
+      if (!profile) {
+        return { ok: false, error: 'Profile not found.' };
+      }
+      const launchWeightOptions = request && typeof request === 'object' ? request : {};
+      const weight = computeLaunchWeight(profile, {
+        buildSystemMonitorSnapshot,
+        createProfileMonitorMap,
+        gatherProfileAppLaunches,
+        gatherLegacyActionLaunches,
+        normalizeSafeUrl,
+      }, launchWeightOptions);
+      return { ok: true, ...weight };
+    } catch (err) {
+      console.error('[profile-launch-weight]', err);
+      return { ok: false, error: 'Could not compute launch weight.' };
+    }
+  });
 
   handleTrustedIpc('cancel-profile-launch', async (_event, payload) => {
   const profileId = safeLimitedString(payload?.profileId, MAX_PROFILE_ID_LENGTH);

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -42,6 +42,7 @@ const { buildCompanionProcessHints } = require('./services/process-hints');
 const { captureAllMonitorsScreenshot } = require('./utils/windows-desktop-screenshot');
 const {
   isWithinAcceptableStateTolerance,
+  isWithinSalvagePlacementTolerance,
   planLaunchSlots,
   scoreReuseCandidate,
   shouldTriggerAmbiguityFallback,
@@ -844,9 +845,10 @@ const { launchProfileById: launchProfileByIdCore } = createProfileLaunchRunner({
   shouldTriggerAmbiguityFallback,
   isLikelyAuxiliaryWindowClass,
   isChromiumNonPrimaryWindowRow,
-  isChromiumTopLevelWindowRow,
-  isWithinAcceptableStateTolerance,
-  centerWindowHandleOnMonitor,
+    isChromiumTopLevelWindowRow,
+    isWithinAcceptableStateTolerance,
+    isWithinSalvagePlacementTolerance,
+    centerWindowHandleOnMonitor,
   maximizeWindowHandle,
   buildMonitorMappingDiagnostics,
   normalizeSafeUrl,
@@ -1281,6 +1283,10 @@ if (shouldBootstrapElectronMain) {
     getRunningWindowProcesses,
     hiddenProcessNamePatterns,
     hiddenWindowTitlePatterns,
+    createProfileMonitorMap,
+    gatherProfileAppLaunches,
+    gatherLegacyActionLaunches,
+    normalizeSafeUrl,
   });
 
   if (process.platform === 'win32') {

--- a/src/main/services/profile-launch-runner.js
+++ b/src/main/services/profile-launch-runner.js
@@ -6,6 +6,13 @@
  */
 const path = require('path');
 const { execFile } = require('child_process');
+const launchLimits = require('../../shared/launch-weight-limits');
+const {
+  dedupeAppLaunchesFromGather,
+  sliceProfileForExcludedMonitors,
+  buildSkippedLaunchTargetsSummary,
+} = require('../utils/compute-launch-weight');
+const { buildBrowserTabLaunchList } = require('../utils/browser-tab-launch-list');
 const { PROCESS_HINTS_VERSION } = require('./process-hints');
 const { hiddenProcessNamePatterns } = require('./windows-process-service');
 const { launchIconDataUrlFromProfileApp } = require('../utils/launch-ui-icons');
@@ -56,6 +63,7 @@ const createProfileLaunchRunner = (deps) => {
     isChromiumNonPrimaryWindowRow,
     isChromiumTopLevelWindowRow,
     isWithinAcceptableStateTolerance,
+    isWithinSalvagePlacementTolerance,
     centerWindowHandleOnMonitor,
     maximizeWindowHandle,
     buildMonitorMappingDiagnostics,
@@ -989,6 +997,80 @@ const launchProfileById = async (profileId, options = {}) => {
         .filter(Boolean),
     };
   }
+
+  const launchWeightOptions = options.launchWeight && typeof options.launchWeight === 'object'
+    ? options.launchWeight
+    : {};
+  const profileForLaunch = sliceProfileForExcludedMonitors(
+    profile,
+    launchWeightOptions.excludedProfileMonitorIds,
+  );
+  const systemMonitors = buildSystemMonitorSnapshot();
+  const monitorMap = createProfileMonitorMap(profileForLaunch?.monitors, systemMonitors);
+  const modernLaunchData = gatherProfileAppLaunches(profileForLaunch, monitorMap);
+  const legacyLaunchData = gatherLegacyActionLaunches(profileForLaunch, monitorMap);
+  const appLaunches = dedupeAppLaunchesFromGather(modernLaunchData, legacyLaunchData);
+  const tabEntriesForWeight = buildBrowserTabLaunchList(
+    profileForLaunch,
+    legacyLaunchData,
+    normalizeSafeUrl,
+  );
+  const totalLaunchUnits = (
+    appLaunches.length * launchLimits.LAUNCH_WEIGHT_PER_APP_LAUNCH
+    + tabEntriesForWeight.length * launchLimits.LAUNCH_WEIGHT_PER_BROWSER_TAB
+  );
+  if (totalLaunchUnits > launchLimits.LAUNCH_WEIGHT_HARD_MAX_UNITS) {
+    return {
+      ok: false,
+      code: 'LAUNCH_TOO_LARGE',
+      error: `This profile is too large to launch (${totalLaunchUnits} work units; maximum is ${launchLimits.LAUNCH_WEIGHT_HARD_MAX_UNITS}). Remove some apps or browser tabs, or split the profile.`,
+      requestedProfileId: normalizedProfileId,
+      profile,
+      details: {
+        totalUnits: totalLaunchUnits,
+        breakdown: {
+          dedupedAppLaunches: appLaunches.length,
+          dedupedBrowserTabs: tabEntriesForWeight.length,
+        },
+        limits: {
+          softWarn: launchLimits.LAUNCH_WEIGHT_SOFT_WARN_UNITS,
+          hardMax: launchLimits.LAUNCH_WEIGHT_HARD_MAX_UNITS,
+        },
+        skippedLaunchTargets: buildSkippedLaunchTargetsSummary(
+          modernLaunchData,
+          legacyLaunchData,
+          12,
+        ),
+      },
+    };
+  }
+
+  if (appLaunches.length === 0 && tabEntriesForWeight.length === 0) {
+    return {
+      ok: false,
+      code: 'LAUNCH_NOTHING_TO_RUN',
+      error: 'Nothing to launch: no app has a valid executable, shortcut, or URL, and there are no browser tabs to open. Add launch targets or fix paths in the inspector.',
+      requestedProfileId: normalizedProfileId,
+      profile,
+      details: {
+        totalUnits: totalLaunchUnits,
+        breakdown: {
+          dedupedAppLaunches: 0,
+          dedupedBrowserTabs: 0,
+        },
+        limits: {
+          softWarn: launchLimits.LAUNCH_WEIGHT_SOFT_WARN_UNITS,
+          hardMax: launchLimits.LAUNCH_WEIGHT_HARD_MAX_UNITS,
+        },
+        skippedLaunchTargets: buildSkippedLaunchTargetsSummary(
+          modernLaunchData,
+          legacyLaunchData,
+          12,
+        ),
+      },
+    };
+  }
+
   const runSession = launchStatusStore.startRun(normalizedProfileId);
   const activeRunId = String(runSession?.runId || '').trim();
   if (!activeRunId) {
@@ -1014,39 +1096,12 @@ const launchProfileById = async (profileId, options = {}) => {
     runId: activeRunId,
   });
 
-  const launchState = profile?.launchMaximized
+  const launchState = profileForLaunch?.launchMaximized
     ? 'maximized'
-    : profile?.launchMinimized
+    : profileForLaunch?.launchMinimized
       ? 'minimized'
       : 'normal';
 
-  const systemMonitors = buildSystemMonitorSnapshot();
-  const monitorMap = createProfileMonitorMap(profile?.monitors, systemMonitors);
-  const modernLaunchData = gatherProfileAppLaunches(profile, monitorMap);
-  const legacyLaunchData = gatherLegacyActionLaunches(profile, monitorMap);
-  const hasModernLaunches = modernLaunchData.launches.length > 0;
-  const launchKey = (launch) => {
-    const instanceId = String(launch.app?.instanceId || '').trim();
-    if (instanceId) {
-      return `${instanceId}::${launch.monitor?.id || 'monitor'}`;
-    }
-    // Without an explicit instanceId, treat same launch target on same monitor as one logical app launch.
-    // This prevents accidental duplicates from mixed/legacy profile data from opening multiple windows.
-    return `${launch.monitor?.id || 'monitor'}::${String(launch.executablePath || '').toLowerCase()}::${String(launch.shortcutPath || '').toLowerCase()}::${String(launch.launchUrl || '').toLowerCase()}`;
-  };
-  const seenLaunchKeys = new Set();
-  // Prefer modern monitor-layout launches. Legacy action-app launches are fallback only
-  // when a profile has no modern app definitions.
-  const preferredLaunches = hasModernLaunches
-    ? modernLaunchData.launches
-    : [...modernLaunchData.launches, ...legacyLaunchData.launches];
-  const appLaunches = preferredLaunches
-    .filter((launch) => {
-      const key = launchKey(launch);
-      if (seenLaunchKeys.has(key)) return false;
-      seenLaunchKeys.add(key);
-      return true;
-    });
   const skippedApps = [...modernLaunchData.skippedApps, ...legacyLaunchData.skippedApps];
   const failedApps = [];
   const pendingConfirmations = [];
@@ -1148,34 +1203,7 @@ const launchProfileById = async (profileId, options = {}) => {
     if (nl && !launchExeByAppName.has(nl)) launchExeByAppName.set(nl, ex);
   }
 
-  /** Ordered browser tabs (profile + legacy), deduped by URL + preferred host hints. */
-  const tabUrlList = [];
-  const tabUrlSeen = new Set();
-  const pushTabEntry = (raw, meta = {}) => {
-    const u = normalizeSafeUrl(raw);
-    if (!u) return;
-    const browser = String(meta.browser || '').trim();
-    const appInstanceId = String(meta.appInstanceId || '').trim();
-    const key = `${u}\0${browser.toLowerCase()}\0${appInstanceId}`;
-    if (tabUrlSeen.has(key)) return;
-    tabUrlSeen.add(key);
-    let label = u;
-    try {
-      label = new URL(u).hostname || u;
-    } catch {
-      label = u;
-    }
-    tabUrlList.push({ key, url: u, label, browser, appInstanceId });
-  };
-  for (const tab of (Array.isArray(profile?.browserTabs) ? profile.browserTabs : [])) {
-    pushTabEntry(tab?.url, {
-      browser: tab?.browser,
-      appInstanceId: tab?.appInstanceId,
-    });
-  }
-  for (const raw of legacyLaunchData.browserUrls || []) {
-    pushTabEntry(raw);
-  }
+  const tabUrlList = buildBrowserTabLaunchList(profileForLaunch, legacyLaunchData, normalizeSafeUrl);
   const requestedBrowserTabCount = tabUrlList.length;
   const tabEntriesByAppInstanceId = new Map();
   for (const entry of tabUrlList) {
@@ -2993,10 +3021,111 @@ try {
           applied: result.applied,
           handle: result.handle || null,
         });
-        if (!result.applied || !result.handle) {
+        // Move helpers sometimes report `applied: false` while the ready-gate handle is already
+        // on the correct monitor after layout settles (resize animation, DPI, or late reparent).
+        const readyHandleForLateVerify = String(readyGate?.handle || '').trim();
+        if (
+          (!result.applied || !String(result.handle || '').trim())
+          && readyGate?.ready
+          && readyHandleForLateVerify
+        ) {
+          await sleep(220);
+          const placementRectsLate = await getWindowPlacementRectsByHandle(readyHandleForLateVerify);
+          const measuredLate = placementRectsLate?.visibleRect || placementRectsLate?.outerRect || null;
+          const onTargetLate = isWindowOnTargetMonitor({
+            rect: measuredLate,
+            monitor: launchItem.monitor,
+            bounds: placementBounds,
+          });
+          const withinLate = isWithinAcceptableStateTolerance({
+            actual: measuredLate,
+            target: placementBounds,
+            onTargetMonitor: onTargetLate,
+          });
+          const salvageLate = isWithinSalvagePlacementTolerance({
+            actual: measuredLate,
+            target: placementBounds,
+            onTargetMonitor: onTargetLate,
+          });
+          if (onTargetLate && (withinLate || salvageLate)) {
+            launchDiagnostics.decision({
+              processHintLc,
+              strategy: 'placement-final',
+              reason: salvageLate && !withinLate
+                ? 'late-verify-accept-ready-handle-salvage-geometry'
+                : 'late-verify-accept-ready-handle-after-move-miss',
+              handle: readyHandleForLateVerify,
+            });
+            result = { applied: true, handle: readyHandleForLateVerify };
+          }
+        }
+        if (!result.applied || !String(result.handle || '').trim()) {
+          const salvageDiagnosticsContext = {
+            processHintLc,
+            strategy: 'placement-on-target-salvage',
+            placementState: placementBounds.state,
+          };
+          const salvageRows = await getVisibleWindowInfos(processHintLc, {
+            diagnostics: launchDiagnostics,
+            diagnosticsContext: salvageDiagnosticsContext,
+            includeNonVisible: true,
+          });
+          let salvageCandidates = (Array.isArray(salvageRows) ? salvageRows : [])
+            .filter((row) => row?.enabled && !row?.hung && !row?.cloaked && !row?.tool)
+            .filter((row) => String(row?.handle || '').trim())
+            .filter((row) => !placedHandlesInRun.has(String(row.handle).trim()));
+          if (isChromiumFamily && salvageCandidates.some(isChromiumTopLevelWindowRow)) {
+            salvageCandidates = salvageCandidates.filter(isChromiumTopLevelWindowRow);
+          }
+          salvageCandidates = salvageCandidates
+            .filter((row) => !isLikelyAuxiliaryWindowClass(row?.className))
+            .sort((a, b) => (
+              scoreWindowCandidate(b, { chromiumProcessHint: processHintLc })
+              - scoreWindowCandidate(a, { chromiumProcessHint: processHintLc })
+            ));
+          launchDiagnostics.attempt({
+            ...salvageDiagnosticsContext,
+            reason: 'scan-visible-rows-for-on-target-handle',
+            candidateCount: salvageCandidates.length,
+          });
+          for (const row of salvageCandidates.slice(0, 22)) {
+            const h = String(row?.handle || '').trim();
+            if (!h) continue;
+            const rectsSalvage = await getWindowPlacementRectsByHandle(h);
+            const measuredSalvage = rectsSalvage?.visibleRect || rectsSalvage?.outerRect || null;
+            const onSalvage = isWindowOnTargetMonitor({
+              rect: measuredSalvage,
+              monitor: launchItem.monitor,
+              bounds: placementBounds,
+            });
+            if (!onSalvage) continue;
+            const strictSalvage = isWithinAcceptableStateTolerance({
+              actual: measuredSalvage,
+              target: placementBounds,
+              onTargetMonitor: onSalvage,
+            });
+            const looseSalvage = isWithinSalvagePlacementTolerance({
+              actual: measuredSalvage,
+              target: placementBounds,
+              onTargetMonitor: onSalvage,
+            });
+            if (!strictSalvage && !looseSalvage) continue;
+            launchDiagnostics.decision({
+              processHintLc,
+              strategy: 'placement-final',
+              reason: looseSalvage && !strictSalvage
+                ? 'on-target-salvage-from-visible-scan-loose-geometry'
+                : 'on-target-salvage-from-visible-scan',
+              handle: h,
+            });
+            result = { applied: true, handle: h };
+            break;
+          }
+        }
+        if (!result.applied || !String(result.handle || '').trim()) {
           throw new Error('Window placement was not applied to a launchable handle.');
         }
-        claimRunPlacementHandle(result.handle);
+        claimRunPlacementHandle(String(result.handle).trim());
         const postPlacementRows = await getVisibleWindowInfos(processHintLc, {
           diagnostics: launchDiagnostics,
           diagnosticsContext: {

--- a/src/main/services/profile-launch-runner.test.js
+++ b/src/main/services/profile-launch-runner.test.js
@@ -1,6 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { createProfileLaunchRunner } = require('./profile-launch-runner');
+const { LAUNCH_WEIGHT_HARD_MAX_UNITS } = require('../../shared/launch-weight-limits');
 
 test('createProfileLaunchRunner returns launchProfileById function', () => {
   const noop = () => {};
@@ -54,6 +55,7 @@ test('createProfileLaunchRunner returns launchProfileById function', () => {
     isChromiumNonPrimaryWindowRow: () => false,
     isChromiumTopLevelWindowRow: () => false,
     isWithinAcceptableStateTolerance: () => false,
+    isWithinSalvagePlacementTolerance: () => false,
     centerWindowHandleOnMonitor: asyncNoop,
     maximizeWindowHandle: asyncNoop,
     buildMonitorMappingDiagnostics: () => [],
@@ -71,4 +73,189 @@ test('createProfileLaunchRunner returns launchProfileById function', () => {
 
   const { launchProfileById } = createProfileLaunchRunner(deps);
   assert.equal(typeof launchProfileById, 'function');
+});
+
+test('launchProfileById rejects before startRun when launch weight exceeds hard max', async () => {
+  let startRunCalled = false;
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  const stubProfile = { id: 'p1', name: 'Big', monitors: [{ id: 'm1', apps: [] }] };
+  const manyLaunches = Array.from({ length: LAUNCH_WEIGHT_HARD_MAX_UNITS + 1 }, (_, i) => ({
+    appName: `App${i}`,
+    executablePath: `C:\\app${i}.exe`,
+    shortcutPath: null,
+    launchUrl: null,
+    launchSequence: i,
+    monitor: { id: 'm1' },
+    app: { instanceId: `id-${i}`, name: `App${i}` },
+  }));
+  const deps = {
+    sleep: async () => {},
+    getVisibleWindowInfos: async () => [],
+    scoreWindowCandidate: () => 0,
+    moveSpecificWindowHandleToBounds: async () => ({ applied: false, handle: null }),
+    getWindowPlacementRectsByHandle: async () => null,
+    isWindowOnTargetMonitor: () => false,
+    waitForMainWindowReadyOrBlocker: async () => ({
+      ready: false,
+      blocked: false,
+      timedOut: true,
+      handle: null,
+    }),
+    isLikelyMainPlacementWindowIgnoringBlocker: () => false,
+    verifyAndCorrectWindowPlacement: async () => ({ verified: false, corrected: false }),
+    stabilizePlacementForSlowLaunch: async () => ({ verified: false, handle: null }),
+    readProfilesFromDisk: () => ({}),
+    unpackProfilesReadResult: () => ({
+      profiles: [stubProfile],
+      storeError: null,
+    }),
+    launchStatusStore: {
+      startRun: () => {
+        startRunCalled = true;
+        return { runId: 'should-not-run', replacedRunId: null };
+      },
+      publishStatus: noop,
+      getStatus: () => null,
+      sealRun: noop,
+      isActiveRun: () => false,
+    },
+    initializeLatestLaunchDiagnosticsLog: () => null,
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: () => new Map([['m1', { id: 'm1', primary: true }]]),
+    gatherProfileAppLaunches: () => ({ launches: manyLaunches, skippedApps: [] }),
+    gatherLegacyActionLaunches: () => ({ launches: [], browserUrls: [], skippedApps: [] }),
+    createLaunchDiagnostics: () => ({
+      start: noop,
+      decision: noop,
+      result: noop,
+      failure: noop,
+    }),
+    publishLaunchProfileStatus: noop,
+    getPlacementProcessKey: () => 'app',
+    isChromiumFamilyProcessKey: () => false,
+    describeMonitor: () => '',
+    buildWindowBoundsForApp: () => null,
+    buildCompanionProcessHints: async () => [],
+    planLaunchSlots: () => ({ reuseSlots: [], spawnSlots: [{}] }),
+    summarizeWindowRows: () => [],
+    shouldTriggerAmbiguityFallback: () => false,
+    isLikelyAuxiliaryWindowClass: () => false,
+    isChromiumNonPrimaryWindowRow: () => false,
+    isChromiumTopLevelWindowRow: () => false,
+    isWithinAcceptableStateTolerance: () => false,
+    isWithinSalvagePlacementTolerance: () => false,
+    centerWindowHandleOnMonitor: asyncNoop,
+    maximizeWindowHandle: asyncNoop,
+    buildMonitorMappingDiagnostics: () => [],
+    normalizeSafeUrl: () => '',
+    launchExecutable: async () => ({}),
+    getForegroundWindowHandle: () => null,
+    waitForWindowResponsive: async () => false,
+    placeChromiumByRankedWindows: async () => ({ applied: false, handle: null }),
+    moveWindowToBounds: async () => ({ applied: false, handle: null }),
+    bringWindowHandleToFront: asyncNoop,
+    stabilizeKnownHandlePlacement: async () => ({ verified: false, handle: null }),
+    minimizeWindowHandle: () => {},
+    ensureMinimizedAfterLaunch: async () => {},
+  };
+
+  const { launchProfileById } = createProfileLaunchRunner(deps);
+  const result = await launchProfileById('p1', {});
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'LAUNCH_TOO_LARGE');
+  assert.equal(startRunCalled, false);
+  assert.ok(result.details && result.details.totalUnits > LAUNCH_WEIGHT_HARD_MAX_UNITS);
+});
+
+test('launchProfileById rejects before startRun when no app launches and no browser tabs', async () => {
+  let startRunCalled = false;
+  const noop = () => {};
+  const asyncNoop = async () => {};
+  const stubProfile = {
+    id: 'p1',
+    name: 'Empty targets',
+    monitors: [{ id: 'm1', apps: [{ name: 'Ghost', instanceId: 'g1' }] }],
+    browserTabs: [],
+  };
+  const deps = {
+    sleep: async () => {},
+    getVisibleWindowInfos: async () => [],
+    scoreWindowCandidate: () => 0,
+    moveSpecificWindowHandleToBounds: async () => ({ applied: false, handle: null }),
+    getWindowPlacementRectsByHandle: async () => null,
+    isWindowOnTargetMonitor: () => false,
+    waitForMainWindowReadyOrBlocker: async () => ({
+      ready: false,
+      blocked: false,
+      timedOut: true,
+      handle: null,
+    }),
+    isLikelyMainPlacementWindowIgnoringBlocker: () => false,
+    verifyAndCorrectWindowPlacement: async () => ({ verified: false, corrected: false }),
+    stabilizePlacementForSlowLaunch: async () => ({ verified: false, handle: null }),
+    readProfilesFromDisk: () => ({}),
+    unpackProfilesReadResult: () => ({
+      profiles: [stubProfile],
+      storeError: null,
+    }),
+    launchStatusStore: {
+      startRun: () => {
+        startRunCalled = true;
+        return { runId: 'should-not-run', replacedRunId: null };
+      },
+      publishStatus: noop,
+      getStatus: () => null,
+      sealRun: noop,
+      isActiveRun: () => false,
+    },
+    initializeLatestLaunchDiagnosticsLog: () => null,
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: () => new Map([['m1', { id: 'm1', primary: true }]]),
+    gatherProfileAppLaunches: () => ({
+      launches: [],
+      skippedApps: [{ name: 'Ghost', reason: 'missing-launch-target' }],
+    }),
+    gatherLegacyActionLaunches: () => ({ launches: [], browserUrls: [], skippedApps: [] }),
+    createLaunchDiagnostics: () => ({
+      start: noop,
+      decision: noop,
+      result: noop,
+      failure: noop,
+    }),
+    publishLaunchProfileStatus: noop,
+    getPlacementProcessKey: () => 'app',
+    isChromiumFamilyProcessKey: () => false,
+    describeMonitor: () => '',
+    buildWindowBoundsForApp: () => null,
+    buildCompanionProcessHints: async () => [],
+    planLaunchSlots: () => ({ reuseSlots: [], spawnSlots: [{}] }),
+    summarizeWindowRows: () => [],
+    shouldTriggerAmbiguityFallback: () => false,
+    isLikelyAuxiliaryWindowClass: () => false,
+    isChromiumNonPrimaryWindowRow: () => false,
+    isChromiumTopLevelWindowRow: () => false,
+    isWithinAcceptableStateTolerance: () => false,
+    isWithinSalvagePlacementTolerance: () => false,
+    centerWindowHandleOnMonitor: asyncNoop,
+    maximizeWindowHandle: asyncNoop,
+    buildMonitorMappingDiagnostics: () => [],
+    normalizeSafeUrl: () => '',
+    launchExecutable: async () => ({}),
+    getForegroundWindowHandle: () => null,
+    waitForWindowResponsive: async () => false,
+    placeChromiumByRankedWindows: async () => ({ applied: false, handle: null }),
+    moveWindowToBounds: async () => ({ applied: false, handle: null }),
+    bringWindowHandleToFront: asyncNoop,
+    stabilizeKnownHandlePlacement: async () => ({ verified: false, handle: null }),
+    minimizeWindowHandle: () => {},
+    ensureMinimizedAfterLaunch: async () => {},
+  };
+
+  const { launchProfileById } = createProfileLaunchRunner(deps);
+  const result = await launchProfileById('p1', {});
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'LAUNCH_NOTHING_TO_RUN');
+  assert.equal(startRunCalled, false);
+  assert.ok(String(result.error || '').includes('Nothing to launch'));
 });

--- a/src/main/services/window-placement-runtime.js
+++ b/src/main/services/window-placement-runtime.js
@@ -934,6 +934,28 @@ const createWindowPlacementRuntime = (deps) => {
       );
     };
 
+    /**
+     * Qt / some maximized HWNDs report outer-rect or DWM visibleRect smaller than work-area
+     * while still filling the monitor; strict `isMeaningfulRectForBounds` drops them from the
+     * stabilization candidate list and verification never runs on the placed handle.
+     */
+    const isLooselyMeaningfulMaximizedRect = (rect, targetBounds) => {
+      if (!rect || !targetBounds) return false;
+      const rectWidth = Number(rect.width || 0);
+      const rectHeight = Number(rect.height || 0);
+      const targetWidth = Math.max(1, Number(targetBounds.width || 0));
+      const targetHeight = Math.max(1, Number(targetBounds.height || 0));
+      const areaRatio = (rectWidth * rectHeight) / (targetWidth * targetHeight);
+      const widthRatio = rectWidth / targetWidth;
+      const heightRatio = rectHeight / targetHeight;
+      return (
+        areaRatio >= 0.26
+        && widthRatio >= 0.42
+        && heightRatio >= 0.36
+        && (widthRatio >= 0.56 || heightRatio >= 0.56)
+      );
+    };
+
     const safeProcess = String(processHintLc || '').trim().toLowerCase();
     if (!safeProcess || !bounds) {
       return { verified: false, handle: initialHandle ? String(initialHandle) : null };
@@ -956,13 +978,15 @@ const createWindowPlacementRuntime = (deps) => {
         diagnostics,
         diagnosticsContext,
       });
-      const candidates = rows
+      let candidates = rows
         .filter((row) => row?.handle)
         .filter((row) => !row?.isMinimized)
         .filter((row) => (bounds.state !== 'maximized' ? true : (!row?.hasOwner && !row?.topMost)))
         .filter((row) => row.handle === forcedHandle || !excluded.has(row.handle))
         .filter((row) => {
           if (bounds.state !== 'maximized') return true;
+          // Keep the HWND we already placed even when EnumWindow sizes look "too small" for maximized.
+          if (forcedHandle && String(row.handle) === String(forcedHandle)) return true;
           return isMeaningfulRectForBounds(
             {
               width: Number(row?.width || 0),
@@ -975,6 +999,26 @@ const createWindowPlacementRuntime = (deps) => {
           scoreWindowCandidate(b, { chromiumProcessHint: safeProcess })
           - scoreWindowCandidate(a, { chromiumProcessHint: safeProcess })
         ));
+      if (bounds.state === 'maximized' && forcedHandle) {
+        const fh = String(forcedHandle);
+        const inList = candidates.some((r) => String(r.handle) === fh);
+        if (!inList) {
+          const direct = rows.find((r) => String(r?.handle) === fh);
+          if (direct) {
+            candidates = [direct, ...candidates.filter((r) => String(r.handle) !== fh)];
+          } else {
+            candidates = [{
+              handle: fh,
+              width: 0,
+              height: 0,
+              enabled: true,
+              isMinimized: false,
+              hasOwner: false,
+              topMost: false,
+            }, ...candidates];
+          }
+        }
+      }
       lastCandidates = candidates;
 
       if (bounds.state === 'minimized') {
@@ -1052,7 +1096,30 @@ const createWindowPlacementRuntime = (deps) => {
           const placementRects = await getWindowPlacementRectsByHandle(row.handle);
           const rect = placementRects?.visibleRect || placementRects?.outerRect || await getWindowRectByHandle(row.handle);
           const onTarget = isWindowOnTargetMonitor({ rect, monitor, bounds });
-          const meaningful = isMeaningfulRectForBounds(rect, bounds);
+          const strictMeaningful = isMeaningfulRectForBounds(rect, bounds);
+          const looseMeaningful = Boolean(
+            forcedHandle
+            && String(row.handle) === String(forcedHandle)
+            && isLooselyMeaningfulMaximizedRect(rect, bounds),
+          );
+          const meaningful = strictMeaningful || looseMeaningful;
+          if (
+            forcedHandle
+            && String(row.handle) === String(forcedHandle)
+            && onTarget
+            && meaningful
+          ) {
+            if (looseMeaningful && !strictMeaningful && diagnostics) {
+              diagnostics.decision({
+                ...diagnosticsContext,
+                strategy: 'stabilize-maximized',
+                reason: 'forced-handle-loose-meaningful-accept',
+                candidateHandle: row.handle,
+                measuredRect: rect,
+              });
+            }
+            return { verified: true, handle: row.handle };
+          }
           if (onTarget && meaningful) {
             if (verifiedHandle === row.handle) {
               verifiedHandleStableCount += 1;

--- a/src/main/utils/browser-tab-launch-list.js
+++ b/src/main/utils/browser-tab-launch-list.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * @param {unknown} profile
+ * @returns {'by_url_and_app' | 'each_saved_row'}
+ */
+const normalizeBrowserTabLaunchDedupe = (profile) => {
+  const v = String(profile?.browserTabLaunchDedupe || '').trim();
+  if (v === 'each_saved_row') return 'each_saved_row';
+  return 'by_url_and_app';
+};
+
+/**
+ * Ordered browser tab entries for launch + weight (must match `profile-launch-runner.js`).
+ * @param {object} profile
+ * @param {{ browserUrls?: string[] }} legacyLaunchData
+ * @param {(raw: unknown) => string} normalizeSafeUrl
+ * @returns {{ key: string, url: string, label: string, browser: string, appInstanceId: string }[]}
+ */
+const buildBrowserTabLaunchList = (profile, legacyLaunchData, normalizeSafeUrl) => {
+  const dedupeMode = normalizeBrowserTabLaunchDedupe(profile);
+  const tabUrlList = [];
+  const tabUrlSeen = new Set();
+  const pushTabEntry = (raw, meta = {}) => {
+    const u = normalizeSafeUrl(raw);
+    if (!u) return;
+    const browser = String(meta.browser || '').trim();
+    const appInstanceId = String(meta.appInstanceId || '').trim();
+    const rowSeg = dedupeMode === 'each_saved_row'
+      ? `\0row:${String(meta.rowIndex ?? '')}\0id:${String(meta.tabId || '').trim()}`
+      : '';
+    const key = `${u}\0${browser.toLowerCase()}\0${appInstanceId}${rowSeg}`;
+    if (tabUrlSeen.has(key)) return;
+    tabUrlSeen.add(key);
+    let label = u;
+    try {
+      label = new URL(u).hostname || u;
+    } catch {
+      label = u;
+    }
+    tabUrlList.push({ key, url: u, label, browser, appInstanceId });
+  };
+  const tabs = Array.isArray(profile?.browserTabs) ? profile.browserTabs : [];
+  for (let i = 0; i < tabs.length; i += 1) {
+    const tab = tabs[i];
+    pushTabEntry(tab?.url, {
+      browser: tab?.browser,
+      appInstanceId: tab?.appInstanceId,
+      rowIndex: i,
+      tabId: tab?.id,
+    });
+  }
+  const legacyUrls = legacyLaunchData?.browserUrls || [];
+  for (let li = 0; li < legacyUrls.length; li += 1) {
+    pushTabEntry(legacyUrls[li], { rowIndex: `legacy-${li}` });
+  }
+  return tabUrlList;
+};
+
+module.exports = {
+  normalizeBrowserTabLaunchDedupe,
+  buildBrowserTabLaunchList,
+};

--- a/src/main/utils/browser-tab-launch-list.test.js
+++ b/src/main/utils/browser-tab-launch-list.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildBrowserTabLaunchList } = require('./browser-tab-launch-list');
+
+const normalizeSafeUrl = (raw) => {
+  const s = String(raw || '').trim();
+  return s.startsWith('https://') ? s : '';
+};
+
+test('by_url_and_app collapses duplicate profile tabs', () => {
+  const profile = {
+    browserTabLaunchDedupe: 'by_url_and_app',
+    browserTabs: [
+      { url: 'https://example.com/a', browser: 'Edge', appInstanceId: 'i1' },
+      { url: 'https://example.com/a', browser: 'Edge', appInstanceId: 'i1' },
+    ],
+  };
+  const list = buildBrowserTabLaunchList(profile, { browserUrls: [] }, normalizeSafeUrl);
+  assert.equal(list.length, 1);
+});
+
+test('each_saved_row keeps duplicate URLs as separate entries', () => {
+  const profile = {
+    browserTabLaunchDedupe: 'each_saved_row',
+    browserTabs: [
+      { id: 't1', url: 'https://example.com/a', browser: 'Edge', appInstanceId: 'i1' },
+      { id: 't2', url: 'https://example.com/a', browser: 'Edge', appInstanceId: 'i1' },
+    ],
+  };
+  const list = buildBrowserTabLaunchList(profile, { browserUrls: [] }, normalizeSafeUrl);
+  assert.equal(list.length, 2);
+});
+
+test('legacy browserUrls respect each_saved_row', () => {
+  const profile = {
+    browserTabLaunchDedupe: 'each_saved_row',
+    browserTabs: [],
+  };
+  const list = buildBrowserTabLaunchList(
+    profile,
+    { browserUrls: ['https://x.test/', 'https://x.test/'] },
+    normalizeSafeUrl,
+  );
+  assert.equal(list.length, 2);
+});

--- a/src/main/utils/compute-launch-weight.js
+++ b/src/main/utils/compute-launch-weight.js
@@ -1,0 +1,200 @@
+'use strict';
+
+const limits = require('../../shared/launch-weight-limits');
+const { buildBrowserTabLaunchList } = require('./browser-tab-launch-list');
+
+/**
+ * @param {{ skippedApps?: object[] }} modernLaunchData
+ * @param {{ skippedApps?: object[] }} legacyLaunchData
+ * @param {number} [sampleMax]
+ */
+const buildSkippedLaunchTargetsSummary = (modernLaunchData, legacyLaunchData, sampleMax = 12) => {
+  const modernSk = modernLaunchData?.skippedApps || [];
+  const legacySk = legacyLaunchData?.skippedApps || [];
+  const merged = [];
+  const seen = new Set();
+  for (const row of [...modernSk, ...legacySk]) {
+    const name = String(row?.name || '').trim() || 'App';
+    const reason = String(row?.reason || '').trim() || 'unknown';
+    const key = `${name.toLowerCase()}::${reason}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ name, reason });
+  }
+  return {
+    count: merged.length,
+    sample: merged.slice(0, sampleMax),
+  };
+};
+
+/**
+ * App tiles on layout + minimized row (same scope as gather), after optional monitor slice.
+ * @param {object} profile
+ * @returns {number}
+ */
+const countLayoutAppSlots = (profile) => {
+  let n = 0;
+  for (const mon of Array.isArray(profile?.monitors) ? profile.monitors : []) {
+    n += Array.isArray(mon?.apps) ? mon.apps.length : 0;
+  }
+  n += Array.isArray(profile?.minimizedApps) ? profile.minimizedApps.length : 0;
+  return n;
+};
+
+/**
+ * Skips with reason `missing-launch-target` (no exe, shortcut, or URL on Windows).
+ * @param {{ skippedApps?: object[] }} modernLaunchData
+ * @param {{ skippedApps?: object[] }} legacyLaunchData
+ * @returns {number}
+ */
+const countMissingLaunchTargetSkips = (modernLaunchData, legacyLaunchData) => {
+  let n = 0;
+  for (const row of [...(modernLaunchData?.skippedApps || []), ...(legacyLaunchData?.skippedApps || [])]) {
+    if (String(row?.reason || '').trim() === 'missing-launch-target') n += 1;
+  }
+  return n;
+};
+
+/**
+ * Dedupe key aligned with `profile-launch-runner.js` launch pipeline.
+ * @param {object} launch
+ * @returns {string}
+ */
+const launchKey = (launch) => {
+  const instanceId = String(launch.app?.instanceId || '').trim();
+  if (instanceId) {
+    return `${instanceId}::${launch.monitor?.id || 'monitor'}`;
+  }
+  return `${launch.monitor?.id || 'monitor'}::${String(launch.executablePath || '').toLowerCase()}::${String(launch.shortcutPath || '').toLowerCase()}::${String(launch.launchUrl || '').toLowerCase()}`;
+};
+
+/**
+ * @param {{ launches: object[] }} modernLaunchData
+ * @param {{ launches: object[], browserUrls?: string[] }} legacyLaunchData
+ * @returns {object[]}
+ */
+const dedupeAppLaunchesFromGather = (modernLaunchData, legacyLaunchData) => {
+  const modern = modernLaunchData?.launches || [];
+  const legacy = legacyLaunchData?.launches || [];
+  const hasModernLaunches = modern.length > 0;
+  const preferredLaunches = hasModernLaunches ? modern : [...modern, ...legacy];
+  const seenLaunchKeys = new Set();
+  return preferredLaunches.filter((launch) => {
+    const key = launchKey(launch);
+    if (seenLaunchKeys.has(key)) return false;
+    seenLaunchKeys.add(key);
+    return true;
+  });
+};
+
+/**
+ * Drop profile monitors (and minimized rows targeting them) excluded from a best-effort launch.
+ * @param {object} profile
+ * @param {string[]|undefined} excludedProfileMonitorIds
+ * @returns {object}
+ */
+const sliceProfileForExcludedMonitors = (profile, excludedProfileMonitorIds) => {
+  if (!Array.isArray(excludedProfileMonitorIds) || excludedProfileMonitorIds.length === 0) {
+    return profile;
+  }
+  const ex = new Set(
+    excludedProfileMonitorIds.map((id) => String(id || '').trim()).filter(Boolean),
+  );
+  const monitors = (Array.isArray(profile?.monitors) ? profile.monitors : []).filter(
+    (m) => m?.id && !ex.has(String(m.id)),
+  );
+  const minimizedApps = (Array.isArray(profile?.minimizedApps) ? profile.minimizedApps : []).filter(
+    (a) => {
+      const t = a?.targetMonitor;
+      if (t == null || t === '') return true;
+      return !ex.has(String(t).trim());
+    },
+  );
+  return { ...profile, monitors, minimizedApps };
+};
+
+/**
+ * @param {object} deps
+ * @param {() => object[]} deps.buildSystemMonitorSnapshot
+ * @param {(profileMonitors: unknown, systemMonitors: unknown) => Map<string, object>} deps.createProfileMonitorMap
+ * @param {(profile: object, monitorMap: Map<string, object>) => { launches: object[], skippedApps: object[] }} deps.gatherProfileAppLaunches
+ * @param {(profile: object, monitorMap: Map<string, object>) => { launches: object[], browserUrls?: string[], skippedApps: object[] }} deps.gatherLegacyActionLaunches
+ * @param {(raw: unknown) => string} deps.normalizeSafeUrl
+ * @param {object} [options]
+ * @param {object[]} [options.systemMonitorsOverride] — use instead of buildSystemMonitorSnapshot()
+ * @param {string[]} [options.excludedProfileMonitorIds]
+ */
+const computeLaunchWeight = (profile, deps, options = {}) => {
+  const {
+    buildSystemMonitorSnapshot,
+    createProfileMonitorMap,
+    gatherProfileAppLaunches,
+    gatherLegacyActionLaunches,
+    normalizeSafeUrl,
+  } = deps;
+
+  const effectiveProfile = sliceProfileForExcludedMonitors(
+    profile,
+    options.excludedProfileMonitorIds,
+  );
+  const systemMonitors = Array.isArray(options.systemMonitorsOverride) && options.systemMonitorsOverride.length
+    ? options.systemMonitorsOverride
+    : buildSystemMonitorSnapshot();
+  const monitorMap = createProfileMonitorMap(effectiveProfile?.monitors, systemMonitors);
+  const modernLaunchData = gatherProfileAppLaunches(effectiveProfile, monitorMap);
+  const legacyLaunchData = gatherLegacyActionLaunches(effectiveProfile, monitorMap);
+  const appLaunches = dedupeAppLaunchesFromGather(modernLaunchData, legacyLaunchData);
+  const tabEntries = buildBrowserTabLaunchList(
+    effectiveProfile,
+    legacyLaunchData,
+    normalizeSafeUrl,
+  );
+
+  const perApp = limits.LAUNCH_WEIGHT_PER_APP_LAUNCH;
+  const perTab = limits.LAUNCH_WEIGHT_PER_BROWSER_TAB;
+  const appUnits = appLaunches.length * perApp;
+  const tabUnits = tabEntries.length * perTab;
+  const totalUnits = appUnits + tabUnits;
+
+  const skippedLaunchTargets = buildSkippedLaunchTargetsSummary(
+    modernLaunchData,
+    legacyLaunchData,
+    12,
+  );
+
+  const layoutAppSlots = countLayoutAppSlots(effectiveProfile);
+  const missingLaunchTargetSkips = countMissingLaunchTargetSkips(
+    modernLaunchData,
+    legacyLaunchData,
+  );
+
+  return {
+    totalUnits,
+    breakdown: {
+      dedupedAppLaunches: appLaunches.length,
+      dedupedBrowserTabs: tabEntries.length,
+    },
+    limits: {
+      softWarn: limits.LAUNCH_WEIGHT_SOFT_WARN_UNITS,
+      hardMax: limits.LAUNCH_WEIGHT_HARD_MAX_UNITS,
+    },
+    skippedLaunchTargets,
+    preflight: {
+      layoutAppSlots,
+      launchableAppLaunches: appLaunches.length,
+      missingLaunchTargetSkips,
+      dedupedBrowserTabs: tabEntries.length,
+    },
+  };
+};
+
+module.exports = {
+  launchKey,
+  dedupeAppLaunchesFromGather,
+  sliceProfileForExcludedMonitors,
+  buildSkippedLaunchTargetsSummary,
+  countLayoutAppSlots,
+  countMissingLaunchTargetSkips,
+  buildBrowserTabLaunchList,
+  computeLaunchWeight,
+};

--- a/src/main/utils/compute-launch-weight.test.js
+++ b/src/main/utils/compute-launch-weight.test.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  dedupeAppLaunchesFromGather,
+  computeLaunchWeight,
+  sliceProfileForExcludedMonitors,
+} = require('./compute-launch-weight');
+
+test('dedupeAppLaunchesFromGather prefers modern only when modern has rows', () => {
+  const m = { launches: [{ app: { instanceId: 'a' }, monitor: { id: 'm1' }, executablePath: 'C:\\a.exe' }] };
+  const l = {
+    launches: [{ app: { name: 'x' }, monitor: { id: 'm1' }, executablePath: 'C:\\b.exe' }],
+    browserUrls: [],
+  };
+  const out = dedupeAppLaunchesFromGather(m, l);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].app.instanceId, 'a');
+});
+
+test('dedupeAppLaunchesFromGather merges legacy when no modern launches', () => {
+  const m = { launches: [] };
+  const l = {
+    launches: [
+      { app: { name: 'x' }, monitor: { id: 'm1' }, executablePath: 'C:\\b.exe' },
+    ],
+    browserUrls: [],
+  };
+  const out = dedupeAppLaunchesFromGather(m, l);
+  assert.equal(out.length, 1);
+});
+
+test('sliceProfileForExcludedMonitors removes monitors and targeted minimized apps', () => {
+  const profile = {
+    monitors: [{ id: 'mon-a', apps: [] }, { id: 'mon-b', apps: [] }],
+    minimizedApps: [
+      { name: 'App1', targetMonitor: 'mon-a' },
+      { name: 'App2', targetMonitor: 'mon-b' },
+    ],
+  };
+  const sliced = sliceProfileForExcludedMonitors(profile, ['mon-a']);
+  assert.equal(sliced.monitors.length, 1);
+  assert.equal(sliced.monitors[0].id, 'mon-b');
+  assert.equal(sliced.minimizedApps.length, 1);
+  assert.equal(sliced.minimizedApps[0].name, 'App2');
+});
+
+test('computeLaunchWeight merges skippedApps from modern and legacy gathers', () => {
+  const profile = {
+    monitors: [{ id: 'm1', apps: [{ name: 'Ok', instanceId: 'i1', executablePath: 'C:\\a.exe' }] }],
+    minimizedApps: [],
+    browserTabs: [],
+  };
+  const deps = {
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: (pm, sm) => new Map([[String(pm[0].id), sm[0]]]),
+    gatherProfileAppLaunches: () => ({
+      launches: [],
+      skippedApps: [{ name: 'Ghost', reason: 'missing-launch-target' }],
+    }),
+    gatherLegacyActionLaunches: () => ({
+      launches: [],
+      browserUrls: [],
+      skippedApps: [{ name: 'Legacy skip', reason: 'missing-path' }],
+    }),
+    normalizeSafeUrl: () => '',
+  };
+  const w = computeLaunchWeight(profile, deps, {});
+  assert.equal(w.skippedLaunchTargets.count, 2);
+  assert.equal(w.skippedLaunchTargets.sample.length, 2);
+});
+
+test('computeLaunchWeight dedupes skippedApps by name and reason', () => {
+  const profile = {
+    monitors: [{ id: 'm1', apps: [] }],
+    minimizedApps: [],
+    browserTabs: [],
+  };
+  const deps = {
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: (pm, sm) => new Map([[String(pm[0].id), sm[0]]]),
+    gatherProfileAppLaunches: () => ({
+      launches: [],
+      skippedApps: [{ name: 'Dup', reason: 'missing-launch-target' }],
+    }),
+    gatherLegacyActionLaunches: () => ({
+      launches: [],
+      browserUrls: [],
+      skippedApps: [{ name: 'Dup', reason: 'missing-launch-target' }],
+    }),
+    normalizeSafeUrl: () => '',
+  };
+  const w = computeLaunchWeight(profile, deps, {});
+  assert.equal(w.skippedLaunchTargets.count, 1);
+});
+
+test('computeLaunchWeight sums deduped apps and tabs', () => {
+  const profile = {
+    monitors: [{ id: 'm1', apps: [{ name: 'A', instanceId: 'i1', executablePath: 'C:\\a.exe' }] }],
+    minimizedApps: [],
+    browserTabs: [{ url: 'https://example.com/', browser: 'edge' }],
+  };
+  const deps = {
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: (pm, sm) => new Map([[String(pm[0].id), sm[0]]]),
+    gatherProfileAppLaunches: (p, map) => {
+      const mon = map.get('m1');
+      return {
+        launches: p.monitors[0].apps.map((app, idx) => ({
+          appName: app.name,
+          executablePath: app.executablePath,
+          shortcutPath: null,
+          launchUrl: null,
+          launchSequence: idx,
+          monitor: mon,
+          app,
+        })),
+        skippedApps: [],
+      };
+    },
+    gatherLegacyActionLaunches: () => ({ launches: [], browserUrls: [], skippedApps: [] }),
+    normalizeSafeUrl: (u) => (typeof u === 'string' && u.startsWith('https://') ? u : ''),
+  };
+  const w = computeLaunchWeight(profile, deps, {});
+  assert.equal(w.breakdown.dedupedAppLaunches, 1);
+  assert.equal(w.breakdown.dedupedBrowserTabs, 1);
+  assert.equal(w.totalUnits, 2);
+  assert.equal(w.skippedLaunchTargets.count, 0);
+  assert.ok(w.preflight);
+  assert.equal(w.preflight.layoutAppSlots, 1);
+  assert.equal(w.preflight.launchableAppLaunches, 1);
+  assert.equal(w.preflight.missingLaunchTargetSkips, 0);
+  assert.equal(w.preflight.dedupedBrowserTabs, 1);
+});
+
+test('computeLaunchWeight preflight counts layout slots and missing-launch-target skips', () => {
+  const profile = {
+    monitors: [
+      { id: 'm1', apps: [{ name: 'A', instanceId: 'i1' }, { name: 'B', instanceId: 'i2' }] },
+    ],
+    minimizedApps: [{ name: 'Min', instanceId: 'i3' }],
+    browserTabs: [],
+  };
+  const deps = {
+    buildSystemMonitorSnapshot: () => [{ id: 'm1', primary: true }],
+    createProfileMonitorMap: (pm, sm) => new Map([[String(pm[0].id), sm[0]]]),
+    gatherProfileAppLaunches: () => ({
+      launches: [],
+      skippedApps: [
+        { name: 'A', reason: 'missing-launch-target' },
+        { name: 'B', reason: 'missing-launch-target' },
+      ],
+    }),
+    gatherLegacyActionLaunches: () => ({
+      launches: [],
+      browserUrls: [],
+      skippedApps: [{ name: 'Min', reason: 'missing-launch-target' }],
+    }),
+    normalizeSafeUrl: () => '',
+  };
+  const w = computeLaunchWeight(profile, deps, {});
+  assert.equal(w.preflight.layoutAppSlots, 3);
+  assert.equal(w.preflight.missingLaunchTargetSkips, 3);
+  assert.equal(w.preflight.launchableAppLaunches, 0);
+  assert.equal(w.preflight.dedupedBrowserTabs, 0);
+});

--- a/src/main/utils/launch-target-mode.js
+++ b/src/main/utils/launch-target-mode.js
@@ -60,6 +60,37 @@ const isWithinAcceptableStateTolerance = ({
   return false;
 };
 
+/**
+ * Last-resort geometry check when move helpers report failure but a window is already on the
+ * target monitor. Stricter {@link isWithinAcceptableStateTolerance} rejects common DPI / theme /
+ * profile-snapshot drift (e.g. Qt apps like Anki) even though placement is effectively correct.
+ */
+const isWithinSalvagePlacementTolerance = ({
+  actual,
+  target,
+  onTargetMonitor,
+} = {}) => {
+  if (!actual || !target || onTargetMonitor !== true) return false;
+  const state = String(target.state || 'normal').trim().toLowerCase();
+
+  if (state === 'normal') {
+    const aw = Number(actual.width || 0);
+    const ah = Number(actual.height || 0);
+    if (aw < 120 || ah < 80) return false;
+    const dx = Math.abs(Number(actual.left || 0) - Number(target.left || 0));
+    const dy = Math.abs(Number(actual.top || 0) - Number(target.top || 0));
+    const dw = Math.abs(aw - Number(target.width || 0));
+    const dh = Math.abs(ah - Number(target.height || 0));
+    return dx <= 96 && dy <= 96 && dw <= 220 && dh <= 220;
+  }
+
+  if (state === 'maximized') {
+    return isMeaningfulBoundsForTarget(actual, target);
+  }
+
+  return isWithinAcceptableStateTolerance({ actual, target, onTargetMonitor });
+};
+
 const planLaunchSlots = ({ requestedSlots, existingHandles } = {}) => {
   const safeRequestedSlots = normalizeCount(requestedSlots);
   const safeExistingHandles = Array.isArray(existingHandles)
@@ -133,6 +164,7 @@ module.exports = {
   REUSE_SCORE_WEIGHTS,
   normalizeUnitScore,
   isWithinAcceptableStateTolerance,
+  isWithinSalvagePlacementTolerance,
   planLaunchSlots,
   scoreReuseCandidate,
   shouldTriggerAmbiguityFallback,

--- a/src/main/utils/launch-target-mode.test.js
+++ b/src/main/utils/launch-target-mode.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   isWithinAcceptableStateTolerance,
+  isWithinSalvagePlacementTolerance,
   planLaunchSlots,
   scoreReuseCandidate,
   shouldTriggerAmbiguityFallback,
@@ -224,6 +225,37 @@ test('isWithinAcceptableStateTolerance rejects maximized state with underfilled 
         height: 1080,
         state: 'maximized',
       },
+      onTargetMonitor: true,
+    }),
+    false,
+  );
+});
+
+test('isWithinSalvagePlacementTolerance accepts normal drift that strict tolerance rejects', () => {
+  assert.equal(
+    isWithinAcceptableStateTolerance({
+      actual: { left: 100, top: 100, width: 1100, height: 800 },
+      target: { left: 100, top: 100, width: 1280, height: 720, state: 'normal' },
+      onTargetMonitor: true,
+    }),
+    false,
+    'strict tolerance should reject large width delta',
+  );
+  assert.equal(
+    isWithinSalvagePlacementTolerance({
+      actual: { left: 100, top: 100, width: 1100, height: 800 },
+      target: { left: 100, top: 100, width: 1280, height: 720, state: 'normal' },
+      onTargetMonitor: true,
+    }),
+    true,
+  );
+});
+
+test('isWithinSalvagePlacementTolerance rejects tiny windows on target monitor', () => {
+  assert.equal(
+    isWithinSalvagePlacementTolerance({
+      actual: { left: 200, top: 200, width: 100, height: 70 },
+      target: { left: 100, top: 100, width: 1280, height: 720, state: 'normal' },
       onTargetMonitor: true,
     }),
     false,

--- a/src/main/utils/sanitize-profile-store-payload.js
+++ b/src/main/utils/sanitize-profile-store-payload.js
@@ -34,6 +34,8 @@ const sanitizeProfilesArray = (profiles) => {
       normalized.id = safeLimitedString(profile.id, MAX_PROFILE_ID_LENGTH);
       normalized.name = safeLimitedString(profile.name, MAX_PROFILE_NAME_LENGTH);
       normalized.icon = sanitizeProfileRootIcon(profile.icon);
+      const tabDedupe = String(profile.browserTabLaunchDedupe || '').trim();
+      normalized.browserTabLaunchDedupe = tabDedupe === 'each_saved_row' ? 'each_saved_row' : 'by_url_and_app';
       if (Array.isArray(profile.browserTabs)) {
         normalized.browserTabs = profile.browserTabs
           .map((tab) => {

--- a/src/main/utils/sanitize-profiles-payload.js
+++ b/src/main/utils/sanitize-profiles-payload.js
@@ -31,6 +31,8 @@ const sanitizeProfilesPayload = (profiles) => {
       normalized.id = safeLimitedString(profile.id, MAX_PROFILE_ID_LENGTH);
       normalized.name = safeLimitedString(profile.name, MAX_PROFILE_NAME_LENGTH);
       normalized.icon = sanitizeProfileRootIcon(profile.icon);
+      const tabDedupe = String(profile.browserTabLaunchDedupe || '').trim();
+      normalized.browserTabLaunchDedupe = tabDedupe === 'each_saved_row' ? 'each_saved_row' : 'by_url_and_app';
       if (Array.isArray(profile.browserTabs)) {
         normalized.browserTabs = profile.browserTabs
           .map((tab) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -6,6 +6,11 @@ contextBridge.exposeInMainWorld('electron', {
   // Launch profile actions in main process (apps + tabs)
   launchProfile: (profileId, options) => ipcRenderer.invoke('launch-profile', profileId, options || {}),
 
+  /** Same launch weight as main uses for guardrails; read-only, does not start a run. */
+  getProfileLaunchWeight: (profileId, request) => (
+    ipcRenderer.invoke('profile-launch-weight', profileId, request || {})
+  ),
+
   /** Main → renderer when a profile launch run starts (any origin). */
   subscribeProfileLaunchStarted: (callback) => {
     const channel = 'profile-launch-started';

--- a/src/renderer/layout/MainLayout.tsx
+++ b/src/renderer/layout/MainLayout.tsx
@@ -9,6 +9,10 @@ import { LaunchControl } from "./components/LaunchControl";
 import { TitleBarAppMenu } from "./components/TitleBarAppMenu";
 import { TitleBarSidebarToggleIcon } from "./components/TitleBarSidebarToggleIcons";
 import { AppChromeModals } from "./components/AppChromeModals";
+import {
+  LargeProfileLaunchConfirm,
+  type LargeProfileLaunchConfirmPayload,
+} from "./components/LargeProfileLaunchConfirm";
 import { ProfileHeaderSettingsButton } from "./components/ProfileHeaderSettingsButton";
 import { ProfileHeaderMetaChips } from "./components/ProfileHeaderMetaChips";
 import { NewProfileMenu } from "./components/NewProfileMenu";
@@ -83,6 +87,7 @@ import {
   resolveInstalledAppLibraryCategory,
   installedAppCategoryOverrideLookupKeys,
 } from "../utils/installedAppLibraryCategory";
+import { inferIsWebBrowserFromInstalledApp } from "../utils/installedWebBrowserInference";
 import type { FlowProfile, FlowProfileKind, ProfileSavePayload } from "../../types/flow-profile";
 import {
   FLOW_PROFILE_KINDS,
@@ -217,6 +222,23 @@ export default function App() {
   const [launchCancelPending, setLaunchCancelPending] = useState(false);
   const expectedLaunchRunIdRef = useRef<string | null>(null);
   const expectedLaunchProfileIdRef = useRef<string | null>(null);
+  const largeLaunchResolveRef = useRef<((confirmed: boolean) => void) | null>(null);
+  const [largeLaunchModal, setLargeLaunchModal] =
+    useState<LargeProfileLaunchConfirmPayload | null>(null);
+
+  const settleLargeLaunchModal = useCallback((confirmed: boolean) => {
+    const r = largeLaunchResolveRef.current;
+    largeLaunchResolveRef.current = null;
+    setLargeLaunchModal(null);
+    r?.(confirmed);
+  }, []);
+
+  const confirmLargeLaunch = useCallback(async (payload: LargeProfileLaunchConfirmPayload) => {
+    return await new Promise<boolean>((resolve) => {
+      largeLaunchResolveRef.current = resolve;
+      setLargeLaunchModal(payload);
+    });
+  }, []);
 
   const launchRunProgressRunId = lastLaunchProgress?.runId?.trim() ?? "";
   const launchRunIdsMismatched =
@@ -878,6 +900,7 @@ export default function App() {
     setIsLaunching,
     setLaunchFeedback,
     launchFeedbackTimeoutRef,
+    confirmLargeLaunch,
     onLaunchPreparing: (profileId) => {
       expectedLaunchProfileIdRef.current = profileId;
       expectedLaunchRunIdRef.current = null;
@@ -1064,12 +1087,13 @@ export default function App() {
       setOpenLibraryFolderId(null);
 
       // Determine if this is a browser app
-      const isBrowser =
-        appData.name?.toLowerCase().includes("chrome") ||
-        appData.name?.toLowerCase().includes("browser") ||
-        appData.name?.toLowerCase().includes("firefox") ||
-        appData.name?.toLowerCase().includes("safari") ||
-        appData.name?.toLowerCase().includes("edge");
+      const isBrowser = inferIsWebBrowserFromInstalledApp({
+        name: appData.name,
+        executablePath:
+          typeof appData.executablePath === "string"
+            ? appData.executablePath
+            : null,
+      });
 
       // Get fresh app data with current browser tabs
       const freshAppData = { ...appData };
@@ -1139,13 +1163,11 @@ export default function App() {
       setLibrarySelection(null);
       setOpenLibraryFolderId(null);
 
-      const nameLc = app.name?.toLowerCase() || "";
-      const isBrowser =
-        nameLc.includes("chrome")
-        || nameLc.includes("browser")
-        || nameLc.includes("firefox")
-        || nameLc.includes("safari")
-        || nameLc.includes("edge");
+      const isBrowser = inferIsWebBrowserFromInstalledApp({
+        name: app.name,
+        executablePath:
+          typeof app.executablePath === "string" ? app.executablePath : null,
+      });
 
       setSelectedApp({
         type: isBrowser ? "browser" : "app",
@@ -1330,20 +1352,13 @@ export default function App() {
         );
 
         // Refresh browser tabs if this is a browser app
-        const isBrowser =
-          selectedApp.data.name
-            ?.toLowerCase()
-            .includes("chrome") ||
-          selectedApp.data.name
-            ?.toLowerCase()
-            .includes("browser") ||
-          selectedApp.data.name
-            ?.toLowerCase()
-            .includes("firefox") ||
-          selectedApp.data.name
-            ?.toLowerCase()
-            .includes("safari") ||
-          selectedApp.data.name?.toLowerCase().includes("edge");
+        const isBrowser = inferIsWebBrowserFromInstalledApp({
+          name: selectedApp.data.name,
+          executablePath:
+            typeof selectedApp.data.executablePath === "string"
+              ? selectedApp.data.executablePath
+              : null,
+        });
 
         const updatedData = { ...selectedApp.data, ...updates };
 
@@ -2678,7 +2693,7 @@ export default function App() {
             <div className="flex items-center justify-between gap-2 border-b border-flow-border px-3 py-2">
               <div
                 role="tablist"
-                aria-label="Inspector: selection details or launch progress"
+                aria-label="Inspector: selection details or Launch"
                 className="inline-flex max-w-full shrink-0 flex-nowrap items-stretch gap-px rounded-[10px] border border-white/[0.12] bg-black/40 p-0.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] backdrop-blur-sm"
               >
                 <FlowTooltip
@@ -2686,7 +2701,7 @@ export default function App() {
                   delayDuration={380}
                   label={
                     "Placement, paths, and per-app Launch settings for your selection.\n"
-                    + "Live profile launch timeline is on Progress—not this tab."
+                    + "Live profile launch timeline is on Launch—not this tab."
                   }
                 >
                   <button
@@ -2722,7 +2737,7 @@ export default function App() {
                     role="tab"
                     aria-selected={inspectorMode === "launch"}
                     onClick={() => setInspectorMode("launch")}
-                    aria-label="Progress: live launch status for the active or last profile run"
+                    aria-label="Launch: live launch status for the active or last profile run"
                     className={`relative ${FLOW_INSPECTOR_MODE_TAB_BASE} ${
                       inspectorMode === "launch"
                         ? FLOW_INSPECTOR_MODE_TAB_SELECTED
@@ -2734,7 +2749,7 @@ export default function App() {
                       strokeWidth={2}
                       aria-hidden
                     />
-                    Progress
+                    Launch
                     {isLaunching || launchFeedback.status !== "idle" || lastLaunchProgress ? (
                       <span
                         className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-flow-accent-blue ring-2 ring-flow-bg-secondary"
@@ -2962,6 +2977,15 @@ export default function App() {
           <p className="text-sm text-flow-text-secondary">Loading profiles…</p>
         </div>
       )}
+
+      {largeLaunchModal ? (
+        <LargeProfileLaunchConfirm
+          isOpen
+          {...largeLaunchModal}
+          onCancel={() => settleLargeLaunchModal(false)}
+          onConfirm={() => settleLargeLaunchModal(true)}
+        />
+      ) : null}
 
       <AppChromeModals
         preferencesOpen={appChromeModal === "preferences"}

--- a/src/renderer/layout/components/AppFileWindow.tsx
+++ b/src/renderer/layout/components/AppFileWindow.tsx
@@ -11,6 +11,7 @@ import {
   suspendDocumentTextSelection,
 } from "../utils/documentTextSelection";
 import { FlowTooltip } from "./ui/tooltip";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 const isRenderableIconComponent = (value: unknown): value is LucideIcon => {
   if (typeof value === "function") return true;
@@ -436,11 +437,11 @@ export function AppFileWindow({
     const app = item as AppItem;
     
     // Check if this is a browser app
-    const isBrowser = app.name?.toLowerCase().includes('chrome') || 
-                     app.name?.toLowerCase().includes('browser') ||
-                     app.name?.toLowerCase().includes('firefox') ||
-                     app.name?.toLowerCase().includes('safari') ||
-                     app.name?.toLowerCase().includes('edge');
+    const isBrowser = inferIsWebBrowserFromInstalledApp({
+      name: app.name,
+      executablePath:
+        typeof app.executablePath === "string" ? app.executablePath : null,
+    });
     
     // Get associated files
     const files = app.associatedFiles || [];

--- a/src/renderer/layout/components/AppWindow.tsx
+++ b/src/renderer/layout/components/AppWindow.tsx
@@ -8,6 +8,7 @@ import {
 import { Settings, Trash2, Move, Shield, Minimize2, File, Folder, Link } from "lucide-react";
 import { FlowTooltip } from "./ui/tooltip";
 import { LucideIcon } from "lucide-react";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 // Type guards for app types
 function isDiscoveredApp(app: any): app is { iconPath: string | null } {
@@ -37,6 +38,8 @@ interface AppWindowProps {
       associatedApp: string;
       useDefaultApp: boolean;
     }[];
+    executablePath?: string | null;
+    shortcutPath?: string | null;
   };
   appIndex: number;
   monitorId: string;
@@ -145,11 +148,11 @@ export function AppWindow({
   // FIXED: Content indicator with browser tabs and files combined
   const renderContentIndicator = () => {
     // Check if this is a browser app
-    const isBrowser = app.name?.toLowerCase().includes('chrome') || 
-                     app.name?.toLowerCase().includes('browser') ||
-                     app.name?.toLowerCase().includes('firefox') ||
-                     app.name?.toLowerCase().includes('safari') ||
-                     app.name?.toLowerCase().includes('edge');
+    const isBrowser = inferIsWebBrowserFromInstalledApp({
+      name: app.name,
+      executablePath:
+        typeof app.executablePath === "string" ? app.executablePath : null,
+    });
     
     // Get associated files
     const files = app.associatedFiles || [];

--- a/src/renderer/layout/components/BrowserTabs.tsx
+++ b/src/renderer/layout/components/BrowserTabs.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Globe, X, Copy, Bookmark, Plus, MoreVertical, ExternalLink, Monitor, Minimize2, Maximize2 } from "lucide-react";
 import { FlowTooltip } from "./ui/tooltip";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 interface BrowserTab {
   name: string;
@@ -20,6 +21,7 @@ interface MinimizedApp {
   launchBehavior?: 'new' | 'focus' | 'minimize';
   targetMonitor?: string;
   browserTabs?: { name: string; url: string; isActive: boolean }[];
+  executablePath?: string | null;
 }
 
 interface BrowserTabsProps {
@@ -38,6 +40,7 @@ interface BrowserTabsProps {
       icon: any;
       color: string;
       monitorId?: string;
+      executablePath?: string | null;
     }>;
   }>;
 }
@@ -75,11 +78,11 @@ export function BrowserTabs({
     // Add browser apps from monitors
     monitors.forEach((monitor, monitorIndex) => {
       monitor.apps?.forEach((app, appIndex) => {
-        const isBrowser = app.name.toLowerCase().includes('chrome') || 
-                         app.name.toLowerCase().includes('browser') ||
-                         app.name.toLowerCase().includes('firefox') ||
-                         app.name.toLowerCase().includes('safari') ||
-                         app.name.toLowerCase().includes('edge');
+        const isBrowser = inferIsWebBrowserFromInstalledApp({
+          name: app.name,
+          executablePath:
+            typeof app.executablePath === "string" ? app.executablePath : null,
+        });
         
         if (isBrowser) {
           const browserKey = `${monitor.id}-${app.name}`;
@@ -114,11 +117,11 @@ export function BrowserTabs({
 
     // Add browser apps from minimized apps
     minimizedApps.forEach((app, index) => {
-      const isBrowser = app.name.toLowerCase().includes('chrome') || 
-                       app.name.toLowerCase().includes('browser') ||
-                       app.name.toLowerCase().includes('firefox') ||
-                       app.name.toLowerCase().includes('safari') ||
-                       app.name.toLowerCase().includes('edge');
+      const isBrowser = inferIsWebBrowserFromInstalledApp({
+        name: app.name,
+        executablePath:
+          typeof app.executablePath === "string" ? app.executablePath : null,
+      });
       
       if (isBrowser) {
         const monitor = monitors.find(m => m.id === app.targetMonitor);
@@ -359,9 +362,6 @@ export function BrowserTabs({
                             <div className="text-xs text-flow-text-muted truncate">{tab.url}</div>
                           )}
                         </div>
-                        {isActive && (
-                          <div className="w-2 h-2 bg-flow-accent-blue rounded-full flex-shrink-0" />
-                        )}
                         {tab.newWindow && (
                           <ExternalLink className="w-3 h-3 text-flow-text-muted flex-shrink-0" />
                         )}

--- a/src/renderer/layout/components/ContentManager.tsx
+++ b/src/renderer/layout/components/ContentManager.tsx
@@ -26,6 +26,7 @@ import {
   getBrowserIcon,
 } from "../utils/layoutDropPresentation";
 import { resolveHostExecutableForCatalogLabel } from "../utils/catalogHostResolve";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 // Enhanced content types for the unified system
 export interface ContentFolder {
@@ -112,10 +113,6 @@ interface ContentManagerProps {
 const CONTENT_SIDEBAR_COMPACT_HELP =
   "Click a row to set path and Opens with. Use ⋯ on a row for Add to layout or Remove from library. Drag the content icon to place precisely on the canvas.";
 
-const SIDEBAR_DRAG_BROWSER_NAMES = new Set(
-  ["Chrome", "Firefox", "Safari", "Edge"].map((s) => s.toLowerCase()),
-);
-
 function resolveInstalledCatalogIconPath(
   catalog: {
     name: string;
@@ -150,13 +147,11 @@ function renderOpensWithDragPreview(
   );
   const AppGlyph = getAppIcon(defaultApp);
   const BrowserGlyph = getBrowserIcon(defaultApp);
-  const tl = defaultApp.trim().toLowerCase();
-  const isLikelyBrowser =
-    SIDEBAR_DRAG_BROWSER_NAMES.has(tl)
-    || tl.includes("chrome")
-    || tl.includes("firefox")
-    || tl.includes("edge")
-    || tl.includes("safari");
+  const hostExe = resolveHostExecutableForCatalogLabel(catalog, defaultApp);
+  const isLikelyBrowser = inferIsWebBrowserFromInstalledApp({
+    name: defaultApp,
+    executablePath: hostExe,
+  });
   return (
     <div className="flex max-w-[240px] items-center gap-2">
       {raster ? (
@@ -355,14 +350,11 @@ export function ContentManager({
     if (raster) {
       return <img src={raster} alt="" className={`${className} rounded object-contain`} />;
     }
-    const tl = String(appName || "").trim().toLowerCase();
-    const isLikelyBrowser =
-      SIDEBAR_DRAG_BROWSER_NAMES.has(tl)
-      || tl.includes("chrome")
-      || tl.includes("firefox")
-      || tl.includes("edge")
-      || tl.includes("safari")
-      || tl.includes("browser");
+    const hostExe = resolveHostExecutableForCatalogLabel(installedAppsCatalog, appName);
+    const isLikelyBrowser = inferIsWebBrowserFromInstalledApp({
+      name: appName,
+      executablePath: hostExe,
+    });
     if (isLikelyBrowser) {
       const Glyph = getBrowserIcon(appName);
       return <Glyph className={className} style={{ color: getBrowserColor(appName) }} />;

--- a/src/renderer/layout/components/LargeProfileLaunchConfirm.tsx
+++ b/src/renderer/layout/components/LargeProfileLaunchConfirm.tsx
@@ -1,0 +1,163 @@
+import { AlertTriangle } from "lucide-react";
+import { useEscapeToClose } from "../hooks/useEscapeToClose";
+
+export type LargeProfileLaunchConfirmPayload = {
+  profileName: string;
+  totalUnits: number;
+  appCount: number;
+  tabCount: number;
+  softWarn: number;
+  hardMax: number;
+  /** Apps gather marks as non-launchable (missing target, restricted, …). */
+  skippedLaunchCount?: number;
+  skippedLaunchSample?: { name: string; reason: string }[];
+  /** From weight preflight: app tiles on layout + minimized row (after monitor exclusions). */
+  preflightLayoutAppSlots?: number;
+  /** From weight preflight: skipped rows with reason `missing-launch-target`. */
+  preflightMissingLaunchTargets?: number;
+};
+
+type LargeProfileLaunchConfirmProps = LargeProfileLaunchConfirmPayload & {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+function summarizeSkipReason(reason: string): string {
+  const r = String(reason || '').trim().toLowerCase();
+  if (r === 'missing-launch-target') return 'no executable, shortcut, or URL';
+  if (r === 'disallowed-executable-path') return 'executable not allowed';
+  if (r === 'restricted') return 'restricted for this profile';
+  if (r === 'missing-name') return 'unnamed tile';
+  if (r === 'missing-path') return 'missing path';
+  return r.replace(/-/g, ' ') || 'unknown';
+}
+
+export function LargeProfileLaunchConfirm({
+  isOpen,
+  profileName,
+  totalUnits,
+  appCount,
+  tabCount,
+  softWarn,
+  hardMax,
+  skippedLaunchCount = 0,
+  skippedLaunchSample = [],
+  preflightLayoutAppSlots,
+  preflightMissingLaunchTargets,
+  onCancel,
+  onConfirm,
+}: LargeProfileLaunchConfirmProps) {
+  useEscapeToClose(isOpen, onCancel);
+
+  if (!isOpen) return null;
+
+  const appLabel = `${appCount} app${appCount === 1 ? "" : "s"}`;
+  const tabLabel = `${tabCount} browser tab${tabCount === 1 ? "" : "s"}`;
+
+  return (
+    <div
+      className="flow-modal-backdrop-enter fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="large-launch-title"
+        aria-describedby="large-launch-desc"
+        className="flow-modal-nested-panel-enter w-full max-w-md rounded-xl border border-flow-border bg-flow-surface-elevated p-5 shadow-flow-shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-amber-500/35 bg-amber-500/15">
+            <AlertTriangle className="h-5 w-5 text-amber-400" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 id="large-launch-title" className="text-lg font-semibold text-flow-text-primary">
+              Large profile launch
+            </h3>
+            <div
+              id="large-launch-desc"
+              className="mt-2 space-y-3 text-sm leading-relaxed text-flow-text-secondary"
+            >
+              <p>
+                Launching{" "}
+                <span className="font-medium text-flow-text-primary">{profileName}</span>
+                {" "}
+                will open approximately{" "}
+                <span className="font-medium text-flow-text-primary">{totalUnits}</span>
+                {" "}
+                items ({appLabel}, {tabLabel}). This may take multiple minutes.
+              </p>
+              <ul className="list-disc space-y-1.5 pl-5 text-sm leading-relaxed text-flow-text-secondary">
+                <li>Apps open one at a time, in list order.</li>
+                <li>Existing windows for profile apps will be reused where possible.</li>
+                <li>Apps outside this profile won&apos;t be affected.</li>
+              </ul>
+              {typeof preflightLayoutAppSlots === "number"
+                && preflightLayoutAppSlots > 0
+                && typeof preflightMissingLaunchTargets === "number"
+                && preflightMissingLaunchTargets > 0 ? (
+                <p className="text-xs leading-snug text-flow-text-muted">
+                  Layout has{" "}
+                  <span className="font-medium text-flow-text-secondary">{preflightLayoutAppSlots}</span>
+                  {" "}
+                  app tile{preflightLayoutAppSlots === 1 ? "" : "s"};{" "}
+                  <span className="font-medium text-flow-text-secondary">{preflightMissingLaunchTargets}</span>
+                  {" "}
+                  {preflightMissingLaunchTargets === 1 ? "has" : "have"} no executable, shortcut, or URL.
+                </p>
+              ) : null}
+              {skippedLaunchCount > 0 ? (
+                <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-flow-text-secondary">
+                  <p className="font-medium text-flow-text-primary">
+                    {skippedLaunchCount} app tile{skippedLaunchCount === 1 ? "" : "s"} won&apos;t launch
+                  </p>
+                  <p className="mt-1 text-xs leading-snug text-flow-text-muted">
+                    Resolve paths in Inspect → Overview before launch, or remove the tiles.
+                  </p>
+                  {skippedLaunchSample.length > 0 ? (
+                    <ul className="mt-2 list-disc space-y-0.5 pl-4 text-xs text-flow-text-muted">
+                      {skippedLaunchSample.map((row, i) => (
+                        <li key={`${row.name}-${row.reason}-${i}`}>
+                          <span className="text-flow-text-secondary">{row.name}</span>
+                          {' — '}
+                          {summarizeSkipReason(row.reason)}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  {skippedLaunchCount > skippedLaunchSample.length ? (
+                    <p className="mt-1.5 text-xs text-flow-text-muted">
+                      And {skippedLaunchCount - skippedLaunchSample.length} more not shown.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+            <p className="mt-3 text-xs leading-snug text-flow-text-muted">
+              Recommended: under {softWarn} items. Maximum: {hardMax}.
+            </p>
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-flow-border bg-flow-surface px-3 py-2 text-sm font-medium text-flow-text-secondary transition-colors hover:bg-flow-surface-elevated hover:text-flow-text-primary"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-lg border border-flow-accent-blue/40 bg-flow-accent-blue/15 px-3 py-2 text-sm font-medium text-flow-accent-blue transition-colors hover:bg-flow-accent-blue/25"
+          >
+            Launch anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/layout/components/LaunchCenterInspector.tsx
+++ b/src/renderer/layout/components/LaunchCenterInspector.tsx
@@ -29,6 +29,11 @@ import {
   deriveBuckets,
 } from "../utils/launchTimeline";
 import { orderLaunchActionsForProgressDisplay } from "../utils/launchTimelineDisplayOrder";
+import {
+  inspectorBrowserLinkGlobeStrokeWidth,
+  inspectorBrowserTabGlobeIconClass,
+  inspectorBrowserTabGlobeIconMdClass,
+} from "./inspectorStyles";
 
 type LaunchCenterInspectorProps = {
   profile: FlowProfile;
@@ -77,8 +82,14 @@ function LaunchInspectorCancelButton({
 const LAUNCH_LEAD_SURFACE_CLASS =
   "flex min-w-0 w-full cursor-default items-stretch rounded-lg border border-white/[0.09] bg-black/28 py-1.5 pl-2 pr-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]";
 
+/** Lead row inside the “current action” card only — outer card already frames; avoid nested borders. */
+const LAUNCH_LEAD_INSIDE_CURRENT_CARD_CLASS =
+  "flex min-w-0 w-full cursor-default items-stretch rounded-lg bg-black/22 py-1.5 pl-2 pr-2";
+
 /** Same chrome on every `layoutId` node so Framer doesn’t morph borders/rings between zones. */
 const LAUNCH_LEAD_LAYOUT_SHELL_CLASS = `${LAUNCH_LEAD_SURFACE_CLASS} transform-gpu`;
+
+const LAUNCH_LEAD_INSIDE_CURRENT_CARD_SHELL_CLASS = `${LAUNCH_LEAD_INSIDE_CURRENT_CARD_CLASS} transform-gpu`;
 
 const LAUNCH_LEAD_LAYOUT_SHELL_STYLE = { borderRadius: 10 } as const;
 
@@ -316,22 +327,22 @@ function summaryOutcomeHeaderChip(outcome: SummaryOutcome): {
     case "error":
       return {
         label: "Issues",
-        className: "bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/35",
+        className: "bg-rose-500/15 text-rose-200 ring-1 ring-inset ring-rose-400/35",
       };
     case "cancelled":
       return {
         label: "Cancelled",
-        className: "bg-rose-500/15 text-rose-200 ring-1 ring-rose-400/35",
+        className: "bg-rose-500/15 text-rose-200 ring-1 ring-inset ring-rose-400/35",
       };
     case "warning":
       return {
         label: "Warnings",
-        className: "bg-amber-500/15 text-amber-100 ring-1 ring-amber-400/35",
+        className: "bg-amber-500/15 text-amber-100 ring-1 ring-inset ring-amber-400/35",
       };
     default:
       return {
         label: "OK",
-        className: "bg-emerald-500/15 text-emerald-100 ring-1 ring-emerald-400/35",
+        className: "bg-emerald-500/15 text-emerald-100 ring-1 ring-inset ring-emerald-400/35",
       };
   }
 }
@@ -776,8 +787,8 @@ function ActionIcon({
   const src = safeIconSrc(action.iconDataUrl ?? undefined);
   const sm = size === "sm";
   const globeClass = sm
-    ? "h-4 w-4 shrink-0 text-sky-300"
-    : "h-5 w-5 shrink-0 text-sky-300";
+    ? inspectorBrowserTabGlobeIconClass
+    : inspectorBrowserTabGlobeIconMdClass;
   const globeMuted = sm
     ? "h-4 w-4 shrink-0 text-flow-text-muted"
     : "h-9 w-9 shrink-0 text-flow-text-muted";
@@ -785,14 +796,26 @@ function ActionIcon({
     ? "h-7 w-7 shrink-0 rounded-md object-cover ring-1 ring-white/15"
     : "h-10 w-10 shrink-0 rounded-lg object-cover ring-1 ring-white/15";
   if (action.kind === "tab" || action.kind === "system") {
-    return <Globe className={globeClass} strokeWidth={1.5} aria-hidden />;
+    return (
+      <Globe
+        className={globeClass}
+        strokeWidth={inspectorBrowserLinkGlobeStrokeWidth}
+        aria-hidden
+      />
+    );
   }
   if (src) {
     return (
       <img src={src} alt="" className={imgClass} draggable={false} />
     );
   }
-  return <Globe className={globeMuted} strokeWidth={1.5} aria-hidden />;
+  return (
+    <Globe
+      className={globeMuted}
+      strokeWidth={inspectorBrowserLinkGlobeStrokeWidth}
+      aria-hidden
+    />
+  );
 }
 
 function LaunchActionLeadSurface({
@@ -931,7 +954,7 @@ function SubstepList({
   warnSubstepIds?: Set<string> | null;
 }) {
   return (
-    <ul className="mt-2 space-y-1 border-t border-white/[0.08] pt-2">
+    <ul className="mt-1.5 space-y-1 border-t border-white/[0.08] pt-1.5">
       {subs.map((s) => (
         <li key={s.id} className="flex items-center gap-2 text-[11px] text-flow-text-secondary">
           {(warnSubstepIds?.has(s.id) && s.state === "completed") ? (
@@ -972,32 +995,29 @@ function CurrentActionExpandedBody({
   const warnSubstepIds = shouldMarkVerifySubstepAsWarning(action)
     ? new Set(["sub-verify"])
     : null;
+  const pills = visibleLaunchPills(action.pills);
+  const smartTop = pills.length > 0 ? "mt-1" : "mt-0";
   return (
     <div className="border-t border-white/[0.08] pt-2">
-      <div className="min-h-[2.5rem]">
-        {(() => {
-          const pills = visibleLaunchPills(action.pills);
-          return pills.length > 0 ? (
-            <div className="flex flex-wrap gap-1">
-              {pills.map((p) => (
-                <span
-                  key={p}
-                  className="rounded-md bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-100 ring-1 ring-amber-400/25"
-                >
-                  {p}
-                </span>
-              ))}
-            </div>
-          ) : null;
-        })()}
+      <div className="min-w-0">
+        {pills.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {pills.map((p) => (
+              <span
+                key={p}
+                className="rounded-md bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-medium text-amber-100 ring-1 ring-amber-400/25"
+              >
+                {p}
+              </span>
+            ))}
+          </div>
+        ) : null}
         {action.smartDecisions?.[0] ? (
-          <p className="mt-1 flex items-start gap-1.5 text-[11px] leading-snug text-sky-100/90">
+          <p className={`${smartTop} flex items-start gap-1.5 text-[11px] leading-snug text-sky-100/90`}>
             <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0 text-sky-300/90" aria-hidden />
             <span className="min-w-0">{action.smartDecisions[0]}</span>
           </p>
-        ) : (
-          <p className="mt-1 text-[11px] text-flow-text-muted">&nbsp;</p>
-        )}
+        ) : null}
         {extra > 0 ? (
           <p className="mt-0.5 text-[10px] text-flow-text-muted">
             +
@@ -1295,6 +1315,15 @@ export function LaunchCenterInspector({
     [timelineActions],
   );
 
+  /** Per-action outcomes — not `launchedAppCount`, which increments when a spawn/reuse starts (before placement). */
+  const summaryAppsWithoutFailureCount = useMemo(() => {
+    if (!summaryAppActions.length) return null;
+    return summaryAppActions.filter((a) => {
+      const st = resolveAppSummaryStatus(a, runState);
+      return st === "ok" || st === "warn";
+    }).length;
+  }, [summaryAppActions, runState]);
+
   const completedAllList = useMemo(() => {
     if (!timelineActions.length) return [];
     return timelineActions.filter((a) => isTerminalActionState(a.state));
@@ -1306,7 +1335,7 @@ export function LaunchCenterInspector({
 
   if (!hasTimeline) {
     return (
-      <div className="min-h-0 min-w-0">
+      <div className="min-h-0 min-w-0 pr-2 sm:pr-3">
         {summaryMessage?.trim() ? (
           <div
             className={`mb-2 rounded-lg px-2.5 py-2 text-[11px] ring-1 ${
@@ -1320,8 +1349,8 @@ export function LaunchCenterInspector({
             {summaryMessage.trim()}
           </div>
         ) : null}
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
+        <div className="flex min-w-0 items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
             <p className="text-[11px] font-semibold uppercase tracking-wide text-flow-text-muted">
               Launch
             </p>
@@ -1334,11 +1363,13 @@ export function LaunchCenterInspector({
               </p>
             ) : null}
           </div>
-          <LaunchInspectorCancelButton
-            disabled={cancelDisabled}
-            pending={cancelPending}
-            onCancel={onCancel}
-          />
+          <div className="shrink-0">
+            <LaunchInspectorCancelButton
+              disabled={cancelDisabled}
+              pending={cancelPending}
+              onCancel={onCancel}
+            />
+          </div>
         </div>
 
         <div className="mt-3">
@@ -1454,7 +1485,7 @@ export function LaunchCenterInspector({
 
       {showSummaryChrome ? (
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <div className="min-w-0 overflow-visible pr-2 sm:pr-3">
+          <div className="min-w-0 shrink-0 pr-2 sm:pr-3">
             <div className="border-b border-white/10 pb-2">
               <div className="flex min-w-0 items-start justify-between gap-3">
                 <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
@@ -1477,11 +1508,29 @@ export function LaunchCenterInspector({
                   </span>
                 </div>
                 <div className="min-w-0 shrink-0 text-right">
-                  <p className="tabular-nums text-xl font-semibold leading-none text-flow-text-primary">
-                    {progress?.launchedAppCount ?? summaryAppActions.filter((a) => actionLooksLaunched(a, progress, runState)).length}
-                    <span className="text-flow-text-secondary">/{progress?.requestedAppCount ?? summaryAppActions.length}</span>
+                  <p
+                    className="tabular-nums text-xl font-semibold leading-none text-flow-text-primary"
+                    title={
+                      summaryAppsWithoutFailureCount != null
+                        ? "Apps that finished without errors (warnings count as completed)."
+                        : "Apps launched vs requested for this profile."
+                    }
+                  >
+                    {summaryAppsWithoutFailureCount != null
+                      ? summaryAppsWithoutFailureCount
+                      : (progress?.launchedAppCount
+                        ?? summaryAppActions.filter((a) => actionLooksLaunched(a, progress, runState)).length)}
+                    <span className="text-flow-text-secondary">
+                      /
+                      {progress?.requestedAppCount ?? summaryAppActions.length}
+                    </span>
                   </p>
-                  <p className="text-[11px] font-semibold text-flow-text-muted">apps</p>
+                  <p className="text-[11px] font-semibold text-flow-text-muted">
+                    {summaryAppsWithoutFailureCount != null
+                    && summaryAppsWithoutFailureCount < summaryAppActions.length
+                      ? "apps without errors"
+                      : "apps"}
+                  </p>
                 </div>
               </div>
               <p className="mt-1.5 min-w-0 text-sm font-semibold leading-snug text-flow-text-primary">
@@ -1500,8 +1549,10 @@ export function LaunchCenterInspector({
                 {postRunContextLine}
               </p>
             ) : null}
+          </div>
+          <div className="scrollbar-elegant min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-2 sm:pr-3 pt-1">
             {summaryAppActions.length > 0 ? (
-              <ul className="min-w-0 divide-y divide-white/10">
+              <ul className="min-w-0 divide-y divide-white/10 pb-2">
                 {summaryAppActions.map((a) => (
                   <LaunchSummaryAppRow
                     key={a.id}
@@ -1681,28 +1732,26 @@ export function LaunchCenterInspector({
           <>
               {renderBuckets?.current ? (
                 <div
-                  className={`relative isolate mt-3 rounded-xl border border-flow-accent-blue/35 bg-gradient-to-b from-flow-text-primary/[0.07] to-flow-bg-secondary/80 p-3 ring-1 ring-flow-accent-blue/20 ${
+                  className={`relative isolate mt-3 rounded-xl border border-flow-accent-blue/35 bg-gradient-to-b from-flow-text-primary/[0.07] to-flow-bg-secondary/80 p-3 ${
                     renderBuckets.current.state === "running"
-                      ? "shadow-[0_0_24px_rgba(56,189,248,0.12)]"
+                      ? "shadow-[inset_0_0_28px_rgba(56,189,248,0.14)]"
                       : ""
                   }`}
                 >
                   <p className="relative mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-flow-accent-blue/80">
                     Current action
                   </p>
-                  <div className="rounded-[10px] p-px ring-1 ring-inset ring-flow-accent-blue/30 bg-flow-accent-blue/[0.07]">
-                    <div
-                      className={LAUNCH_LEAD_LAYOUT_SHELL_CLASS}
-                      style={LAUNCH_LEAD_LAYOUT_SHELL_STYLE}
-                    >
-                      <LaunchActionLeadSurface
-                        action={renderBuckets.current}
-                        progress={progress}
-                        tabHost={resolveTabHostForAction(renderBuckets.current, tabHostLookup)}
-                      />
-                    </div>
+                  <div
+                    className={LAUNCH_LEAD_INSIDE_CURRENT_CARD_SHELL_CLASS}
+                    style={LAUNCH_LEAD_LAYOUT_SHELL_STYLE}
+                  >
+                    <LaunchActionLeadSurface
+                      action={renderBuckets.current}
+                      progress={progress}
+                      tabHost={resolveTabHostForAction(renderBuckets.current, tabHostLookup)}
+                    />
                   </div>
-                  <div className="relative min-w-0 overflow-hidden">
+                  <div className="relative min-w-0">
                     <CurrentActionExpandedBody
                       action={renderBuckets.current}
                       reducedMotion={reducedMotion}

--- a/src/renderer/layout/components/ProfileSettings.tsx
+++ b/src/renderer/layout/components/ProfileSettings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useMemo, useCallback, useRef, useId } from "react";
-import { X, User, Settings, Zap, Volume2, VolumeX, Clock, Minimize2, Maximize2, RotateCcw, Play, ArrowRight, AlertTriangle, Sparkles, Monitor, Copy, Trash2, Ban, HelpCircle, ChevronUp, ChevronDown, ChevronRight, Download, RefreshCw, Upload, Image } from "lucide-react";
+import { X, User, Settings, Zap, Volume2, VolumeX, Clock, Minimize2, Maximize2, RotateCcw, Play, ArrowRight, AlertTriangle, Sparkles, Monitor, Copy, Trash2, Ban, HelpCircle, ChevronUp, ChevronDown, ChevronRight, Download, RefreshCw, Upload, Image, Globe, ListTree } from "lucide-react";
 import { DeleteConfirmation } from "./profile-settings/DeleteConfirmation";
 import { Switch } from "./ui/switch";
 import { Checkbox } from "./ui/checkbox";
@@ -10,12 +10,13 @@ import { HotkeyRecorderField } from "./HotkeyRecorderField";
 import { FlowTooltip } from "./ui/tooltip";
 import { safeIconSrc } from "../../utils/safeIconSrc";
 import { profileAppPlacementKey } from "../../utils/profileAppPlacementKey";
-import type { FlowProfileKind } from "../../../types/flow-profile";
+import type { BrowserTabLaunchDedupeMode, FlowProfileKind } from "../../../types/flow-profile";
 import {
   FLOW_PROFILE_KINDS,
   FLOW_PROFILE_KIND_LABELS,
   FLOW_PROFILE_VISUAL_ICON_IDS,
   FLOW_PROFILE_VISUAL_ICON_LABELS,
+  normalizeBrowserTabLaunchDedupeMode,
   normalizeProfileKind,
   normalizeProfileVisualIcon,
   normalizeStoredProfileIcon,
@@ -59,6 +60,7 @@ interface ProfileSettingsProps {
     launchOrder?: 'all-at-once' | 'sequential';
     appLaunchOrder?: string[];
     appLaunchDelays?: Record<string, number>;
+    browserTabLaunchDedupe?: BrowserTabLaunchDedupeMode;
     monitors?: any[];
     minimizedApps?: any[];
   } | null;
@@ -212,7 +214,10 @@ function ProfileSettingsInner({
   const [launchOrder, setLaunchOrder] = useState<'all-at-once' | 'sequential'>('sequential');
   const [appLaunchOrder, setAppLaunchOrder] = useState<string[]>([]);
   const [appLaunchDelays, setAppLaunchDelays] = useState<Record<string, number>>({});
-  
+  const [browserTabLaunchDedupe, setBrowserTabLaunchDedupe] = useState<BrowserTabLaunchDedupeMode>(
+    "by_url_and_app",
+  );
+
   // App-specific volume settings
   const [appVolumes, setAppVolumes] = useState<Record<string, number>>({});
   const [applyProfileVolumesOnLaunch, setApplyProfileVolumesOnLaunch] = useState(false);
@@ -307,6 +312,9 @@ function ProfileSettingsInner({
       setLaunchMaximized(profile.launchMaximized || false);
       setLaunchOrder('sequential');
       setAppLaunchDelays(profile.appLaunchDelays || {});
+      setBrowserTabLaunchDedupe(normalizeBrowserTabLaunchDedupeMode(
+        (profile as { browserTabLaunchDedupe?: string }).browserTabLaunchDedupe,
+      ));
       // Applying volumes on launch is not implemented yet; keep UI aligned with current behavior.
       setApplyProfileVolumesOnLaunch(false);
       const currentAppIds = getAllApps().map((app) => String(app.instanceId || app.name)).filter(Boolean);
@@ -464,6 +472,7 @@ function ProfileSettingsInner({
       launchOrder,
       appLaunchOrder,
       appLaunchDelays,
+      browserTabLaunchDedupe,
       ...buildVolumeProfilePayload(),
     }),
     [
@@ -485,6 +494,7 @@ function ProfileSettingsInner({
       launchOrder,
       appLaunchOrder,
       appLaunchDelays,
+      browserTabLaunchDedupe,
       buildVolumeProfilePayload,
     ],
   );
@@ -1398,6 +1408,59 @@ function ProfileSettingsInner({
                     })}
                   </div>
                 </div>
+              </div>
+            </div>
+
+            {/* Browser tabs & links */}
+            <div className="rounded-xl border border-flow-border bg-flow-surface p-4">
+              <div className="mb-4 flex items-center gap-3">
+                <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/15">
+                  <Globe className="h-4 w-4 text-sky-300" />
+                </div>
+                <div>
+                  <h3 className="font-medium text-flow-text-primary">Browser tabs &amp; links</h3>
+                  <p className="text-xs text-flow-text-muted">
+                    Saved URLs on browser apps (and legacy profile links). Does not change file or folder content.
+                  </p>
+                </div>
+              </div>
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => setBrowserTabLaunchDedupe("by_url_and_app")}
+                  className={`flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all ${
+                    browserTabLaunchDedupe === "by_url_and_app"
+                      ? "border-flow-accent-blue bg-flow-accent-blue/10 text-flow-accent-blue"
+                      : "border-flow-border bg-flow-bg-secondary text-flow-text-secondary hover:bg-flow-surface-elevated"
+                  }`}
+                >
+                  <Globe className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium">Open once per URL</div>
+                    <div className="text-xs opacity-80">
+                      Same normalized URL + browser app opens a single tab (default). Duplicates in the list are
+                      skipped at launch.
+                    </div>
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setBrowserTabLaunchDedupe("each_saved_row")}
+                  className={`flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all ${
+                    browserTabLaunchDedupe === "each_saved_row"
+                      ? "border-flow-accent-blue bg-flow-accent-blue/10 text-flow-accent-blue"
+                      : "border-flow-border bg-flow-bg-secondary text-flow-text-secondary hover:bg-flow-surface-elevated"
+                  }`}
+                >
+                  <ListTree className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium">Open every saved row</div>
+                    <div className="text-xs opacity-80">
+                      Each row in your tab list launches separately, even when the URL matches another row. Launch
+                      order follows list order (reordering changes the sequence).
+                    </div>
+                  </div>
+                </button>
               </div>
             </div>
 

--- a/src/renderer/layout/components/SelectedAppDetails.tsx
+++ b/src/renderer/layout/components/SelectedAppDetails.tsx
@@ -27,7 +27,6 @@ import {
   ChevronDown,
   Upload,
   Folder,
-  GripVertical,
   AppWindow,
   HelpCircle,
 } from "lucide-react";
@@ -46,6 +45,7 @@ import {
   countAssociatedNonFolderEntries,
   getAssociatedContentLimitsForHost,
 } from "../utils/associatedContentHostLimits";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 import { useFlowSnackbar } from "./FlowSnackbar";
 import {
   inspectorFieldLabelClass,
@@ -65,6 +65,9 @@ import {
   inspectorMenuItemClass,
   inspectorMenuPanelClass,
   inspectorMenuTriggerClass,
+  inspectorBrowserLinkGlobeStrokeWidth,
+  inspectorBrowserTabGlobeEmptyIconClass,
+  inspectorBrowserTabGlobeIconClass,
   inspectorSectionLabelClass,
   inspectorSectionLabelTextClass,
   inspectorTextLinkClass,
@@ -75,13 +78,6 @@ const isRenderableIconComponent = (value: unknown): value is LucideIcon => {
   if (!value || typeof value !== "object") return false;
   return ("$$typeof" in (value as Record<string, unknown>))
     || ("render" in (value as Record<string, unknown>));
-};
-
-/** Use text/plain so Electron/Chromium reliably carries drag payload. */
-const dragTabPayload = (index: number) => `flowswitch-tab:${index}`;
-const parseTabDragPayload = (raw: string) => {
-  const m = /^flowswitch-tab:(\d+)$/.exec(String(raw || "").trim());
-  return m ? Number(m[1]) : NaN;
 };
 
 const associationBaseName = (p: string) => {
@@ -351,7 +347,10 @@ export function SelectedAppDetails({
   }, [selectedApp, pushSnackbar]);
 
   const handlePickCatalogLaunchExeOverride = useCallback(async () => {
-    if (!selectedApp || selectedApp.type !== "app") return;
+    if (
+      !selectedApp
+      || (selectedApp.type !== "app" && selectedApp.type !== "browser")
+    ) return;
     if (!window.electron?.pickCatalogLaunchExeOverride) {
       pushSnackbar("File picker is not available.", { variant: "error" });
       return;
@@ -378,7 +377,10 @@ export function SelectedAppDetails({
   }, [selectedApp, onCatalogLaunchExeChanged, pushSnackbar]);
 
   const handleClearCatalogLaunchExeOverride = useCallback(async () => {
-    if (!selectedApp || selectedApp.type !== "app") return;
+    if (
+      !selectedApp
+      || (selectedApp.type !== "app" && selectedApp.type !== "browser")
+    ) return;
     if (!window.electron?.clearCatalogLaunchExeOverride) {
       pushSnackbar("Clear override is not available.", { variant: "error" });
       return;
@@ -442,6 +444,14 @@ export function SelectedAppDetails({
 
   // Get current data
   const currentData = data;
+
+  const profileAppSuggestsWebBrowser =
+    type === "browser"
+    || inferIsWebBrowserFromInstalledApp({
+      name: data.name,
+      executablePath:
+        typeof data.executablePath === "string" ? data.executablePath : null,
+    });
 
   const installedAppTypeFieldId = `installed-app-library-type-${source}-${String(
     monitorId ?? "",
@@ -876,7 +886,7 @@ export function SelectedAppDetails({
             ) : null}
           </div>
 
-          {showInspectorTestLaunch || type === "app" ? (
+          {showInspectorTestLaunch || type === "app" || type === "browser" ? (
             <div className="flex min-w-0 flex-wrap items-center gap-2 rounded-lg border border-flow-border/45 bg-flow-bg-primary/[0.07] px-2.5 py-2">
               {showInspectorTestLaunch ? (
                 <button
@@ -891,7 +901,7 @@ export function SelectedAppDetails({
                   Test launch
                 </button>
               ) : null}
-              {type === "app" ? (
+              {(type === "app" || type === "browser") ? (
                 <>
                   <FlowTooltip label="Opens the Windows file picker to choose a different .exe. Confirm to save it for this catalog entry.">
                     <button
@@ -1083,13 +1093,7 @@ export function SelectedAppDetails({
 
   // Get browser tabs for this specific app/browser
   const getAppBrowserTabs = () => {
-    if (type !== 'browser' && !data.name?.toLowerCase().includes('chrome') && !data.name?.toLowerCase().includes('browser') && !data.name?.toLowerCase().includes('firefox') && !data.name?.toLowerCase().includes('safari') && !data.name?.toLowerCase().includes('edge')) {
-      return [];
-    }
-
-    const isBrowser = type === 'browser' || data.name?.toLowerCase().includes('chrome') || data.name?.toLowerCase().includes('browser') || data.name?.toLowerCase().includes('firefox') || data.name?.toLowerCase().includes('safari') || data.name?.toLowerCase().includes('edge');
-    
-    if (!isBrowser) return [];
+    if (!profileAppSuggestsWebBrowser) return [];
 
     // Get tabs for this specific browser app
     if (source === 'monitor' && monitorId) {
@@ -1128,9 +1132,7 @@ export function SelectedAppDetails({
 
     if (contentType === 'link') {
       // Add as browser tab if this is a browser app
-      const isBrowser = type === 'browser' || data.name?.toLowerCase().includes('chrome') || data.name?.toLowerCase().includes('browser') || data.name?.toLowerCase().includes('firefox') || data.name?.toLowerCase().includes('safari') || data.name?.toLowerCase().includes('edge');
-      
-      if (isBrowser) {
+      if (profileAppSuggestsWebBrowser) {
         if (source === 'monitor' && onAddBrowserTab) {
           // For monitor apps, add to global browserTabs array
           const newTab = {
@@ -1233,48 +1235,6 @@ export function SelectedAppDetails({
     const currentFiles = currentData.associatedFiles || [];
     const updatedFiles = currentFiles.filter((_: any, index: number) => index !== fileIndex);
     onUpdateAssociatedFiles(updatedFiles);
-  };
-
-  const tabMatchesThisApp = (t: {
-    monitorId?: string;
-    browser?: string;
-    appInstanceId?: string;
-  }) => (
-    source === "monitor"
-    && Boolean(monitorId)
-    && t.monitorId === monitorId
-    && t.browser === data.name
-    && t.appInstanceId === data.instanceId
-  );
-
-  const reorderBrowserTabs = (fromIndex: number, toIndex: number) => {
-    if (fromIndex === toIndex) return;
-    if (source === "monitor" && onUpdateBrowserTabs) {
-      const mineInOrder = browserTabs.filter(tabMatchesThisApp);
-      if (
-        fromIndex < 0
-        || toIndex < 0
-        || fromIndex >= mineInOrder.length
-        || toIndex >= mineInOrder.length
-      ) return;
-      const reordered = [...mineInOrder];
-      const [item] = reordered.splice(fromIndex, 1);
-      reordered.splice(toIndex, 0, item);
-      let i = 0;
-      const newGlobal = browserTabs.map((t) => (tabMatchesThisApp(t) ? reordered[i++] : t));
-      onUpdateBrowserTabs(newGlobal);
-    } else if (source === "minimized" && onUpdateApp) {
-      const tabs = [...(data.browserTabs || [])];
-      if (
-        fromIndex < 0
-        || toIndex < 0
-        || fromIndex >= tabs.length
-        || toIndex >= tabs.length
-      ) return;
-      const [item] = tabs.splice(fromIndex, 1);
-      tabs.splice(toIndex, 0, item);
-      onUpdateApp({ browserTabs: tabs });
-    }
   };
 
   const associatedRowDisplayName = (file: any) => {
@@ -1421,7 +1381,6 @@ export function SelectedAppDetails({
         </div>
       );
     }
-    const isBrowser = type === 'browser' || data.name?.toLowerCase().includes('chrome') || data.name?.toLowerCase().includes('browser') || data.name?.toLowerCase().includes('firefox') || data.name?.toLowerCase().includes('safari') || data.name?.toLowerCase().includes('edge');
     const appBrowserTabs = getAppBrowserTabs();
 
     const assocLimits = getAssociatedContentLimitsForHost(data.name);
@@ -1474,7 +1433,7 @@ export function SelectedAppDetails({
         </div>
 
         {/* Browser Tabs (for browser apps) */}
-        {isBrowser && (
+        {profileAppSuggestsWebBrowser && (
           <div className="max-h-48 shrink-0 overflow-hidden">
             <div className="mb-3 flex min-w-0 items-center justify-between gap-2">
               <span className={`${inspectorSectionLabelTextClass} min-w-0`}>
@@ -1490,50 +1449,31 @@ export function SelectedAppDetails({
                 {appBrowserTabs.map((tab: any, index: number) => (
                   <div
                     key={tab.id || `tab-${index}-${tab.url}`}
-                    onDragOver={(e) => {
-                      e.preventDefault();
-                      e.dataTransfer.dropEffect = "move";
-                    }}
-                    onDrop={(e) => {
-                      e.preventDefault();
-                      const from = parseTabDragPayload(e.dataTransfer.getData("text/plain"));
-                      if (Number.isNaN(from)) return;
-                      reorderBrowserTabs(from, index);
-                    }}
                     className="group flex min-w-0 items-center gap-2 rounded-lg border border-flow-border bg-flow-surface p-3"
                   >
-                    <FlowTooltip label="Drag to reorder">
-                      <span
-                        draggable
-                        onDragStart={(e) => {
-                          e.stopPropagation();
-                          e.dataTransfer.setData("text/plain", dragTabPayload(index));
-                          e.dataTransfer.effectAllowed = "move";
-                        }}
-                        className="shrink-0 cursor-grab touch-none text-flow-text-muted active:cursor-grabbing"
-                        aria-hidden
-                      >
-                        <GripVertical className="h-4 w-4" />
-                      </span>
-                    </FlowTooltip>
-                    <Globe className="h-4 w-4 shrink-0 text-flow-text-muted" />
+                    <Globe
+                      className={inspectorBrowserTabGlobeIconClass}
+                      strokeWidth={inspectorBrowserLinkGlobeStrokeWidth}
+                      aria-hidden
+                    />
                     <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium text-flow-text-primary truncate">{tab.name}</div>
                       <div className="text-xs text-flow-text-muted truncate">{tab.url}</div>
                     </div>
                     <div className="flex shrink-0 items-center gap-1">
-                      {tab.isActive && <div className="h-2 w-2 shrink-0 rounded-full bg-flow-accent-blue" />}
                       <button
                         type="button"
                         onClick={() => window.open(tab.url, "_blank", "noopener,noreferrer")}
                         className="shrink-0 rounded-lg p-1.5 text-flow-text-muted transition-colors hover:text-flow-accent-blue opacity-0 group-hover:opacity-100"
+                        title="Open in new tab"
                       >
                         <ExternalLink className="h-3 w-3" />
                       </button>
                       <button
                         type="button"
                         onClick={() => removeBrowserTab(index)}
-                        className="shrink-0 rounded-lg p-1.5 text-flow-text-muted transition-colors hover:text-flow-accent-red opacity-0 group-hover:opacity-100"
+                        className="shrink-0 rounded-lg p-1.5 text-flow-text-muted transition-colors hover:text-flow-accent-red"
+                        title="Remove tab"
                       >
                         <Trash2 className="h-3 w-3" />
                       </button>
@@ -1543,7 +1483,11 @@ export function SelectedAppDetails({
               </div>
             ) : (
               <div className="p-6 text-center bg-flow-surface rounded-lg border border-flow-border">
-                <Globe className="w-8 h-8 text-flow-text-muted mx-auto mb-2" />
+                <Globe
+                  className={inspectorBrowserTabGlobeEmptyIconClass}
+                  strokeWidth={inspectorBrowserLinkGlobeStrokeWidth}
+                  aria-hidden
+                />
                 <p className="text-sm text-flow-text-muted">No tabs configured</p>
                 <p className="text-xs text-flow-text-muted mt-1">Paste URLs above to add browser tabs</p>
               </div>
@@ -1551,11 +1495,11 @@ export function SelectedAppDetails({
           </div>
         )}
 
-        {/* Associated Content (fills remaining tab height) */}
+        {/* Files section (fills remaining tab height) */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2">
           <div className="grid min-w-0 shrink-0 grid-cols-1 gap-x-2 gap-y-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
             <span className={`${inspectorSectionLabelTextClass} min-w-0`}>
-              Associated content
+              Files
             </span>
             {onUpdateAssociatedFiles && hasDesktopPicker ? (
               <div
@@ -1648,7 +1592,7 @@ export function SelectedAppDetails({
                       type="button"
                       onClick={() => removeAssociatedFile(index)}
                       className="shrink-0 rounded-lg p-1.5 text-flow-text-muted transition-colors hover:text-flow-accent-red"
-                      title="Remove associated content"
+                      title="Remove file"
                     >
                       <Trash2 className="h-3 w-3" />
                     </button>
@@ -1659,7 +1603,7 @@ export function SelectedAppDetails({
           ) : (
             <div className="flex min-h-0 flex-1 flex-col items-center justify-center rounded-lg border border-flow-border bg-flow-surface p-6 text-center">
               <FileText className="mx-auto mb-2 h-8 w-8 text-flow-text-muted" />
-              <p className="text-sm text-flow-text-muted">No associated content for this app</p>
+              <p className="text-sm text-flow-text-muted">No files attached to this app</p>
               <p className="mt-1 text-xs text-flow-text-muted">
                 Use Add → files or folder (same as Content sidebar), or paste a path or URL above.
               </p>

--- a/src/renderer/layout/components/inspectorStyles.ts
+++ b/src/renderer/layout/components/inspectorStyles.ts
@@ -17,6 +17,23 @@ export const inspectorSectionLabelTextClass =
 /** Bottom margin for labels not wrapped in a `space-y-*` stack (e.g. Launch tab). */
 export const inspectorSectionLabelClass = `${inspectorSectionLabelTextClass} mb-2`;
 
+/**
+ * Lucide `Globe` for browser tab / URL rows — matches Launch timeline (`text-sky-300`, stroke {@link inspectorBrowserLinkGlobeStrokeWidth}).
+ */
+export const inspectorBrowserLinkGlobeStrokeWidth = 1.5;
+
+/** Inspect sidebar: saved browser tab rows (compact). */
+export const inspectorBrowserTabGlobeIconClass =
+  "h-4 w-4 shrink-0 text-sky-300";
+
+/** Launch timeline / summary primary column (slightly larger Globe). */
+export const inspectorBrowserTabGlobeIconMdClass =
+  "h-5 w-5 shrink-0 text-sky-300";
+
+/** Empty-state hero Globe in Browser tabs section. */
+export const inspectorBrowserTabGlobeEmptyIconClass =
+  "mx-auto mb-2 h-8 w-8 shrink-0 text-sky-300";
+
 /** Top rule + spacing before destructive-only block. */
 export const inspectorDangerZoneClass =
   "mt-4 border-t border-flow-border/50 pt-4";

--- a/src/renderer/layout/hooks/useLayoutCustomDrag.ts
+++ b/src/renderer/layout/hooks/useLayoutCustomDrag.ts
@@ -31,6 +31,7 @@ import { resolveDropTargetFromEventStack } from "../utils/layoutHitTesting";
 import type { ContentFolder } from "../components/ContentManager";
 import type { InstalledApp } from "../../hooks/useInstalledApps";
 import { resolveHostExecutableForCatalogLabel } from "../utils/catalogHostResolve";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 /** Sidebar drag-drop for library folders (wired from MainLayout; uses global `contentLibrary`). */
 export type LibraryFolderPlacementActions = {
@@ -205,13 +206,13 @@ export function useLayoutCustomDrag({
           const targetApp = monitor?.apps[appIndex];
 
           const isLink = dragData.contentType === "link" || (dragData.type === "content" && dragData.url);
-          const isBrowserApp = targetApp && (
-            targetApp.name?.toLowerCase().includes("chrome")
-            || targetApp.name?.toLowerCase().includes("browser")
-            || targetApp.name?.toLowerCase().includes("firefox")
-            || targetApp.name?.toLowerCase().includes("safari")
-            || targetApp.name?.toLowerCase().includes("edge")
-          );
+          const isBrowserApp = Boolean(targetApp) && inferIsWebBrowserFromInstalledApp({
+            name: targetApp.name,
+            executablePath:
+              typeof targetApp.executablePath === "string"
+                ? targetApp.executablePath
+                : null,
+          });
 
           if (isLink && isBrowserApp) {
             console.log("🌐 ADDING LINK AS BROWSER TAB TO EXISTING BROWSER:", {

--- a/src/renderer/layout/hooks/useMainLayoutProfileMutations.ts
+++ b/src/renderer/layout/hooks/useMainLayoutProfileMutations.ts
@@ -21,6 +21,7 @@ import {
   snapZoneForApp,
 } from "../utils/monitorLayoutStacking";
 import { getSnapZonesForMonitor } from "../utils/monitorSnapZones";
+import { inferIsWebBrowserFromInstalledApp } from "../../utils/installedWebBrowserInference";
 
 function buildAppsWithMergedInsert(
   apps: any[],
@@ -481,12 +482,13 @@ export function useMainLayoutProfileMutations({
         const appToMove = monitor.apps[appIndex];
 
         // Check if this is a browser app
-        const isBrowser =
-          appToMove.name.toLowerCase().includes("chrome") ||
-          appToMove.name.toLowerCase().includes("browser") ||
-          appToMove.name.toLowerCase().includes("firefox") ||
-          appToMove.name.toLowerCase().includes("safari") ||
-          appToMove.name.toLowerCase().includes("edge");
+        const isBrowser = inferIsWebBrowserFromInstalledApp({
+          name: appToMove.name,
+          executablePath:
+            typeof appToMove.executablePath === "string"
+              ? appToMove.executablePath
+              : null,
+        });
 
         // Collect associated browser tabs if this is a browser
         let associatedTabs: {
@@ -682,11 +684,13 @@ export function useMainLayoutProfileMutations({
         let updatedBrowserTabs = profile.browserTabs || [];
         for (const appToMove of appsToMove) {
           const isBrowser =
-            appToMove.name.toLowerCase().includes("chrome") ||
-            appToMove.name.toLowerCase().includes("browser") ||
-            appToMove.name.toLowerCase().includes("firefox") ||
-            appToMove.name.toLowerCase().includes("safari") ||
-            appToMove.name.toLowerCase().includes("edge");
+            inferIsWebBrowserFromInstalledApp({
+              name: appToMove.name,
+              executablePath:
+                typeof appToMove.executablePath === "string"
+                  ? appToMove.executablePath
+                  : null,
+            });
           if (!isBrowser) continue;
           updatedBrowserTabs = updatedBrowserTabs.map((tab) => {
             if (
@@ -998,19 +1002,13 @@ export function useMainLayoutProfileMutations({
       selectedApp.monitorId
     ) {
       const isBrowser =
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("chrome") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("browser") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("firefox") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("safari") ||
-        selectedApp.data.name?.toLowerCase().includes("edge");
+        inferIsWebBrowserFromInstalledApp({
+          name: selectedApp.data.name,
+          executablePath:
+            typeof selectedApp.data.executablePath === "string"
+              ? selectedApp.data.executablePath
+              : null,
+        });
 
       if (isBrowser) {
         // NEW: Use instance ID for precise matching
@@ -1063,19 +1061,13 @@ export function useMainLayoutProfileMutations({
       selectedApp.monitorId === tab.monitorId
     ) {
       const isBrowser =
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("chrome") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("browser") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("firefox") ||
-        selectedApp.data.name
-          ?.toLowerCase()
-          .includes("safari") ||
-        selectedApp.data.name?.toLowerCase().includes("edge");
+        inferIsWebBrowserFromInstalledApp({
+          name: selectedApp.data.name,
+          executablePath:
+            typeof selectedApp.data.executablePath === "string"
+              ? selectedApp.data.executablePath
+              : null,
+        });
 
       // NEW: Match both browser name AND instance ID
       if (

--- a/src/renderer/layout/hooks/useProfileLaunch.ts
+++ b/src/renderer/layout/hooks/useProfileLaunch.ts
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { FlowProfile, ProfileSavePayload } from "../../../types/flow-profile";
 import type { LaunchFeedbackState } from "./useLaunchFeedback";
+import type { LargeProfileLaunchConfirmPayload } from "../components/LargeProfileLaunchConfirm";
 
 type UseProfileLaunchOptions = {
   profiles: FlowProfile[];
@@ -17,7 +18,12 @@ type UseProfileLaunchOptions = {
   setIsLaunching: Dispatch<SetStateAction<boolean>>;
   setLaunchFeedback: Dispatch<SetStateAction<LaunchFeedbackState>>;
   launchFeedbackTimeoutRef: MutableRefObject<number | null>;
-  /** Fired as soon as the user starts a launch (before save + IPC). Use to clear stale run ids. */
+  /**
+   * When main reports launch weight at or above the soft threshold, await this before
+   * calling `launchProfile`. Return false to cancel. Omit to skip the soft-warning step.
+   */
+  confirmLargeLaunch?: (payload: LargeProfileLaunchConfirmPayload) => Promise<boolean>;
+  /** Fired when launch is committed (after save, weight check, and optional soft confirm). */
   onLaunchPreparing?: (profileId: string) => void;
   onLaunchStarted?: (profileId: string, runId: string) => void;
   /** Called when a launch finishes successfully, with wall-clock seconds for this run. */
@@ -34,6 +40,7 @@ export function useProfileLaunch({
   setIsLaunching,
   setLaunchFeedback,
   launchFeedbackTimeoutRef,
+  confirmLargeLaunch,
   onLaunchPreparing,
   onLaunchStarted,
   onLaunchCompletedDuration,
@@ -145,10 +152,9 @@ export function useProfileLaunch({
       }
 
       setIsLaunching(true);
-      onLaunchPreparing?.(launchProfileId);
       setLaunchFeedback({
         status: "in-progress",
-        message: "Launching profile...",
+        message: "Preparing launch…",
         progress: null,
       });
 
@@ -182,6 +188,114 @@ export function useProfileLaunch({
           return;
         }
 
+        if (window.electron?.getProfileLaunchWeight) {
+          try {
+            const weightData = await window.electron.getProfileLaunchWeight(
+              launchProfileId,
+            );
+            if (
+              weightData?.ok
+              && typeof weightData.totalUnits === "number"
+              && weightData.limits
+            ) {
+              const { totalUnits, limits, breakdown } = weightData;
+              const hardMax = Number(limits.hardMax);
+              const softWarn = Number(limits.softWarn);
+              if (Number.isFinite(hardMax) && hardMax > 0 && totalUnits > hardMax) {
+                setLaunchFeedback({
+                  status: "error",
+                  message:
+                    `This profile exceeds the launch size limit (${totalUnits} units; max ${hardMax}). `
+                    + "Remove some apps or browser tabs, or split the profile.",
+                  progress: null,
+                });
+                setIsLaunching(false);
+                launchFeedbackTimeoutRef.current = window.setTimeout(() => {
+                  setLaunchFeedback({
+                    status: "idle",
+                    message: "",
+                    progress: null,
+                  });
+                  launchFeedbackTimeoutRef.current = null;
+                }, 7000);
+                return;
+              }
+              const apps = Number(breakdown?.dedupedAppLaunches ?? 0);
+              const tabs = Number(breakdown?.dedupedBrowserTabs ?? 0);
+              const skippedLaunchCount =
+                typeof weightData?.skippedLaunchTargets?.count === "number"
+                  ? weightData.skippedLaunchTargets.count
+                  : 0;
+              const skippedLaunchSample = Array.isArray(
+                weightData?.skippedLaunchTargets?.sample,
+              )
+                ? weightData.skippedLaunchTargets.sample
+                : [];
+              const preflight = weightData?.preflight as
+                | {
+                    layoutAppSlots?: number;
+                    missingLaunchTargetSkips?: number;
+                    launchableAppLaunches?: number;
+                  }
+                | undefined;
+              if (apps === 0 && tabs === 0) {
+                setLaunchFeedback({
+                  status: "error",
+                  message:
+                    "Nothing to launch: every app tile is missing a path or URL, and there are no browser tabs. "
+                    + "Fix paths in Inspect → Overview or add tabs.",
+                  progress: null,
+                });
+                setIsLaunching(false);
+                scheduleIdleReset();
+                return;
+              }
+              if (
+                confirmLargeLaunch
+                && Number.isFinite(softWarn)
+                && softWarn > 0
+                && totalUnits >= softWarn
+              ) {
+                const confirmed = await confirmLargeLaunch({
+                  profileName: String(currentProfile.name || "").trim() || "This profile",
+                  totalUnits,
+                  appCount: apps,
+                  tabCount: tabs,
+                  softWarn,
+                  hardMax,
+                  skippedLaunchCount,
+                  skippedLaunchSample,
+                  preflightLayoutAppSlots: preflight?.layoutAppSlots,
+                  preflightMissingLaunchTargets: preflight?.missingLaunchTargetSkips,
+                });
+                if (!confirmed) {
+                  setIsLaunching(false);
+                  setLaunchFeedback({
+                    status: "warning",
+                    message: "Launch cancelled.",
+                    progress: null,
+                  });
+                  scheduleIdleReset();
+                  return;
+                }
+              }
+            }
+          } catch (weightErr) {
+            console.warn("[launch] getProfileLaunchWeight failed:", weightErr);
+          }
+        }
+
+        if (pendingLaunchAbortRef.current) {
+          return;
+        }
+
+        onLaunchPreparing?.(launchProfileId);
+        setLaunchFeedback({
+          status: "in-progress",
+          message: "Launching profile…",
+          progress: null,
+        });
+
         const launchResult = await window.electron.launchProfile(
           launchProfileId,
           { fireAndForget: true, launchOrigin: "renderer" },
@@ -192,8 +306,29 @@ export function useProfileLaunch({
         }
 
         if (!launchResult?.ok) {
-          const errorMessage = launchResult?.error
+          let errorMessage = launchResult?.error
             || "Could not launch this profile. Check app executable paths in app details.";
+          if (
+            launchResult?.code === "LAUNCH_TOO_LARGE"
+            && launchResult?.details
+            && typeof launchResult.details === "object"
+          ) {
+            const d = launchResult.details as {
+              totalUnits?: number;
+              limits?: { hardMax?: number };
+            };
+            const total = d.totalUnits;
+            const max = d.limits?.hardMax;
+            if (typeof total === "number" && typeof max === "number") {
+              errorMessage =
+                `This profile exceeds the launch size limit (${total} units; max ${max}). `
+                + "Remove some apps or browser tabs, or split the profile.";
+            }
+          } else if (launchResult?.code === "LAUNCH_NOTHING_TO_RUN") {
+            errorMessage =
+              String(launchResult?.error || "").trim()
+              || "Nothing to launch: fix app paths or add browser tabs.";
+          }
           setLaunchFeedback({
             status: "error",
             message: errorMessage,
@@ -260,8 +395,10 @@ export function useProfileLaunch({
     setIsLaunching,
     setLaunchFeedback,
     launchFeedbackTimeoutRef,
+    confirmLargeLaunch,
     onLaunchPreparing,
     onLaunchStarted,
+    scheduleIdleReset,
   ]);
 
   return {

--- a/src/renderer/layout/utils/buildNewProfile.ts
+++ b/src/renderer/layout/utils/buildNewProfile.ts
@@ -352,6 +352,7 @@ export function buildEmptyFlowProfile(args: {
     launchOrder: "sequential",
     appLaunchOrder: [],
     appLaunchDelays: {},
+    browserTabLaunchDedupe: "by_url_and_app",
     monitors: sourceMonitors.map((monitor, monitorIndex) => ({
       id: monitor.id,
       name: monitor.name,
@@ -429,6 +430,7 @@ export function buildMemoryFlowProfileFromCapture(
     launchOrder: "sequential",
     appLaunchOrder: [],
     appLaunchDelays: {},
+    browserTabLaunchDedupe: "by_url_and_app",
     monitors: orderedMonitors.map((monitor) => ({
       id: monitor.id,
       name: monitor.name,

--- a/src/renderer/utils/installedWebBrowserInference.test.ts
+++ b/src/renderer/utils/installedWebBrowserInference.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { inferIsWebBrowserFromInstalledApp } from "./installedWebBrowserInference";
+
+test("inferIsWebBrowserFromInstalledApp matches exe basenames", () => {
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({
+      name: "Irrelevant",
+      executablePath:
+        "C:\\Program Files\\BraveSoftware\\Brave\\Application\\Brave.exe",
+    }),
+    true,
+  );
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({
+      name: "Irrelevant",
+      executablePath: "C:\\Users\\Me\\vivaldi.exe",
+    }),
+    true,
+  );
+});
+
+test("inferIsWebBrowserFromInstalledApp matches common display names", () => {
+  assert.equal(inferIsWebBrowserFromInstalledApp({ name: "Brave" }), true);
+  assert.equal(inferIsWebBrowserFromInstalledApp({ name: "Zen Browser" }), true);
+  assert.equal(inferIsWebBrowserFromInstalledApp({ name: "Opera GX" }), true);
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({ name: "Google Chrome Canary" }),
+    true,
+  );
+  assert.equal(inferIsWebBrowserFromInstalledApp({ name: "Arc" }), true);
+});
+
+test("inferIsWebBrowserFromInstalledApp ignores non-.exe basename leaves", () => {
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({
+      name: "",
+      executablePath: "C:\\no\\extension\\chrome",
+    }),
+    false,
+  );
+});
+
+test("inferIsWebBrowserFromInstalledApp rejects unrelated apps", () => {
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({
+      name: "Calculator",
+      executablePath: "C:\\Windows\\System32\\calc.exe",
+    }),
+    false,
+  );
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({
+      name: "Notepad",
+      executablePath: "C:\\Windows\\notepad.exe",
+    }),
+    false,
+  );
+});
+
+test("inferIsWebBrowserFromInstalledApp treats *browser* in title as legacy heuristic", () => {
+  assert.equal(
+    inferIsWebBrowserFromInstalledApp({ name: "Acme Weird Browser Nightly" }),
+    true,
+  );
+});

--- a/src/renderer/utils/installedWebBrowserInference.ts
+++ b/src/renderer/utils/installedWebBrowserInference.ts
@@ -1,0 +1,131 @@
+/**
+ * Heuristic classification of Windows installed apps FlowSwitch treats as **web browsers**
+ * for tab association, inspector type, drag updates, etc.
+ *
+ * Strategy (in order): known `.exe` basenames (~top desktop browsers + common forks/alternatives),
+ * then recognizable **display-name** phrases, then guarded **whole-word** product tokens,
+ * then a narrow `"... browser"` shortcut-title fallback aligned with legacy behavior.
+ *
+ * **Rough product coverage (~20+)**: Chrome, Edge, Firefox, Brave, Opera & Opera GX, Vivaldi,
+ * Chromium, Arc, DuckDuckGo Privacy Browser, Yandex Browser, Zen Browser, Sigma Browser,
+ * Waterfox, LibreWolf, Floorp, Pale Moon, SeaMonkey, Tor Browser (title), Slimjet, Maxthon,
+ * Torch, Epic Privacy Browser, Avast / AVG Secure Browser, CCleaner Browser, Safari, Internet Explorer.
+ *
+ * Windows does not expose a reliable OS-level “this is a web browser” flag for arbitrary Start
+ * Menu items; maintain this list deliberately when onboarding new major browsers.
+ */
+
+export type InstalledWebBrowserInferenceInput = {
+  name?: string | null;
+  executablePath?: string | null;
+};
+
+/** `.exe` basenames only (already lowercased; include trailing `.exe`). */
+const KNOWN_BROWSER_EXE_BASENAMES = new Set<string>([
+  // Chromium / Blink / evergreen (desktop share leaders)
+  "chrome.exe",
+  "msedge.exe",
+  "brave.exe",
+  "opera.exe",
+  "opera_gx.exe",
+  "vivaldi.exe",
+  "chromium.exe",
+  "arc.exe",
+  "duckduckgo.exe",
+  // Gecko / forks
+  "firefox.exe",
+  "waterfox.exe",
+  "librewolf.exe",
+  "floorp.exe",
+  "palemoon.exe",
+  "seamonkey.exe",
+  "zen.exe",
+  // Blink / Chromium regional / niche with distinct exes on Windows
+  "yandexbrowser.exe",
+  "yandex_browser.exe",
+  "slimjet.exe",
+  "maxthon.exe",
+  "torch.exe",
+  // Privacy / bundled first-party Blink shells
+  "epic.exe",
+  "avastbrowser.exe",
+  "ccleanerbrowser.exe",
+  // WebKit legacy on Windows (rare)
+  "safari.exe",
+]);
+
+/**
+ * Multi-word / distinctive substrings matched against the **display name** (lowercase).
+ * Longest matches first reduces accidental partial hits.
+ */
+const TITLE_PHRASE_SUBSTRINGS: string[] = [
+  "avast secure browser",
+  "avg secure browser",
+  "ccleaner browser",
+  "microsoft edge",
+  "internet explorer",
+  "mozilla firefox",
+  "google chrome",
+  "opera gx",
+  "duckduckgo",
+  "duck duck go",
+  "tor browser",
+  "arc browser",
+  "vivaldi",
+  "yandex browser",
+  "zen browser",
+  "sigma browser",
+  "librewolf",
+  "waterfox",
+  "pale moon",
+  "sea monkey",
+  "dragon browser",
+  "slimjet",
+  "maxthon",
+].sort((a, b) => b.length - a.length);
+
+/** Single-token product cues (whole-word match on normalized display name). */
+const TITLE_BOUNDARY_HINTS =
+  /\b(arc|brave|opera|vivaldi|chromium|chrome|firefox|edge|safari|msedge|seamonkey|palemoon|floorp|librewolf|waterfox|epic|slimjet|maxthon|torch|zen|yandex)\b/i;
+
+function normalizeExeBasename(executablePath: string | undefined | null): string | null {
+  const raw = String(executablePath ?? "").trim().replace(/\//g, "\\");
+  if (!raw) return null;
+  const slash = raw.replace(/[/\\]+$/, "").split(/[/\\]/);
+  const leaf = slash[slash.length - 1] ?? "";
+  const lower = leaf.trim().toLowerCase();
+  if (!lower.endsWith(".exe")) return null;
+  return lower;
+}
+
+function normalizeTitle(raw: string | undefined | null): string {
+  return String(raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * `true` when this catalog / layout snapshot should behave as a FlowSwitch **browser** host
+ * (browser tab wiring, inspector `browser` typing, tab moves across monitors).
+ */
+export function inferIsWebBrowserFromInstalledApp(
+  input: InstalledWebBrowserInferenceInput,
+): boolean {
+  const exeLeaf = normalizeExeBasename(input.executablePath ?? null);
+  if (exeLeaf && KNOWN_BROWSER_EXE_BASENAMES.has(exeLeaf)) return true;
+
+  const title = normalizeTitle(input.name ?? null);
+  if (!title) return false;
+
+  for (const phrase of TITLE_PHRASE_SUBSTRINGS) {
+    if (phrase && title.includes(phrase)) return true;
+  }
+
+  if (TITLE_BOUNDARY_HINTS.test(title)) return true;
+
+  // Legacy catch-all for Start Menu shortcuts like "Brave Browser", "Tor Browser".
+  if (/\bbrowser\b/.test(title)) return true;
+
+  return false;
+}

--- a/src/shared/launch-weight-limits.js
+++ b/src/shared/launch-weight-limits.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Single source of truth for profile launch "weight" thresholds (main + renderer).
+ * See docs/superpowers/specs/large-profile-launch-guardrails.md
+ */
+
+/** One unit per deduped app launch row (same notion as launch pipeline). */
+const LAUNCH_WEIGHT_PER_APP_LAUNCH = 1;
+
+/** One unit per deduped browser tab URL (profile.browserTabs + legacy action URLs). */
+const LAUNCH_WEIGHT_PER_BROWSER_TAB = 1;
+
+/**
+ * Soft threshold: renderer may show a confirm dialog before IPC (Phase 2).
+ * Main process does not block on this alone.
+ */
+const LAUNCH_WEIGHT_SOFT_WARN_UNITS = 32;
+
+/**
+ * Hard ceiling: main rejects launch before starting a run when totalUnits exceeds this.
+ * Tune after dogfood; keep in sync with spec revision history when changed.
+ */
+const LAUNCH_WEIGHT_HARD_MAX_UNITS = 100;
+
+module.exports = {
+  LAUNCH_WEIGHT_PER_APP_LAUNCH,
+  LAUNCH_WEIGHT_PER_BROWSER_TAB,
+  LAUNCH_WEIGHT_SOFT_WARN_UNITS,
+  LAUNCH_WEIGHT_HARD_MAX_UNITS,
+};

--- a/src/types/flow-profile.ts
+++ b/src/types/flow-profile.ts
@@ -14,6 +14,16 @@ export const FLOW_PROFILE_KINDS = [
 
 export type FlowProfileKind = (typeof FLOW_PROFILE_KINDS)[number];
 
+/** How saved browser tab rows map to launch actions (see Profile → Behavior). */
+export const BROWSER_TAB_LAUNCH_DEDUPE_MODES = ["by_url_and_app", "each_saved_row"] as const;
+export type BrowserTabLaunchDedupeMode = (typeof BROWSER_TAB_LAUNCH_DEDUPE_MODES)[number];
+
+export function normalizeBrowserTabLaunchDedupeMode(value: unknown): BrowserTabLaunchDedupeMode {
+  const s = String(value || "").trim();
+  if (s === "each_saved_row") return "each_saved_row";
+  return "by_url_and_app";
+}
+
 export const FLOW_PROFILE_KIND_LABELS: Record<FlowProfileKind, string> = {
   general: "General",
   work: "Work",
@@ -142,6 +152,11 @@ export type FlowProfile = {
   /** Ordered list of app ids (instanceId/name) for sequential launch. */
   appLaunchOrder: string[];
   appLaunchDelays: Record<string, number>;
+  /**
+   * `by_url_and_app` (default): one launch per normalized URL + browser + app tile.
+   * `each_saved_row`: every saved tab row opens separately (duplicate URLs allowed).
+   */
+  browserTabLaunchDedupe: BrowserTabLaunchDedupeMode;
   monitors: any[];
   minimizedApps: any[];
   minimizedFiles: any[];
@@ -250,6 +265,7 @@ export function normalizeFlowProfile(rawProfile: unknown): FlowProfile {
     // Sequential is the only implemented execution mode right now.
     // Treat any legacy/all-at-once values as sequential until implemented.
     launchOrder: "sequential",
+    browserTabLaunchDedupe: normalizeBrowserTabLaunchDedupeMode(r?.browserTabLaunchDedupe),
     appLaunchOrder: Array.isArray(r?.appLaunchOrder)
       ? (r.appLaunchOrder as unknown[]).map((v) => String(v || "").trim()).filter(Boolean)
       : [],

--- a/src/types/preload.d.ts
+++ b/src/types/preload.d.ts
@@ -17,6 +17,20 @@ declare global {
         ok: boolean;
         started?: boolean;
         error?: string;
+        /** Stable machine code when `ok` is false (e.g. `LAUNCH_TOO_LARGE`, `LAUNCH_NOTHING_TO_RUN`). */
+        code?: string;
+        details?: {
+          totalUnits?: number;
+          breakdown?: {
+            dedupedAppLaunches?: number;
+            dedupedBrowserTabs?: number;
+          };
+          limits?: { softWarn?: number; hardMax?: number };
+          skippedLaunchTargets?: {
+            count: number;
+            sample: Array<{ name: string; reason: string }>;
+          };
+        };
         runId?: string;
         replacedRunId?: string | null;
         storeErrorCode?: string;
@@ -65,6 +79,31 @@ declare global {
         profileId: string,
         runId: string,
       ) => Promise<{ ok: boolean; error?: string; reason?: string }>;
+      getProfileLaunchWeight?: (
+        profileId: string,
+        request?: { excludedProfileMonitorIds?: string[] },
+      ) => Promise<{
+        ok: boolean;
+        error?: string;
+        code?: string;
+        totalUnits?: number;
+        breakdown?: {
+          dedupedAppLaunches?: number;
+          dedupedBrowserTabs?: number;
+        };
+        limits?: { softWarn?: number; hardMax?: number };
+        skippedLaunchTargets?: {
+          count: number;
+          sample: Array<{ name: string; reason: string }>;
+        };
+        preflight?: {
+          layoutAppSlots: number;
+          launchableAppLaunches: number;
+          missingLaunchTargetSkips: number;
+          dedupedBrowserTabs: number;
+        };
+      }>;
+
       getLaunchProfileStatus: (profileId: string) => Promise<{
         ok: boolean;
         error?: string;


### PR DESCRIPTION
## Summary

- **Launch weight**: shared limits, \computeLaunchWeight\ (merged skipped targets), hard cap + \LAUNCH_NOTHING_TO_RUN\, IPC/preload/types; renderer preflight + **Large profile launch** confirm modal.
- **Placement**: late verify + salvage scan, \isWithinSalvagePlacementTolerance\; maximized stabilization keeps forced HWND in candidates, loose meaningful rect, fast accept when on-target.
- **Launch summary**: app count reflects actions finished **without** error vs total; launch inspector chrome (borders, current-action frame).
- **Other**: installed-browser inference + LICENSE/package test wiring where applicable; backlog/spec notes synced.

## Commits (atomic)

1. \eat: add launch weight utilities and tab dedupe persistence\
2. \eat: enforce profile launch weight, salvage placement, and IPC weight\
3. \ix: stabilize maximized placement using placed HWND and looser bounds\
4. \eat: large-launch confirm UI, preflight, and installed-browser inference\
5. \ix: launch summary app counts and launch inspector chrome\
6. \chore: sync backlog notes for large-profile launch guardrails\

## Verification

- \
pm run lint\, \
pm run typecheck\ (baseline) run before commits.

## Manual QA (suggested)

- Large profile → confirm modal when over weight; cancel vs proceed.
- Launch inspector: borders, current action, summary counts after mixed success/failure.
- Maximized app (e.g. Anki): placement completes without false error.

Made with [Cursor](https://cursor.com)