### PR TITLE
fix: profile store backup and restore-from-backup reads

### DIFF
--- a/docs/superpowers/feature-braindump.md
+++ b/docs/superpowers/feature-braindump.md
@@ -172,6 +172,12 @@ Canonical cross-doc snapshot lives in `docs/superpowers/unified-backlog.md`.
 - Merged inbox items: constraints for too many apps, profile launch order, Batch C “competing apps” guidance (soft warnings / copy where overlaps exist with singleton or resource-heavy launch patterns).
 - Done when: users are warned/protected before risky launches and can intentionally choose launch order.
 
+1. Profile store backup / recovery
+
+- Problem: a damaged primary `profiles.v1.json` prevents loading any profiles with no automatic fallback copy on disk.
+- **Status (2026-05-15):** `profiles.v1.json.bak` is updated before each successful save when the current primary parses; reads fall back to the backup when the primary is missing or invalid (`src/main/services/profile-store.js`).
+- Done when: typical corruption or partial writes do not leave users with only an empty library if a recent good snapshot exists.
+
 1. Critical layout-editor responsiveness and first-run shell clarity
 
 - Problem: fast repeated drag operations in the monitor layout editor can freeze the app; some users report a blurry UI on first launch—both damage trust before core workflows land.

--- a/docs/superpowers/unified-backlog.md
+++ b/docs/superpowers/unified-backlog.md
@@ -1,6 +1,6 @@
 # FlowSwitch Unified Backlog (Canonical)
 
-Last updated: 2026-05-05 (launch guardrails Phase 3 slice)  
+Last updated: 2026-05-15 (profile store backup + guardrails branch PR)  
 Owner: active implementation branch owner
 
 **Release note (marketing):** `package.json` / `website/` prepared for **0.1.4**. Live GitHub downloads require pushing annotated tag **`v0.1.4`** after merge and waiting for the release workflow to attach `FlowSwitch-0.1.4-win-x64-*.exe` assets matching `website/latest.json`.
@@ -154,3 +154,4 @@ Current focus phase: `Phase 2 - Reliability Hardening`
 - `MainLayout` renderer hygiene (2026-05-04): stray `console.log` removed from production paths (`chore/mainlayout-remove-debug-logs`).
 - Shell landmarks (2026-05-04): named root/header/nav/region/main/aside wrappers in `MainLayout` to reduce AX “whole sidebar as one name” noise (M2 follow-up).
 - Layout capture / GitHub #51 (partial, `feature/explorer-windows-profile`): Explorer windows with resolvable `file://` folder URLs get `explorer.exe` plus `associatedFiles` on the captured tile; paths dedupe into profile Content rows. Tab coverage depends on what `Shell.Application.Windows()` exposes on the OS build; launch restore uses the existing `profile-launch-gather` Explorer argv path. **Launch fix (2026-05-05):** sequential Explorer tiles exclude HWNDs already placed earlier in the same run (`placedHandlesInRun` → window-ready-gate `excludeHandles`, reuse candidate filter, `moveWindowToBounds` exclusions, post-modal resume quarantine merge) so the second launch cannot reposition the first window into the second slot when the shell reuses or delays new top-level HWNDs.
+- Profile store resilience (2026-05-15): `profiles.v1.json.bak` is refreshed before each save when the on-disk primary still parses cleanly; `readProfilesFromDisk` (`profile-store.js`) loads from that backup when the primary file is missing or unreadable so a single corrupted primary does not permanently brick the library.

--- a/src/main/services/profile-store.js
+++ b/src/main/services/profile-store.js
@@ -6,6 +6,9 @@ const { sanitizeProfileLaunchFieldsDeep } = require('../utils/profile-launch-fie
 
 const PROFILE_STORE_FILENAME = 'profiles.v1.json';
 
+/** Previous good store snapshot; refreshed only when the on-disk primary parses cleanly. */
+const PROFILE_STORE_BACKUP_SUFFIX = '.bak';
+
 const MAGIC = Buffer.from([0x46, 0x4c, 0x53, 0x32]); // "FLS2"
 const FORMAT_VERSION = 1;
 
@@ -16,6 +19,8 @@ const normalizeProfiles = (raw) => (Array.isArray(raw) ? raw : []);
 const getProfileStorePath = () => (
   path.join(app.getPath('userData'), PROFILE_STORE_FILENAME)
 );
+
+const getProfileStoreBackupPath = () => `${getProfileStorePath()}${PROFILE_STORE_BACKUP_SUFFIX}`;
 
 const parseProfilesPayload = (parsed) => {
   if (Array.isArray(parsed)) return parsed;
@@ -113,6 +118,75 @@ const buildReadSuccess = (parsed) => {
   };
 };
 
+const emptyReadFailure = (code, message) => ({
+  profiles: [],
+  contentLibrary: emptyLibrary(),
+  contentLibraryExclusions: {},
+  storeError: { code, message },
+});
+
+/**
+ * Parse a profile-store file buffer (plain JSON or FLS2+encrypted payload).
+ * @param {Buffer} buf
+ */
+const loadProfilesFromBuffer = (buf) => {
+  if (!buf || buf.length === 0) {
+    return emptyReadFailure('PARSE_FAILED', 'Your profile store file is empty.');
+  }
+
+  if (buf.length >= 5 && buf.subarray(0, 4).equals(MAGIC) && buf[4] === FORMAT_VERSION) {
+    if (!safeStorage.isEncryptionAvailable()) {
+      const message = (
+        'Your profile data is encrypted, but this PC cannot use OS secure storage to unlock it '
+        + '(encryption unavailable). Your profiles were not loaded. '
+        + 'Try signing into Windows with your usual account or move userData to a machine '
+        + 'where Electron safeStorage works.'
+      );
+      console.error('[profile-store] Encrypted store present but OS encryption is unavailable');
+      return emptyReadFailure('ENCRYPTION_UNAVAILABLE', message);
+    }
+    const encrypted = buf.subarray(5);
+    let decrypted;
+    try {
+      decrypted = safeStorage.decryptString(encrypted);
+    } catch (err) {
+      console.error('[profile-store] Decrypt failed:', err);
+      return emptyReadFailure(
+        'DECRYPT_FAILED',
+        (
+          'Could not decrypt your profile data. The file may be corrupted, '
+          + 'or it was created under a different Windows user or machine.'
+        ),
+      );
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(decrypted);
+    } catch (err) {
+      console.error('[profile-store] JSON parse failed (encrypted payload):', err);
+      return emptyReadFailure(
+        'PARSE_FAILED',
+        'Decrypted profile data could not be read. The file may be damaged.',
+      );
+    }
+    return buildReadSuccess(parsed);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(buf.toString('utf8'));
+  } catch (err) {
+    console.error('[profile-store] JSON parse failed (plain JSON):', err);
+    return emptyReadFailure(
+      'PARSE_FAILED',
+      (
+        'Your profiles file could not be parsed. It may be damaged or edited incorrectly.'
+      ),
+    );
+  }
+  return buildReadSuccess(parsed);
+};
+
 /**
  * Read profiles + global content library from disk.
  * @returns {{
@@ -124,7 +198,25 @@ const buildReadSuccess = (parsed) => {
  */
 const readProfilesFromDisk = () => {
   const storePath = getProfileStorePath();
+  const backupPath = getProfileStoreBackupPath();
+
+  const tryBackup = (reason) => {
+    if (!fs.existsSync(backupPath)) return null;
+    try {
+      const fromBak = loadProfilesFromBuffer(fs.readFileSync(backupPath));
+      if (!fromBak.storeError) {
+        console.warn(`[profile-store] ${reason}; loaded profiles from backup (${path.basename(backupPath)})`);
+        return fromBak;
+      }
+    } catch (err) {
+      console.error('[profile-store] Failed to read profile store backup:', err);
+    }
+    return null;
+  };
+
   if (!fs.existsSync(storePath)) {
+    const restored = tryBackup('Primary profile store is missing');
+    if (restored) return restored;
     return {
       profiles: [],
       contentLibrary: emptyLibrary(),
@@ -134,80 +226,17 @@ const readProfilesFromDisk = () => {
   }
 
   try {
-    const buf = fs.readFileSync(storePath);
-    if (buf.length >= 5 && buf.subarray(0, 4).equals(MAGIC) && buf[4] === FORMAT_VERSION) {
-      if (!safeStorage.isEncryptionAvailable()) {
-        const message = (
-          'Your profile data is encrypted, but this PC cannot use OS secure storage to unlock it '
-          + '(encryption unavailable). Your profiles were not loaded. '
-          + 'Try signing into Windows with your usual account or move userData to a machine '
-          + 'where Electron safeStorage works.'
-        );
-        console.error('[profile-store] Encrypted store present but OS encryption is unavailable');
-        return {
-          profiles: [],
-          contentLibrary: emptyLibrary(),
-          contentLibraryExclusions: {},
-          storeError: { code: 'ENCRYPTION_UNAVAILABLE', message },
-        };
-      }
-      const encrypted = buf.subarray(5);
-      let decrypted;
-      try {
-        decrypted = safeStorage.decryptString(encrypted);
-      } catch (err) {
-        console.error('[profile-store] Decrypt failed:', err);
-        return {
-          profiles: [],
-          contentLibrary: emptyLibrary(),
-          contentLibraryExclusions: {},
-          storeError: {
-            code: 'DECRYPT_FAILED',
-            message: (
-              'Could not decrypt your profile data. The file may be corrupted, '
-              + 'or it was created under a different Windows user or machine.'
-            ),
-          },
-        };
-      }
-      let parsed;
-      try {
-        parsed = JSON.parse(decrypted);
-      } catch (err) {
-        console.error('[profile-store] JSON parse failed (encrypted payload):', err);
-        return {
-          profiles: [],
-          contentLibrary: emptyLibrary(),
-          contentLibraryExclusions: {},
-          storeError: {
-            code: 'PARSE_FAILED',
-            message: 'Decrypted profile data could not be read. The file may be damaged.',
-          },
-        };
-      }
-      return buildReadSuccess(parsed);
-    }
+    const primary = loadProfilesFromBuffer(fs.readFileSync(storePath));
+    if (!primary.storeError) return primary;
 
-    let parsed;
-    try {
-      parsed = JSON.parse(buf.toString('utf8'));
-    } catch (err) {
-      console.error('[profile-store] JSON parse failed (plain JSON):', err);
-      return {
-        profiles: [],
-        contentLibrary: emptyLibrary(),
-        contentLibraryExclusions: {},
-        storeError: {
-          code: 'PARSE_FAILED',
-          message: (
-            'Your profiles file could not be parsed. It may be damaged or edited incorrectly.'
-          ),
-        },
-      };
-    }
-    return buildReadSuccess(parsed);
+    const restored = tryBackup('Primary profile store is unreadable');
+    if (restored) return restored;
+
+    return primary;
   } catch (error) {
     console.error('[profile-store] Failed to read profiles:', error);
+    const restored = tryBackup('Primary profile store read threw');
+    if (restored) return restored;
     return {
       profiles: [],
       contentLibrary: emptyLibrary(),
@@ -262,10 +291,23 @@ const writeProfilesToDisk = (payload) => {
 
   const safeProfiles = profiles.map((p) => sanitizeProfileLaunchFieldsDeep(sanitizeProfileIconPathsDeep(p)));
   const storePath = getProfileStorePath();
+  const backupPath = getProfileStoreBackupPath();
   const dirPath = path.dirname(storePath);
   const tempPath = `${storePath}.tmp`;
 
   fs.mkdirSync(dirPath, { recursive: true });
+
+  if (fs.existsSync(storePath)) {
+    try {
+      const previous = fs.readFileSync(storePath);
+      const previousOk = loadProfilesFromBuffer(previous);
+      if (!previousOk.storeError) {
+        fs.copyFileSync(storePath, backupPath);
+      }
+    } catch (err) {
+      console.warn('[profile-store] Could not refresh profile store backup before save:', err);
+    }
+  }
 
   const storeBody = {
     version: 1,


### PR DESCRIPTION
## Summary
- Refresh ``profiles.v1.json.bak`` before each save when the primary store file still parses cleanly so a bad write does not destroy the last known-good snapshot.
- If the primary file is missing or unreadable, ``readProfilesFromDisk`` loads from the backup and logs a short warning.
- Syncs ``unified-backlog.md`` and ``feature-braindump.md`` for this resilience work.

**Note:** Large profile launch guardrails already landed on ``main`` (merge of prior work on this branch, e.g. PR #59). This PR is only the follow-up **profile persistence** commit on top of current ``main``.

## Test plan
- [ ] ``npm run lint`` and ``npm run typecheck`` (passed locally before commit)
- [ ] Run app, save a profile change, confirm ``profiles.v1.json`` and ``profiles.v1.json.bak`` exist under userData and primary content looks valid
- [ ] Optional: rename primary to simulate corruption, relaunch, confirm profiles load from ``.bak`` and console shows restore warning